### PR TITLE
Recover from exceptions in Util.string()

### DIFF
--- a/src/com/esotericsoftware/kryo/util/Util.java
+++ b/src/com/esotericsoftware/kryo/util/Util.java
@@ -94,7 +94,7 @@ public class Util {
 		}
                 try {
 		    return String.valueOf(object);
-                } catch(Exception e) {
+                } catch(Throwable e) {
                     return (TRACE ? className(type) : type.getSimpleName()) + "(Exception " + e + " in toString)";
                 }
 	}


### PR DESCRIPTION
Turning on TRACE might result in exceptions (particularly NPE) thrown from `toString` of partially de-serialized objects, thus hindering debugging. This tiny change recovers from such exceptions.
