### PR TITLE
Add Kryo.setClassResolver(ClassResolver)

### DIFF
--- a/src/com/esotericsoftware/kryo/ClassResolver.java
+++ b/src/com/esotericsoftware/kryo/ClassResolver.java
@@ -17,6 +17,9 @@ public interface ClassResolver {
 	/** Called when an unregistered type is encountered and {@link Kryo#setRegistrationRequired(boolean)} is false. */
 	public Registration registerImplicit (Class type);
 
+	/** Returns the registrations */
+	public Iterable<Registration> getRegistrations ();
+
 	/** Returns the registration for the specified class, or null if the class is not registered. */
 	public Registration getRegistration (Class type);
 

--- a/src/com/esotericsoftware/kryo/util/DefaultClassResolver.java
+++ b/src/com/esotericsoftware/kryo/util/DefaultClassResolver.java
@@ -35,6 +35,10 @@ public class DefaultClassResolver implements ClassResolver {
 		this.kryo = kryo;
 	}
 
+	public Iterable<Registration> getRegistrations () {
+		return classToRegistration.values();
+	}
+
 	public Registration register (Registration registration) {
 		if (registration == null) throw new IllegalArgumentException("registration cannot be null.");
 		if (registration.getId() != NAME) {

--- a/test/com/esotericsoftware/kryo/ClassResolverTest.java
+++ b/test/com/esotericsoftware/kryo/ClassResolverTest.java
@@ -1,0 +1,83 @@
+package com.esotericsoftware.kryo;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import com.esotericsoftware.kryo.FieldSerializerTest.DefaultTypes;
+import com.esotericsoftware.kryo.FieldSerializerTest.HasStringField;
+import com.esotericsoftware.kryo.util.DefaultClassResolver;
+
+public class ClassResolverTest extends KryoTestCase {
+
+	public void testSetClassResolverCopiesAllRegistrations() {
+		ClassResolver cr1 = kryo.getClassResolver();
+
+		kryo.register(DefaultTypes.class);
+		assertNotNull(cr1.getRegistration(DefaultTypes.class));
+
+		ClassResolver cr2 = new DefaultClassResolver();
+		kryo.setClassResolver(cr2, true);
+
+		assertNotNull(cr2.getRegistration(DefaultTypes.class));
+		assertEquals(toSet(cr1.getRegistrations()), toSet(cr2.getRegistrations()));
+	}
+
+	public void testSetClassResolverCopiesOnlyPrimitiveRegistrations() {
+		ClassResolver cr1 = kryo.getClassResolver();
+
+		Registration registration = kryo.register(DefaultTypes.class);
+		assertNotNull(cr1.getRegistration(DefaultTypes.class));
+
+		ClassResolver cr2 = new DefaultClassResolver();
+		kryo.setClassResolver(cr2, false);
+
+		assertNull(cr2.getRegistration(DefaultTypes.class));
+		Set<Registration> cr1Registrations = toSet(cr1.getRegistrations());
+		assertTrue(cr1Registrations.remove(registration));
+		assertEquals(cr1Registrations, toSet(cr2.getRegistrations()));
+	}
+
+	public void testSetClassResolverAfterRegistrations () {
+		// Registrations and assertions from FieldSerializerTest.testRegistration
+		int id = kryo.getNextRegistrationId();
+		kryo.register(DefaultTypes.class, id);
+		kryo.register(DefaultTypes.class, id);
+		kryo.register(new Registration(byte[].class, kryo.getDefaultSerializer(byte[].class), id + 1));
+		kryo.register(byte[].class, kryo.getDefaultSerializer(byte[].class), id + 1);
+		kryo.register(HasStringField.class, kryo.getDefaultSerializer(HasStringField.class));
+
+		// Set the class resolver
+		kryo.setClassResolver(new DefaultClassResolver(), true);
+
+		// Assertions from FieldSerializerTest.testRegistration
+		DefaultTypes test = new DefaultTypes();
+		test.intField = 12;
+		test.StringField = "meow";
+		test.CharacterField = 'z';
+		test.byteArrayField = new byte[] {0, 1, 2, 3, 4};
+		test.child = new DefaultTypes();
+		roundTrip(75, 95, test);
+	}
+
+	public void testSetClassResolverBetweenRegistrations () {
+		// Registrations (slightly adjusted) and assertions from FieldSerializerTest.testRegistration
+		kryo.register(DefaultTypes.class, kryo.getNextRegistrationId());
+		kryo.register(new Registration(byte[].class, kryo.getDefaultSerializer(byte[].class), kryo.getNextRegistrationId()));
+
+		// Set the class resolver
+		kryo.setClassResolver(new DefaultClassResolver(), true);
+
+		// Continue registrations
+		kryo.register(byte[].class, kryo.getDefaultSerializer(byte[].class), kryo.getNextRegistrationId());
+		kryo.register(HasStringField.class, kryo.getDefaultSerializer(HasStringField.class));
+
+		// Assertions from FieldSerializerTest.testRegistration
+		DefaultTypes test = new DefaultTypes();
+		test.intField = 12;
+		test.StringField = "meow";
+		test.CharacterField = 'z';
+		test.byteArrayField = new byte[] {0, 1, 2, 3, 4};
+		test.child = new DefaultTypes();
+		roundTrip(75, 95, test);
+	}
+}

--- a/test/com/esotericsoftware/kryo/KryoTestCase.java
+++ b/test/com/esotericsoftware/kryo/KryoTestCase.java
@@ -4,6 +4,8 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.lang.reflect.Array;
 import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Set;
 
 import junit.framework.TestCase;
 
@@ -264,5 +266,12 @@ abstract public class KryoTestCase extends TestCase {
 		for (Object item : items)
 			list.add(item);
 		return list;
+	}
+	
+	static public <T> Set<T> toSet(Iterable<T> items) {
+		Set<T> result = new HashSet<T>();
+		for (T item : items)
+			result.add(item);
+		return result;
 	}
 }


### PR DESCRIPTION
Add the possibility to set a `ClassResolver` after Kryo was constructed, but it's expected
that `Kryo.setClassResolver` is invoked before any (de)serialization is performed (other behaviour
is just not tested).

The Kryo instance is set on the new class resolver, so that the client does not have
to invoke this (also setters for ReferenceResolver and StreamFactory are adjusted to set Kryo).