### PR TITLE
If remaining is greater than Integer.MAX_VALUE, "(int) remaining" will be negative

### DIFF
--- a/src/com/esotericsoftware/kryo/io/Input.java
+++ b/src/com/esotericsoftware/kryo/io/Input.java
@@ -271,7 +271,9 @@ public class Input extends InputStream {
 	public long skip (long count) throws KryoException {
 		long remaining = count;
 		while (remaining > 0) {
-			int skip = Math.min(Integer.MAX_VALUE, (int)remaining);
+			//int skip = Math.min(Integer.MAX_VALUE, (int)remaining);
+            //if remaining is greater than Integer.MAX_VALUE, "(int) remaining" will be negative.
+			int skip = (int)Math.min(Integer.MAX_VALUE, remaining);
 			skip(skip);
 			remaining -= skip;
 		}


### PR DESCRIPTION
When the parameter count is great than Integer.MAX_VALUE, like 
(Integer.MAX_VALUE + 1L)
then the code
(int)remaining 
will be return -2147483648
