### PR TITLE
fixed API for read

### DIFF
--- a/src/com/esotericsoftware/kryo/Serializer.java
+++ b/src/com/esotericsoftware/kryo/Serializer.java
@@ -40,7 +40,7 @@ public abstract class Serializer<T> {
 	 * This method should not be called directly, instead this serializer can be passed to {@link Kryo} read methods that accept a
 	 * serialier.
 	 * @return May be null if {@link #getAcceptsNull()} is true. */
-	abstract public T read (Kryo kryo, Input input, Class<T> type);
+	abstract public T read (Kryo kryo, Input input, Class<? extends T> type);
 
 	public boolean getAcceptsNull () {
 		return acceptsNull;

--- a/src/com/esotericsoftware/kryo/serializers/BeanSerializer.java
+++ b/src/com/esotericsoftware/kryo/serializers/BeanSerializer.java
@@ -118,7 +118,7 @@ public class BeanSerializer<T> extends Serializer<T> {
 		}
 	}
 
-	public T read (Kryo kryo, Input input, Class<T> type) {
+	public T read (Kryo kryo, Input input, Class<? extends T> type) {
 		T object = kryo.newInstance(type);
 		kryo.reference(object);
 		for (int i = 0, n = properties.length; i < n; i++) {

--- a/src/com/esotericsoftware/kryo/serializers/CollectionSerializer.java
+++ b/src/com/esotericsoftware/kryo/serializers/CollectionSerializer.java
@@ -81,11 +81,11 @@ public class CollectionSerializer extends Serializer<Collection> {
 
 	/** Used by {@link #read(Kryo, Input, Class)} to create the new object. This can be overridden to customize object creation, eg
 	 * to call a constructor with arguments. The default implementation uses {@link Kryo#newInstance(Class)}. */
-	protected Collection create (Kryo kryo, Input input, Class<Collection> type) {
+	protected Collection create (Kryo kryo, Input input, Class<? extends Collection> type) {
 		return kryo.newInstance(type);
 	}
 
-	public Collection read (Kryo kryo, Input input, Class<Collection> type) {
+	public Collection read (Kryo kryo, Input input, Class<? extends Collection> type) {
 		Collection collection = create(kryo, input, type);
 		kryo.reference(collection);
 		int length = input.readVarInt(true);

--- a/src/com/esotericsoftware/kryo/serializers/CompatibleFieldSerializer.java
+++ b/src/com/esotericsoftware/kryo/serializers/CompatibleFieldSerializer.java
@@ -44,7 +44,7 @@ public class CompatibleFieldSerializer<T> extends FieldSerializer<T> {
 		}
 	}
 
-	public T read (Kryo kryo, Input input, Class<T> type) {
+	public T read (Kryo kryo, Input input, Class<? extends T> type) {
 		T object = create(kryo, input, type);
 		kryo.reference(object);
 		ObjectMap context = kryo.getGraphContext();

--- a/src/com/esotericsoftware/kryo/serializers/DefaultArraySerializers.java
+++ b/src/com/esotericsoftware/kryo/serializers/DefaultArraySerializers.java
@@ -36,7 +36,7 @@ public class DefaultArraySerializers{
 			output.writeBytes(object);
 		}
 
-		public byte[] read (Kryo kryo, Input input, Class<byte[]> type) {
+		public byte[] read (Kryo kryo, Input input, Class<? extends byte[]> type) {
 			int length = input.readVarInt(true);
 			if (length == NULL) return null;
 			return input.readBytes(length - 1);
@@ -63,7 +63,7 @@ public class DefaultArraySerializers{
 			output.writeInts(object, false);
 		}
 
-		public int[] read (Kryo kryo, Input input, Class<int[]> type) {
+		public int[] read (Kryo kryo, Input input, Class<? extends int[]> type) {
 			int length = input.readVarInt(true);
 			if (length == NULL) return null;
 			return input.readInts(length - 1, false);
@@ -90,7 +90,7 @@ public class DefaultArraySerializers{
 			output.writeFloats(object);
 		}
 
-		public float[] read (Kryo kryo, Input input, Class<float[]> type) {
+		public float[] read (Kryo kryo, Input input, Class<? extends float[]> type) {
 			int length = input.readVarInt(true);
 			if (length == NULL) return null;
 			return input.readFloats(length-1);
@@ -117,7 +117,7 @@ public class DefaultArraySerializers{
 			output.writeLongs(object, false);
 		}
 
-		public long[] read (Kryo kryo, Input input, Class<long[]> type) {
+		public long[] read (Kryo kryo, Input input, Class<? extends long[]> type) {
 			int length = input.readVarInt(true);
 			if (length == NULL) return null;
 			return input.readLongs(length-1, false);
@@ -144,7 +144,7 @@ public class DefaultArraySerializers{
 			output.writeShorts(object);
 		}
 
-		public short[] read (Kryo kryo, Input input, Class<short[]> type) {
+		public short[] read (Kryo kryo, Input input, Class<? extends short[]> type) {
 			int length = input.readVarInt(true);
 			if (length == NULL) return null;
 			return input.readShorts(length-1);
@@ -171,7 +171,7 @@ public class DefaultArraySerializers{
 			output.writeChars(object);
 		}
 
-		public char[] read (Kryo kryo, Input input, Class<char[]> type) {
+		public char[] read (Kryo kryo, Input input, Class<? extends char[]> type) {
 			int length = input.readVarInt(true);
 			if (length == NULL) return null;
 			return input.readChars(length-1);
@@ -198,7 +198,7 @@ public class DefaultArraySerializers{
 			output.writeDoubles(object);
 		}
 
-		public double[] read (Kryo kryo, Input input, Class<double[]> type) {
+		public double[] read (Kryo kryo, Input input, Class<? extends double[]> type) {
 			int length = input.readVarInt(true);
 			if (length == NULL) return null;
 			return input.readDoubles(length-1);
@@ -226,7 +226,7 @@ public class DefaultArraySerializers{
 				output.writeBoolean(object[i]);
 		}
 
-		public boolean[] read (Kryo kryo, Input input, Class<boolean[]> type) {
+		public boolean[] read (Kryo kryo, Input input, Class<? extends boolean[]> type) {
 			int length = input.readVarInt(true);
 			if (length == NULL) return null;
 			boolean[] array = new boolean[--length];
@@ -263,7 +263,7 @@ public class DefaultArraySerializers{
 			}
 		}
 
-		public String[] read (Kryo kryo, Input input, Class<String[]> type) {
+		public String[] read (Kryo kryo, Input input, Class<? extends String[]> type) {
 			int length = input.readVarInt(true);
 			if (length == NULL) return null;
 			String[] array = new String[--length];
@@ -355,7 +355,7 @@ public class DefaultArraySerializers{
 			}
 		}
 
-		public Object[] read (Kryo kryo, Input input, Class<Object[]> type) {
+		public Object[] read (Kryo kryo, Input input, Class<? extends Object[]> type) {
 			int length = input.readVarInt(true);
 			if (length == NULL) return null;
 			Object[] object = (Object[])Array.newInstance(type.getComponentType(), length - 1);

--- a/src/com/esotericsoftware/kryo/serializers/DefaultSerializers.java
+++ b/src/com/esotericsoftware/kryo/serializers/DefaultSerializers.java
@@ -55,7 +55,7 @@ public class DefaultSerializers {
 			output.writeBoolean(object);
 		}
 
-		public Boolean read (Kryo kryo, Input input, Class<Boolean> type) {
+		public Boolean read (Kryo kryo, Input input, Class<? extends Boolean> type) {
 			return input.readBoolean();
 		}
 	}
@@ -69,7 +69,7 @@ public class DefaultSerializers {
 			output.writeByte(object);
 		}
 
-		public Byte read (Kryo kryo, Input input, Class<Byte> type) {
+		public Byte read (Kryo kryo, Input input, Class<? extends Byte> type) {
 			return input.readByte();
 		}
 	}
@@ -83,7 +83,7 @@ public class DefaultSerializers {
 			output.writeChar(object);
 		}
 
-		public Character read (Kryo kryo, Input input, Class<Character> type) {
+		public Character read (Kryo kryo, Input input, Class<? extends Character> type) {
 			return input.readChar();
 		}
 	}
@@ -97,7 +97,7 @@ public class DefaultSerializers {
 			output.writeShort(object);
 		}
 
-		public Short read (Kryo kryo, Input input, Class<Short> type) {
+		public Short read (Kryo kryo, Input input, Class<? extends Short> type) {
 			return input.readShort();
 		}
 	}
@@ -111,7 +111,7 @@ public class DefaultSerializers {
 			output.writeInt(object, false);
 		}
 
-		public Integer read (Kryo kryo, Input input, Class<Integer> type) {
+		public Integer read (Kryo kryo, Input input, Class<? extends Integer> type) {
 			return input.readInt(false);
 		}
 	}
@@ -125,7 +125,7 @@ public class DefaultSerializers {
 			output.writeLong(object, false);
 		}
 
-		public Long read (Kryo kryo, Input input, Class<Long> type) {
+		public Long read (Kryo kryo, Input input, Class<? extends Long> type) {
 			return input.readLong(false);
 		}
 	}
@@ -139,7 +139,7 @@ public class DefaultSerializers {
 			output.writeFloat(object);
 		}
 
-		public Float read (Kryo kryo, Input input, Class<Float> type) {
+		public Float read (Kryo kryo, Input input, Class<? extends Float> type) {
 			return input.readFloat();
 		}
 	}
@@ -153,7 +153,7 @@ public class DefaultSerializers {
 			output.writeDouble(object);
 		}
 
-		public Double read (Kryo kryo, Input input, Class<Double> type) {
+		public Double read (Kryo kryo, Input input, Class<? extends Double> type) {
 			return input.readDouble();
 		}
 	}
@@ -169,7 +169,7 @@ public class DefaultSerializers {
 			output.writeString(object);
 		}
 
-		public String read (Kryo kryo, Input input, Class<String> type) {
+		public String read (Kryo kryo, Input input, Class<? extends String> type) {
 			return input.readString();
 		}
 	}
@@ -191,7 +191,7 @@ public class DefaultSerializers {
 			output.writeBytes(bytes);
 		}
 
-		public BigInteger read (Kryo kryo, Input input, Class<BigInteger> type) {
+		public BigInteger read (Kryo kryo, Input input, Class<? extends BigInteger> type) {
 			int length = input.readVarInt(true);
 			if (length == NULL) return null;
 			byte[] bytes = input.readBytes(length - 1);
@@ -217,7 +217,7 @@ public class DefaultSerializers {
 			output.writeInt(value.scale(), false);
 		}
 
-		public BigDecimal read (Kryo kryo, Input input, Class<BigDecimal> type) {
+		public BigDecimal read (Kryo kryo, Input input, Class<? extends BigDecimal> type) {
 			BigInteger unscaledValue = bigIntegerSerializer.read(kryo, input, null);
 			if (unscaledValue == null) return null;
 			int scale = input.readInt(false);
@@ -236,7 +236,7 @@ public class DefaultSerializers {
 			output.writeByte(object.isPrimitive()?1:0);
 		}
 
-		public Class read (Kryo kryo, Input input, Class<Class> type) {
+		public Class read (Kryo kryo, Input input, Class<? extends Class> type) {
 			Registration registration = kryo.readClass(input);
 			int isPrimitive = input.read();
 			Class typ = registration.getType();
@@ -250,7 +250,7 @@ public class DefaultSerializers {
 			output.writeLong(object.getTime(), true);
 		}
 
-		public Date read (Kryo kryo, Input input, Class<Date> type) {
+		public Date read (Kryo kryo, Input input, Class<? extends Date> type) {
 			return new Date(input.readLong(true));
 		}
 
@@ -280,7 +280,7 @@ public class DefaultSerializers {
 			output.writeVarInt(object.ordinal() + 1, true);
 		}
 
-		public Enum read (Kryo kryo, Input input, Class<Enum> type) {
+		public Enum read (Kryo kryo, Input input, Class<? extends Enum> type) {
 			int ordinal = input.readVarInt(true);
 			if (ordinal == NULL) return null;
 			ordinal--;
@@ -306,7 +306,7 @@ public class DefaultSerializers {
 				serializer.write(kryo, output, element);
 		}
 
-		public EnumSet read (Kryo kryo, Input input, Class<EnumSet> type) {
+		public EnumSet read (Kryo kryo, Input input, Class<? extends EnumSet> type) {
 			Registration registration = kryo.readClass(input);
 			EnumSet object = EnumSet.noneOf(registration.getType());
 			Serializer serializer = registration.getSerializer();
@@ -332,7 +332,7 @@ public class DefaultSerializers {
 			output.writeString(object == null ? null : object.getCurrencyCode());
 		}
 
-		public Currency read (Kryo kryo, Input input, Class<Currency> type) {
+		public Currency read (Kryo kryo, Input input, Class<? extends Currency> type) {
 			String currencyCode = input.readString();
 			if (currencyCode == null) return null;
 			return Currency.getInstance(currencyCode);
@@ -349,7 +349,7 @@ public class DefaultSerializers {
 			output.writeString(object);
 		}
 
-		public StringBuffer read (Kryo kryo, Input input, Class<StringBuffer> type) {
+		public StringBuffer read (Kryo kryo, Input input, Class<? extends StringBuffer> type) {
 			String value = input.readString();
 			if (value == null) return null;
 			return new StringBuffer(value);
@@ -370,7 +370,7 @@ public class DefaultSerializers {
 			output.writeString(object);
 		}
 
-		public StringBuilder read (Kryo kryo, Input input, Class<StringBuilder> type) {
+		public StringBuilder read (Kryo kryo, Input input, Class<? extends StringBuilder> type) {
 			return input.readStringBuilder();
 		}
 
@@ -384,7 +384,7 @@ public class DefaultSerializers {
 			object.write(kryo, output);
 		}
 
-		public KryoSerializable read (Kryo kryo, Input input, Class<KryoSerializable> type) {
+		public KryoSerializable read (Kryo kryo, Input input, Class<? extends KryoSerializable> type) {
 			KryoSerializable object = kryo.newInstance(type);
 			kryo.reference(object);
 			object.read(kryo, input);
@@ -501,7 +501,7 @@ public class DefaultSerializers {
 			output.writeString(object.getID());
 		}
 
-		public TimeZone read (Kryo kryo, Input input, Class<TimeZone> type) {
+		public TimeZone read (Kryo kryo, Input input, Class<? extends TimeZone> type) {
 			return TimeZone.getTimeZone(input.readString());
 		}
 	}
@@ -526,7 +526,7 @@ public class DefaultSerializers {
 				output.writeLong(DEFAULT_GREGORIAN_CUTOVER, false);
 		}
 
-		public Calendar read (Kryo kryo, Input input, Class<Calendar> type) {
+		public Calendar read (Kryo kryo, Input input, Class<? extends Calendar> type) {
 			Calendar result = Calendar.getInstance(timeZoneSerializer.read(kryo, input, TimeZone.class));
 			result.setTimeInMillis(input.readLong(true));
 			result.setLenient(input.readBoolean());
@@ -550,7 +550,7 @@ public class DefaultSerializers {
 			super.write(kryo, output, map);
 		}
 
-		protected Map create (Kryo kryo, Input input, Class<Map> type) {
+		protected Map create (Kryo kryo, Input input, Class<? extends Map> type) {
 			return new TreeMap((Comparator)kryo.readClassAndObject(input));
 		}
 
@@ -566,7 +566,7 @@ public class DefaultSerializers {
 			super.write(kryo, output, collection);
 		}
 
-		protected TreeSet create (Kryo kryo, Input input, Class<Collection> type) {
+		protected TreeSet create (Kryo kryo, Input input, Class<? extends Collection> type) {
 			return new TreeSet((Comparator)kryo.readClassAndObject(input));
 		}
 

--- a/src/com/esotericsoftware/kryo/serializers/FieldSerializer.java
+++ b/src/com/esotericsoftware/kryo/serializers/FieldSerializer.java
@@ -460,7 +460,7 @@ public class FieldSerializer<T> extends Serializer<T> implements Comparator<Fiel
 		}
 	}
 
-	public T read (Kryo kryo, Input input, Class<T> type) {
+	public T read (Kryo kryo, Input input, Class<? extends T> type) {
 		try {
 
 			if (typeParameters != null && generics != null) {
@@ -497,7 +497,7 @@ public class FieldSerializer<T> extends Serializer<T> implements Comparator<Fiel
 
 	/** Used by {@link #read(Kryo, Input, Class)} to create the new object. This can be overridden to customize object creation, eg
 	 * to call a constructor with arguments. The default implementation uses {@link Kryo#newInstance(Class)}. */
-	protected T create (Kryo kryo, Input input, Class<T> type) {
+	protected T create (Kryo kryo, Input input, Class<? extends T> type) {
 		return kryo.newInstance(type);
 	}
 

--- a/src/com/esotericsoftware/kryo/serializers/MapSerializer.java
+++ b/src/com/esotericsoftware/kryo/serializers/MapSerializer.java
@@ -94,11 +94,11 @@ public class MapSerializer extends Serializer<Map> {
 
 	/** Used by {@link #read(Kryo, Input, Class)} to create the new object. This can be overridden to customize object creation, eg
 	 * to call a constructor with arguments. The default implementation uses {@link Kryo#newInstance(Class)}. */
-	protected Map create (Kryo kryo, Input input, Class<Map> type) {
+	protected Map create (Kryo kryo, Input input, Class<? extends Map> type) {
 		return kryo.newInstance(type);
 	}
 
-	public Map read (Kryo kryo, Input input, Class<Map> type) {
+	public Map read (Kryo kryo, Input input, Class<? extends Map> type) {
 		Map map = create(kryo, input, type);
 		int length = input.readInt(true);
 

--- a/src/com/esotericsoftware/kryo/serializers/TaggedFieldSerializer.java
+++ b/src/com/esotericsoftware/kryo/serializers/TaggedFieldSerializer.java
@@ -69,7 +69,7 @@ public class TaggedFieldSerializer<T> extends FieldSerializer<T> {
 		}
 	}
 
-	public T read (Kryo kryo, Input input, Class<T> type) {
+	public T read (Kryo kryo, Input input, Class<? extends T> type) {
 		T object = create(kryo, input, type);
 		kryo.reference(object);
 		int fieldCount = input.readVarInt(true);

--- a/test/com/esotericsoftware/kryo/FieldSerializerTest.java
+++ b/test/com/esotericsoftware/kryo/FieldSerializerTest.java
@@ -235,7 +235,7 @@ public class FieldSerializerTest extends KryoTestCase {
 
 	public void testNoDefaultConstructor () {
 		kryo.register(SimpleNoDefaultConstructor.class, new Serializer<SimpleNoDefaultConstructor>() {
-			public SimpleNoDefaultConstructor read (Kryo kryo, Input input, Class<SimpleNoDefaultConstructor> type) {
+			public SimpleNoDefaultConstructor read (Kryo kryo, Input input, Class<? extends SimpleNoDefaultConstructor> type) {
 				return new SimpleNoDefaultConstructor(input.readInt(true));
 			}
 

--- a/test/com/esotericsoftware/kryo/ReferenceTest.java
+++ b/test/com/esotericsoftware/kryo/ReferenceTest.java
@@ -39,7 +39,7 @@ public class ReferenceTest extends KryoTestCase {
 				super.write(kryo, output, object);
 			}
 
-			protected Map create (Kryo kryo, Input input, Class<Map> type) {
+			protected Map create (Kryo kryo, Input input, Class<? extends Map> type) {
 				Ordering ordering = kryo.readObjectOrNull(input, Ordering.class);
 				return new Stuff(ordering);
 			}
@@ -108,7 +108,7 @@ public class ReferenceTest extends KryoTestCase {
 			}
 		}
 
-		public List read (Kryo kryo, Input input, Class<List> type) {
+		public List read (Kryo kryo, Input input, Class<? extends List> type) {
 			List list = (List)kryo.readClassAndObject(input);
 			int fromIndex = input.readInt();
 			int count = input.readInt();
@@ -145,7 +145,7 @@ public class ReferenceTest extends KryoTestCase {
 			}
 		}
 
-		public List read (Kryo kryo, Input input, Class<List> type) {
+		public List read (Kryo kryo, Input input, Class<? extends List> type) {
 			List list = (List)kryo.readClassAndObject(input);
 			int offset = input.readInt();
 			int size = input.readInt();


### PR DESCRIPTION
The current API for the Serializer class reads as follows: 

abstract public T read (Kryo kryo, Input input, Class<T> type)

Here, the type of the input called "type" will often be a lie when the serializer is used as a default serializer: rather than being a Class<T> it will be a Class<U> for some U that extends T (if Java had a notion of covariance, and Class were defined to be covariant in its type argument then this type signature would be just fine). This lie doesn't cause problems at runtime because of the JVM's type-erasure, but the API would be more accurate if it were defined as follows:

abstract public T read (Kryo kryo, Input input, Class<? extends T>

This pull request makes this simple change.
