### PR TITLE
Change KryoPool to interface + Builder, make SoftReferences optional.

### DIFF
--- a/README.md
+++ b/README.md
@@ -552,17 +552,15 @@ Kryo k = kryos.get();
 ...
 ```
 
-Alternatively you may want to use the `KryoPool` provided by kryo. The `KryoPool` keeps references to `Kryo` instances
-using `SoftReference`s, so that `Kryo` instances will be GC'ed when the JVM starts to run out of memory
+Alternatively you may want to use the `KryoPool` provided by kryo. The `KryoPool` allows to keep references to `Kryo` instances
+using `SoftReference`s, so that `Kryo` instances can be GC'ed when the JVM starts to run out of memory
 (of course you could use `ThreadLocal` with `SoftReference`s as well).
 
 Here's an example that shows how to use the `KryoPool`:
 
 ```java
 import com.esotericsoftware.kryo.Kryo;
-import com.esotericsoftware.kryo.pool.KryoCallback;
-import com.esotericsoftware.kryo.pool.KryoFactory;
-import com.esotericsoftware.kryo.pool.KryoPool;
+import com.esotericsoftware.kryo.pool.*;
 
 KryoFactory factory = new KryoFactory() {
   public Kryo create () {
@@ -571,7 +569,8 @@ KryoFactory factory = new KryoFactory() {
     return kryo;
   }
 };
-KryoPool pool = new KryoPool(factory);
+// Build pool with SoftReferences enabled (optional)
+KryoPool pool = new KryoPool.Builder(factory).softReferences().build();
 Kryo kryo = pool.borrow();
 // do s.th. with kryo here, and afterwards release it
 pool.release(kryo);

--- a/src/com/esotericsoftware/kryo/pool/KryoPoolQueueImpl.java
+++ b/src/com/esotericsoftware/kryo/pool/KryoPoolQueueImpl.java
@@ -1,0 +1,53 @@
+package com.esotericsoftware.kryo.pool;
+
+import java.lang.ref.SoftReference;
+import java.util.Queue;
+
+import com.esotericsoftware.kryo.Kryo;
+
+/**
+ * A simple {@link Queue} based {@link KryoPool} implementation, should be built
+ * using the KryoPool.Builder.
+ *
+ * @author Martin Grotzke
+ */
+class KryoPoolQueueImpl implements KryoPool {
+
+	private final Queue<Kryo> queue;
+	private final KryoFactory factory;
+
+	KryoPoolQueueImpl(KryoFactory factory, Queue<Kryo> queue) {
+		this.factory = factory;
+		this.queue = queue;
+	}
+
+	public int size () {
+		return queue.size();
+	}
+
+	public Kryo borrow () {
+		Kryo res;
+		if((res = queue.poll()) != null) {
+			return res;
+		}
+		return factory.create();
+	}
+
+	public void release (Kryo kryo) {
+		queue.offer(kryo);
+	}
+
+	public <T> T run(KryoCallback<T> callback) {
+		Kryo kryo = borrow();
+		try {
+			return callback.execute(kryo);
+		} finally {
+			release(kryo);
+		}
+	}
+
+	public void clear() {
+		queue.clear();
+	}
+
+}

--- a/src/com/esotericsoftware/kryo/pool/SoftReferenceQueue.java
+++ b/src/com/esotericsoftware/kryo/pool/SoftReferenceQueue.java
@@ -1,0 +1,117 @@
+package com.esotericsoftware.kryo.pool;
+
+import java.lang.ref.SoftReference;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.Queue;
+
+import com.esotericsoftware.kryo.Kryo;
+
+/**
+ * Internally uses {@link SoftReference}s for queued Kryo instances,
+ * most importantly adjusts the {@link Queue#poll() poll}
+ * behavior so that gc'ed Kryo instances are skipped.
+ * Most other methods are unsupported.
+ *
+ * @author Martin Grotzke
+ */
+class SoftReferenceQueue implements Queue<Kryo> {
+	
+	private Queue<SoftReference<Kryo>> delegate;
+
+	public SoftReferenceQueue (Queue<?> delegate) {
+		this.delegate = (Queue<SoftReference<Kryo>>)delegate;
+	}
+
+	public Kryo poll () {
+		Kryo res;
+		SoftReference<Kryo> ref;
+		while((ref = delegate.poll()) != null) {
+			if((res = ref.get()) != null) {
+				return res;
+			}
+		}
+		return null;
+	}
+
+	public boolean offer (Kryo e) {
+		return delegate.offer(new SoftReference(e));
+	}
+
+	public boolean add (Kryo e) {
+		return delegate.add(new SoftReference(e));
+	}
+
+	public int size () {
+		return delegate.size();
+	}
+
+	public boolean isEmpty () {
+		return delegate.isEmpty();
+	}
+
+	public boolean contains (Object o) {
+		return delegate.contains(o);
+	}
+
+	public void clear () {
+		delegate.clear();
+	}
+
+	public boolean equals (Object o) {
+		return delegate.equals(o);
+	}
+
+	public int hashCode () {
+		return delegate.hashCode();
+	}
+	
+	@Override
+	public String toString () {
+		return getClass().getSimpleName() + super.toString();
+	}
+
+	public Iterator<Kryo> iterator () {
+		throw new UnsupportedOperationException();
+	}
+
+	public Kryo remove () {
+		throw new UnsupportedOperationException();
+	}
+
+	public Object[] toArray () {
+		throw new UnsupportedOperationException();
+	}
+
+	public Kryo element () {
+		throw new UnsupportedOperationException();
+	}
+
+	public Kryo peek () {
+		throw new UnsupportedOperationException();
+	}
+
+	public <T> T[] toArray (T[] a) {
+		throw new UnsupportedOperationException();
+	}
+
+	public boolean remove (Object o) {
+		throw new UnsupportedOperationException();
+	}
+
+	public boolean containsAll (Collection<?> c) {
+		throw new UnsupportedOperationException();
+	}
+
+	public boolean addAll (Collection<? extends Kryo> c) {
+		throw new UnsupportedOperationException();
+	}
+
+	public boolean removeAll (Collection<?> c) {
+		throw new UnsupportedOperationException();
+	}
+
+	public boolean retainAll (Collection<?> c) {
+		throw new UnsupportedOperationException();
+	}
+}

--- a/test/com/esotericsoftware/kryo/pool/KryoPoolTest.java
+++ b/test/com/esotericsoftware/kryo/pool/KryoPoolTest.java
@@ -2,33 +2,54 @@ package com.esotericsoftware.kryo.pool;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.util.Arrays;
+import java.util.Collection;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
 
 import com.esotericsoftware.kryo.Kryo;
 
+@RunWith(Parameterized.class)
 public class KryoPoolTest {
-	
-	private KryoFactory factory;
+
+	private static KryoFactory factory = new KryoFactory() {
+		@Override
+		public Kryo create () {
+			Kryo kryo = new Kryo();
+			// configure kryo
+			return kryo;
+		}
+	};
+
+	@Parameters
+	public static Collection<Object[]> data () {
+		return Arrays.asList(new Object[][] {
+			{new KryoPool.Builder(factory)},
+			{new KryoPool.Builder(factory).softReferences()}
+		});
+	}
+
 	private KryoPool pool;
-	
+
+	public KryoPoolTest(KryoPool.Builder builder) {
+		pool = builder.build();
+	}
+
 	@Before
 	public void beforeMethod() {
-		factory = new KryoFactory() {
-			@Override
-			public Kryo create () {
-				Kryo kryo = new Kryo();
-				// configure kryo
-				return kryo;
-			}
-		};
-		pool = new KryoPool(factory);
+		// clear the pool's queue
+		((KryoPoolQueueImpl)pool).clear();
+	}
+
+	private int size() {
+		return ((KryoPoolQueueImpl)pool).size();
 	}
 
 	@Test
@@ -40,23 +61,23 @@ public class KryoPoolTest {
 
 	@Test
 	public void releaseShouldAddKryoToPool() {
-		assertEquals(0, pool.size());
+		assertEquals(0, size());
 		Kryo kryo = pool.borrow();
 		pool.release(kryo);
-		assertEquals(1, pool.size());
+		assertEquals(1, size());
 	}
 
 	@Test
 	public void testSize() {
-		assertEquals(0, pool.size());
+		assertEquals(0, size());
 		Kryo kryo1 = pool.borrow();
-		assertEquals(0, pool.size());
+		assertEquals(0, size());
 		Kryo kryo2 = pool.borrow();
 		assertFalse(kryo1 == kryo2);
 		pool.release(kryo1);
-		assertEquals(1, pool.size());
+		assertEquals(1, size());
 		pool.release(kryo2);
-		assertEquals(2, pool.size());
+		assertEquals(2, size());
 	}
 
 	@Test
@@ -72,19 +93,19 @@ public class KryoPoolTest {
 
 	@Test
 	public void runWithKryoShouldAddKryoToPool() {
-		assertEquals(0, pool.size());
+		assertEquals(0, size());
 		pool.run(new KryoCallback<String>() {
 			@Override
 			public String execute(Kryo kryo) {
 				return null;
 			}
 		});
-		assertEquals(1, pool.size());
+		assertEquals(1, size());
 	}
 
 	@Test
 	public void runWithKryoShouldAddKryoToPoolOnException() {
-		assertEquals(0, pool.size());
+		assertEquals(0, size());
 		try {
 			pool.run(new KryoCallback<String>() {
 				@Override
@@ -96,7 +117,7 @@ public class KryoPoolTest {
 		} catch(RuntimeException e) {
 			// expected
 		}
-		assertEquals(1, pool.size());
+		assertEquals(1, size());
 	}
 
 	@Test(expected = IllegalArgumentException.class)


### PR DESCRIPTION
Also removed KryoPool.size() to keep the interface minimal (size would be an issue e.g. for ThreadLocal).

This change is motivated by later comments in PR #230.
