### PR TITLE
Fixed compile errors by reverting cast externalizable in Serializer

### DIFF
--- a/src/com/esotericsoftware/kryo/serializers/ExternalizableSerializer.java
+++ b/src/com/esotericsoftware/kryo/serializers/ExternalizableSerializer.java
@@ -85,7 +85,7 @@ public class ExternalizableSerializer extends Serializer {
 
 	 private Object readExternal (Kryo kryo, Input input, Class type) {
 		  try {
-				Externalizable object = kryo.newInstance(type);
+				Externalizable object = (Externalizable)kryo.newInstance(type);
 				object.readExternal(getObjectInput(kryo, input));
 				return object;
 		  } catch (ClassCastException e) {


### PR DESCRIPTION
Kryo in it's current state will not compile, since kryo.newInstance(type) returns type Object, and the implicit casting via generics does not take place. I only reverted the removal of casting made by change a0cb680 so that this class can now compile.
  
The specific error was:
ERROR
incompatible types
  required: java.io.Externalizable
  found:    java.lang.Object

Location: Line: 88:73
com/esotericsoftware/kryo/serializers/ExternalizableSerializer.java