### PR TITLE
Warn unregistered classes option

### DIFF
--- a/src/com/esotericsoftware/kryo/Kryo.java
+++ b/src/com/esotericsoftware/kryo/Kryo.java
@@ -123,6 +123,7 @@ public class Kryo {
 	private ClassLoader classLoader = getClass().getClassLoader();
 	private InstantiatorStrategy strategy = new DefaultInstantiatorStrategy();
 	private boolean registrationRequired;
+	private boolean warnUnregisteredClasses;
 
 	private int depth, maxDepth = Integer.MAX_VALUE;
 	private boolean autoReset = true;
@@ -481,13 +482,20 @@ public class Kryo {
 			}
 			if (registration == null) {
 				if (registrationRequired) {
-					throw new IllegalArgumentException("Class is not registered: " + className(type)
-						+ "\nNote: To register this class use: kryo.register(" + className(type) + ".class);");
+					throw new IllegalArgumentException(unregisteredClassMessage(type));
+				}
+				if(warnUnregisteredClasses) {
+					warn(unregisteredClassMessage(type));
 				}
 				registration = classResolver.registerImplicit(type);
 			}
 		}
 		return registration;
+	}
+
+	protected String unregisteredClassMessage (Class type) {
+		return "Class is not registered: " + className(type)
+			+ "\nNote: To register this class use: kryo.register(" + className(type) + ".class);";
 	}
 
 	/** @see ClassResolver#getRegistration(int) */
@@ -1021,6 +1029,21 @@ public class Kryo {
 
 	public boolean isRegistrationRequired () {
 		return registrationRequired;
+	}
+	
+	/**
+	 * If true, kryo writes a warn log telling about the classes unregistered. Default is false.
+	 * <p>
+	 * If false, no log are written when unregistered classes are encountered.
+	 * </p>
+	 */
+	public void setWarnUnregisteredClasses (boolean warnUnregisteredClasses) {
+		this.warnUnregisteredClasses = warnUnregisteredClasses;
+		if (TRACE) trace("kryo", "Warn unregistered classes: " + warnUnregisteredClasses);
+	}
+	
+	public boolean isWarnUnregisteredClasses () {
+		return warnUnregisteredClasses;
 	}
 
 	/** If true, each appearance of an object in the graph after the first is stored as an integer ordinal. When set to true,

--- a/test/com/esotericsoftware/kryo/WarnUnregisteredClassesTest.java
+++ b/test/com/esotericsoftware/kryo/WarnUnregisteredClassesTest.java
@@ -1,0 +1,163 @@
+/* Copyright (c) 2008, Nathan Sweet
+ * All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following
+ * conditions are met:
+ * 
+ * - Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the distribution.
+ * - Neither the name of Esoteric Software nor the names of its contributors may be used to endorse or promote products derived
+ * from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
+ * BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. */
+
+package com.esotericsoftware.kryo;
+
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.Collections;
+import java.util.Date;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.TimeZone;
+
+import com.esotericsoftware.kryo.KryoTestCase.StreamFactory;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+import com.esotericsoftware.kryo.io.UnsafeMemoryInput;
+import com.esotericsoftware.kryo.io.UnsafeMemoryOutput;
+import com.esotericsoftware.minlog.Log;
+
+import static com.esotericsoftware.minlog.Log.Logger;
+
+import java.util.Locale;
+
+import junit.framework.TestCase;
+
+/** @author Tiago Albineli Motta <timotta@gmail.com> */
+public class WarnUnregisteredClassesTest extends TestCase {
+	
+	LoggerStub log;
+	
+	@Override
+	protected void setUp() throws Exception {
+		super.setUp();
+		log = new LoggerStub();
+		Log.setLogger(log);
+	}
+	
+	public void testLogOnlyOneTimePerClass () {
+		Kryo kryo = new Kryo();
+		kryo.setRegistrationRequired(false);
+		kryo.setWarnUnregisteredClasses(true);
+		
+		write(kryo, new UnregisteredClass());
+		assertEquals(1, log.messages.size());
+		
+		write(kryo, new UnregisteredClass());
+		assertEquals(1, log.messages.size());
+		
+		write(kryo, new UnregisteredClass2());
+		assertEquals(2, log.messages.size());
+		
+		write(kryo, new UnregisteredClass2());
+		assertEquals(2, log.messages.size());
+	}
+	
+	public void testDontLogIfNotRequired () {
+		Kryo kryo = new Kryo();
+		kryo.setRegistrationRequired(false);
+		kryo.setWarnUnregisteredClasses(false);
+		
+		write(kryo, new UnregisteredClass());
+		assertEquals(0, log.messages.size());
+		
+		write(kryo, new UnregisteredClass2());
+		assertEquals(0, log.messages.size());
+	}
+	
+	public void testDontLogClassIsRegistered () {
+		Kryo kryo = new Kryo();
+		kryo.setRegistrationRequired(false);
+		kryo.setWarnUnregisteredClasses(true);
+		kryo.register(RegisteredClass.class);
+		
+		write(kryo, new RegisteredClass());
+		assertEquals(0, log.messages.size());
+	}
+	
+	public void testLogShouldBeWarn () {
+		Kryo kryo = new Kryo();
+		kryo.setRegistrationRequired(false);
+		kryo.setWarnUnregisteredClasses(true);
+		
+		write(kryo, new UnregisteredClass());
+		assertEquals(Log.LEVEL_WARN, log.levels.get(0).intValue());
+	}
+	
+	public void testLogMessageShouldContainsClassName () {
+		Kryo kryo = new Kryo();
+		kryo.setRegistrationRequired(false);
+		kryo.setWarnUnregisteredClasses(true);
+		
+		write(kryo, new UnregisteredClass());
+		assertTrue(log.messages.get(0).contains(UnregisteredClass.class.getName()));
+	}
+	
+	public void write(Kryo kryo, Object object) {
+		StreamFactory sf = new StreamFactory() {
+			public Output createOutput(OutputStream os) {
+				return new UnsafeMemoryOutput(os);
+			}
+			public Output createOutput(OutputStream os, int size) {
+				return new UnsafeMemoryOutput(os, size);
+			}
+			public Output createOutput(int size, int limit) {
+				return new UnsafeMemoryOutput(size, limit);
+			}
+			public Input createInput(InputStream os, int size) {
+				return new UnsafeMemoryInput(os, size);
+			}
+			public Input createInput(byte[] buffer) {
+				return new UnsafeMemoryInput(buffer);
+			}
+		};
+		ByteArrayOutputStream outStream = new ByteArrayOutputStream();
+		Output output = sf.createOutput(outStream, 4096);
+		kryo.writeClassAndObject(output, object);
+		output.flush();
+	}
+	
+	class LoggerStub extends Logger {
+		
+		public List<Integer> levels = new ArrayList();		
+		public List<String> messages = new ArrayList();
+		
+		@Override
+		public void log (int level, String category, String message, Throwable ex) {
+			levels.add(level);
+			messages.add(message);
+		}
+	}
+}
+
+class UnregisteredClass {
+	public UnregisteredClass() {}
+}
+class UnregisteredClass2 {
+	public UnregisteredClass2() {}
+}
+class RegisteredClass {
+	public RegisteredClass() {}
+}


### PR DESCRIPTION
With this option, unregistered classes are warned on kryos log instead of raise exception like the option registrationRequired do. 

This option is required mostly for processing large amount of data with third vendor libs, to see all classes that are not registered in the first running, instead of have to discover one class for each running. This happens with me using Spark and mlib.ALS

How to use:
```java
kryo.setWarnUnregisteredClasses(true)
```

