### PR TITLE
BigIntegerSerializer, BigDecimalSerializer, TreeMapSerializer and TreeSetSerializer optimizations and enhacements

### DIFF
--- a/test/com/esotericsoftware/kryo/CollectionSerializerTest.java
+++ b/test/com/esotericsoftware/kryo/CollectionSerializerTest.java
@@ -3,7 +3,6 @@ package com.esotericsoftware.kryo;
 
 import java.util.ArrayList;
 import java.util.LinkedList;
-import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.concurrent.CopyOnWriteArrayList;
 
@@ -11,6 +10,7 @@ import com.esotericsoftware.kryo.MapSerializerTest.KeyComparator;
 import com.esotericsoftware.kryo.MapSerializerTest.KeyThatIsntComparable;
 import com.esotericsoftware.kryo.serializers.CollectionSerializer;
 import com.esotericsoftware.kryo.serializers.DefaultSerializers.StringSerializer;
+import java.util.Comparator;
 
 /** @author Nathan Sweet <misc@n4te.com> */
 public class CollectionSerializerTest extends KryoTestCase {
@@ -54,6 +54,21 @@ public class CollectionSerializerTest extends KryoTestCase {
 		set.add(new KeyThatIsntComparable("1"));
 		set.add(new KeyThatIsntComparable("2"));
 		roundTrip(9, 9, set);
+		
+		kryo.register(TreeSetSubclass.class);
+		set = new TreeSetSubclass<Integer>();
+		set.add(12);
+		set.add(63);
+		set.add(34);
+		set.add(45);
+		roundTrip(11, 23, set);
 	}
 
+	static public class TreeSetSubclass<E> extends TreeSet<E> {
+		public TreeSetSubclass() {
+		}
+		public TreeSetSubclass(Comparator<? super E> comparator) {
+			super(comparator);
+		}
+	}
 }

