### PR TITLE
Fix #100: Add LocaleSerializer

### DIFF
--- a/test/com/esotericsoftware/kryo/DefaultSerializersTest.java
+++ b/test/com/esotericsoftware/kryo/DefaultSerializersTest.java
@@ -8,10 +8,12 @@ import java.util.Calendar;
 import java.util.Collections;
 import java.util.Date;
 import java.util.EnumSet;
+import java.util.Locale;
 import java.util.TimeZone;
 
 import com.esotericsoftware.kryo.io.Input;
 import com.esotericsoftware.kryo.io.Output;
+import com.esotericsoftware.kryo.serializers.DefaultSerializers.LocaleSerializer;
 
 /** @author Nathan Sweet <misc@n4te.com> */
 public class DefaultSerializersTest extends KryoTestCase {
@@ -277,6 +279,20 @@ public class DefaultSerializersTest extends KryoTestCase {
 		assertEquals(void.class, kryo.readObject(in, Class.class));
 		assertEquals(ArrayList.class, kryo.readObject(in, Class.class));
 		assertEquals(TestEnum.class, kryo.readObject(in, Class.class));
+	}
+
+	public void testLocaleUsingReflection() {
+		doTestLocale(true);
+	}
+
+	public void testLocaleUsingConstructor() {
+		doTestLocale(false);
+	}
+
+	private void doTestLocale (boolean useReflection) {
+		kryo.setRegistrationRequired(true);
+		kryo.register(Locale.class, new LocaleSerializer(useReflection));
+		roundTrip(5, 5, Locale.ENGLISH);
 	}
 
 	public enum TestEnum {


### PR DESCRIPTION
@NathanSweet, @romix: Because it was requested for msm again I wrote a LocaleSerializer (for kryo1 in kryo-serializers) and ported it to kryo2.

I wondered if I should add it to the list of default serializers in the kryo constructor.
I think this would break compatibility, at least for those people that until now somehow had their own custom LocaleSerializer registered, or that used Objenesis or s.th. similar to handle classes like Locale (not having a default constructor). Not sure if adding a default serializer in general breaks compatibility, because of change ids?

For now I decided to not add the serializer to the default serializers. Perhaps it would be a good thing to do this when other serializers from kryo-serializers are moved to kryo.

What do you think?

Regarding the implementation itself:

For deserialization by default (and if available) the static `Locale.getInstance(String, String, String)` is used via reflection to make use of the Locale cache. If Locale.getInstance is not available it just falls back to the constructor.

If the `Locale(String, String, String)` constructor should be used in any case the `LocaleSerializer(boolean)` has to be used with `useReflection` set to `false`.
