### PR TITLE
Removed final modifier, so Input/Output can have all methods overridden

### DIFF
--- a/src/com/esotericsoftware/kryo/io/Input.java
+++ b/src/com/esotericsoftware/kryo/io/Input.java
@@ -119,7 +119,7 @@ public class Input extends InputStream {
 	}
 
 	/** Returns the current position in the buffer. */
-	final public int position () {
+	public int position () {
 		return position;
 	}
 
@@ -129,7 +129,7 @@ public class Input extends InputStream {
 	}
 
 	/** Returns the limit for the buffer. */
-	final public int limit () {
+	public int limit () {
 		return limit;
 	}
 

--- a/src/com/esotericsoftware/kryo/io/Output.java
+++ b/src/com/esotericsoftware/kryo/io/Output.java
@@ -132,7 +132,7 @@ public class Output extends OutputStream {
 	}
 
 	/** Returns the current position in the buffer. This is the number of bytes that have not been flushed. */
-	final public int position () {
+	public int position () {
 		return position;
 	}
 
@@ -142,7 +142,7 @@ public class Output extends OutputStream {
 	}
 
 	/** Returns the total number of bytes written. This may include bytes that have not been flushed. */
-	final public long total () {
+	public long total () {
 		return total + position;
 	}
 


### PR DESCRIPTION
The Netty project uses their own ByteBuffer implementation in their networking stack, and in order to provide Kryo Input/Output serialization via the Netty ByteBuffer implementation, the following 4 methods cannot be marked final.

This PR removes the final method keyword, so that Input/Output can be effectively overridden for 'native' usage in Netty.