--- a/test/com/esotericsoftware/kryo/DefaultSerializersTest.java
+++ b/test/com/esotericsoftware/kryo/DefaultSerializersTest.java
@@ -181,12 +181,24 @@ public class DefaultSerializersTest extends KryoTestCase {
 
 	public void testBigDecimalSerializer () {
 		kryo.register(BigDecimal.class);
+		kryo.register(BigDecimalSubclass.class);
 		roundTrip(5, 8, BigDecimal.valueOf(12345, 2));
+		roundTrip(7, 10, new BigDecimal("12345.12345"));
+		roundTrip(4, 7, BigDecimal.ZERO);
+		roundTrip(4, 7, BigDecimal.ONE);
+		roundTrip(4, 7, BigDecimal.TEN);
+		roundTrip(5, 8, new BigDecimalSubclass(new BigInteger("12345"), 2));
+		roundTrip(7, 10, new BigDecimalSubclass("12345.12345"));
 	}
 
 	public void testBigIntegerSerializer () {
 		kryo.register(BigInteger.class);
+		kryo.register(BigIntegerSubclass.class);
 		roundTrip(8, 8, BigInteger.valueOf(1270507903945L));
+		roundTrip(3, 3, BigInteger.ZERO);
+		roundTrip(3, 3, BigInteger.ONE);
+		roundTrip(3, 3, BigInteger.TEN);
+		roundTrip(8, 8, new BigIntegerSubclass("1270507903945"));
 	}
 
 	public void testEnumSerializer () {
@@ -300,7 +312,7 @@ public class DefaultSerializersTest extends KryoTestCase {
 		assertEquals(ArrayList.class, kryo.readObject(in, Class.class));
 		assertEquals(TestEnum.class, kryo.readObject(in, Class.class));
 	}
-	
+
 	public void testLocaleSerializer () {
 		kryo.setRegistrationRequired(true);
 		kryo.register(Locale.class);
@@ -324,4 +336,23 @@ public class DefaultSerializersTest extends KryoTestCase {
 		c {
 		}
 	}
+	
+	static class BigDecimalSubclass extends BigDecimal {
+		public BigDecimalSubclass(BigInteger unscaledVal, int scale) {
+			super(unscaledVal, scale);
+		}
+		public BigDecimalSubclass(String val) {
+			super(val);
+		}
+	}
+	
+	static class BigIntegerSubclass extends BigInteger {
+		public BigIntegerSubclass(byte[] val) {
+			super(val);
+		}
+		public BigIntegerSubclass(String val) {
+			super(val);
+		}
+	}
+	
 }

--- a/test/com/esotericsoftware/kryo/GarbageCollectionTest.java
+++ b/test/com/esotericsoftware/kryo/GarbageCollectionTest.java
@@ -1,0 +1,45 @@
+package com.esotericsoftware.kryo;
+
+import com.esotericsoftware.kryo.util.DefaultClassResolver;
+import com.esotericsoftware.kryo.util.DefaultStreamFactory;
+import com.esotericsoftware.kryo.util.FastestStreamFactory;
+import com.esotericsoftware.kryo.util.MapReferenceResolver;
+import java.lang.ref.WeakReference;
+import static junit.framework.Assert.assertNull;
+import junit.framework.TestCase;
+
+/**
+ * Tests for detecting PermGen memory leaks.
+ * 
+ * @author Tumi <serverperformance@gmail.com>
+ */
+public class GarbageCollectionTest extends TestCase {
+
+	public void testDefaultStreamFactory () {
+		final DefaultStreamFactory strongRefToStreamFactory = new DefaultStreamFactory();
+		Kryo kryo = new Kryo(new DefaultClassResolver(), new MapReferenceResolver(), strongRefToStreamFactory);
+		WeakReference<Kryo> kryoWeakRef = new WeakReference<Kryo>(kryo);
+		kryo = null; // remove strong ref, now kryo is only weak-reachable
+		reclaim(kryoWeakRef);
+	}
+
+	public void testFastestStreamFactory () {
+		final FastestStreamFactory strongRefToStreamFactory = new FastestStreamFactory();
+		Kryo kryo = new Kryo(new DefaultClassResolver(), new MapReferenceResolver(), strongRefToStreamFactory);
+		WeakReference<Kryo> kryoWeakRef = new WeakReference<Kryo>(kryo);
+		kryo = null; // remove strong ref, now kryo is only weak-reachable
+		reclaim(kryoWeakRef);
+	}
+	
+	private void reclaim (WeakReference<Kryo> kryoWeakRef) {
+		// Forces GC
+		System.gc();
+		// Waits for recaim the weaked-reachable kryo instance
+		int times = 0;
+		while (kryoWeakRef.get() != null && times < 30) { // limit 3 seconds
+			try { Thread.sleep(100); } catch (InterruptedException ignored) {}
+			times++;
+		}
+		assertNull(kryoWeakRef.get());
+	}
+}

--- a/test/com/esotericsoftware/kryo/MapSerializerTest.java
+++ b/test/com/esotericsoftware/kryo/MapSerializerTest.java
@@ -112,6 +112,14 @@ public class MapSerializerTest extends KryoTestCase {
 		key2.value = "1234";
 		map.put(key2, "4567");
 		roundTrip(21, 24, map);
+
+		kryo.register(TreeMapSubclass.class);
+		map = new TreeMapSubclass<String, Integer>();
+		map.put("1", 47);
+		map.put("2", 34);
+		map.put("3", 65);
+		map.put("4", 44);
+		roundTrip(24, 38, map);
 	}
 
 	public void testTreeMapWithReferences () {
@@ -132,6 +140,14 @@ public class MapSerializerTest extends KryoTestCase {
 		key2.value = "1234";
 		map.put(key2, "4567");
 		roundTrip(29, 32, map);
+
+		kryo.register(TreeMapSubclass.class);
+		map = new TreeMapSubclass<String, Integer>();
+		map.put("1", 47);
+		map.put("2", 34);
+		map.put("3", 65);
+		map.put("4", 44);
+		roundTrip(29, 43, map);
 	}
 	
 	static public class HasGenerics {
@@ -151,6 +167,14 @@ public class MapSerializerTest extends KryoTestCase {
 		}
 		public KeyThatIsntComparable (String value) {
 			this.value = value;
+		}
+	}
+
+	static public class TreeMapSubclass<K,V> extends TreeMap<K,V> {
+		public TreeMapSubclass() {
+		}
+		public TreeMapSubclass(Comparator<? super K> comparator) {
+			super(comparator);
 		}
 	}
 }


### PR DESCRIPTION
- Proper handle of subclasses (Fix #166)
- Small optimizations for common BigDecimal and BigInteger constants (Fix #238)
- Unit test to avoid regression of PermGen leaks (ensure fix of #170 contributed by #173)
