### PR TITLE
Fix end-of-line character in ReferenceTest

### DIFF
--- a/test/com/esotericsoftware/kryo/ReferenceTest.java
+++ b/test/com/esotericsoftware/kryo/ReferenceTest.java
@@ -74,7 +74,8 @@ public class ReferenceTest extends KryoTestCase {
 			// This is JDK > = 1.7
 			kryo.register(subList.getClass(), new ArraySubListSerializer());			
 		} else {
-			kryo.register(subList.getClass(), new SubListSerializer());		    
+			kryo.register(subList.getClass(), new SubListSerializer());
+		    
 		}
 		roundTrip(26, 26,  subList);
 	}


### PR DESCRIPTION
ReferenceTest.java contains a bad end-of-line character (^M) that has side-effects in some 3rd-party tools (last line not displayed in [github blame page](https://github.com/EsotericSoftware/kryo/blame/master/test/com/esotericsoftware/kryo/ReferenceTest.java), SonarQube analysis fails, ...) 
