### PR TITLE
KryoBuilder, builder for Kryo's that implements KryoFactory, with its own Serializer

### DIFF
--- a/src/com/esotericsoftware/kryo/KryoBuilder.java
+++ b/src/com/esotericsoftware/kryo/KryoBuilder.java
@@ -12,29 +12,139 @@ import com.esotericsoftware.kryo.util.DefaultClassResolver;
 import com.esotericsoftware.kryo.util.DefaultStreamFactory;
 import com.esotericsoftware.kryo.util.MapReferenceResolver;
 
+/**
+ * Configurable {@link Kryo} builder (implementing {@link KryoFactory}) with a provided {@link Serializer}
+ * ({@link KryoBuilderSerializer}) to make the builder itself able to be serialized.<p>
+ * 
+ * Typical use case is for "self-descriptive" Kryo data.  One would create a {@link Kryo}
+ * instance using a {@link KryoBuilder}, then as the first object written, serialize the builder
+ * itself.  When deserializing, first deserialize the {@link KryoBuilder}, then from
+ * it build a {@link Kryo} to deserialize the remainder of the input.<p>
+ * 
+ * More advanced uses of {@link Kryo} may require serializing individual {@link Serializer} instances,
+ * such as if {@link #register(Class, Serializer)} or {@link #register(Class, Serializer, int)} is
+ * called on a {@link KryoBuilder} which must be serialized.  An alternative to serializing
+ * {@link Serializer}s is to subclass the {@link Serializer}, performing customizations in the
+ * constructor, and instead call {@link #addDefaultSerializer(Class, Class)}.<p>
+ * 
+ * {@link KryoBuilderSerializer} can serialize a {@link KryoBuilder}, but does not provide
+ * explicit support for potentially required objects, such as {@link Serializer} instances
+ * that must be registered.<p>
+ * 
+ * {@link KryoBuilder} instances represent a single step in the customization of a {@link Kryo}.
+ * Instances are joined in a linked-list fashion, with a reference to the head of the list,
+ * for easy chaining.
+ * 
+ * @author Robin Kirkman
+ *
+ */
 public final class KryoBuilder implements KryoFactory {
 
+	/**
+	 * Steps types taken by a {@link KryoBuilder} upon a {@link Kryo} instance to customize it.
+	 * @author robin
+	 *
+	 */
 	private static enum Step {
+		/**
+		 * Create a new {@link Kryo}
+		 */
 		NEW_INSTANCE,
+		/**
+		 * Set the default serializer
+		 * @see Kryo#setDefaultSerializer(Class)
+		 * @see Kryo#setDefaultSerializer(SerializerFactory)
+		 */
 		SET_DEFAULT_SERIALIZER,
+		/**
+		 * Add a per-type default serializer
+		 * @see Kryo#addDefaultSerializer(Class, Class)
+		 * @see Kryo#addDefaultSerializer(Class, Serializer)
+		 * @see Kryo#addDefaultSerializer(Class, SerializerFactory)
+		 */
 		ADD_DEFAULT_SERIALIZER,
+		/**
+		 * Register a serializer
+		 * @see Kryo#register(Class)
+		 * @see Kryo#register(Registration)
+		 * @see Kryo#register(Class, int)
+		 * @see Kryo#register(Class, Serializer)
+		 * @see Kryo#register(Class, Serializer, int)
+		 */
 		REGISTER,
+		/**
+		 * Set the classloader
+		 * @see Kryo#setClassLoader(ClassLoader)
+		 */
 		SET_CLASSLOADER,
+		/**
+		 * Set whether registration is required
+		 * @see Kryo#setRegistrationRequired(boolean)
+		 */
 		SET_REGISTRATION_REQUIRED,
+		/**
+		 * Sets whether references are used
+		 * @see Kryo#setReferences(boolean)
+		 */
 		SET_REFERENCES,
+		/**
+		 * Sets whether copy-references are used
+		 * @see Kryo#setCopyReferences(boolean)
+		 */
 		SET_COPY_REFERENCES,
+		/**
+		 * Sets the reference resolver
+		 * @see Kryo#setReferenceResolver(ReferenceResolver)
+		 */
 		SET_REFERENCE_RESOLVER,
+		/**
+		 * Sets the instantiator strategy
+		 * @see Kryo#setInstantiatorStrategy(InstantiatorStrategy)
+		 */
 		SET_INSTANTIATOR_STRATEGY,
+		/**
+		 * Sets auto-reset
+		 * @see Kryo#setAutoReset(boolean)
+		 */
 		SET_AUTO_RESET,
+		/**
+		 * Sets the max depth
+		 * @see Kryo#setMaxDepth(int)
+		 */
 		SET_MAX_DEPTH,
+		/**
+		 * Sets the stream factory
+		 * @see Kryo#setStreamFactory(StreamFactory)
+		 */
 		SET_STREAM_FACTORY,
+		/**
+		 * Sets whether asm is enabled
+		 * @see Kryo#setAsmEnabled(boolean)
+		 */
 		SET_ASM_ENABLED,
 		
 		;
 		
+		/**
+		 * Cached array of values as returned by {@link #values()}
+		 */
 		private static final Step[] VALUES = values();
 	}
 	
+	/**
+	 * {@link Serializer} for {@link KryoBuilder}.<p>
+	 * 
+	 * Does not require references.
+	 * @author Robin Kirkman
+	 *
+	 */
+	/*
+	 * Format is:
+	 * 1) step enum ordinal
+	 * 2) length of args array
+	 * 3) individual argument objects
+	 * 4) the next step to be applied (tail)
+	 */
 	public static final class KryoBuilderSerializer extends Serializer<KryoBuilder> {
 
 		@SuppressWarnings("synthetic-access")
@@ -69,23 +179,68 @@ public final class KryoBuilder implements KryoFactory {
 		
 	}
 	
+	/*
+	 * TODO: head, step, and args could be final if KryoBuilderSerializer can
+	 * be assured to never need to use backreferences 
+	 */
+	
+	/**
+	 * Reference to the first action to be taken, which should have {@link #step} = {@link Step#NEW_INSTANCE}.
+	 * Should never be null except (temporarily) during deserialization.
+	 */
 	private KryoBuilder head;
+	/**
+	 * The next step to be taken.  Can be {@code null}
+	 */
 	private KryoBuilder tail;
+	/**
+	 * The {@link Step} to apply.
+	 * Should never be null except (temporarily) during deserialization
+	 */
 	private Step step;
+	/**
+	 * Arguments to the customization step
+	 */
 	private Object[] args;
 
+	/**
+	 * Create a new {@link KryoBuilder} that constructs a {@link Kryo} by
+	 * calling {@link Kryo#Kryo()}
+	 * @see Kryo#Kryo()
+	 */
 	public KryoBuilder () {
 		this((ClassResolver) null, (ReferenceResolver) null, (StreamFactory) null);
 	}
 
+	/**
+	 * Create a new {@link KryoBuilder} that constructs a {@link Kryo} by
+	 * calling {@link Kryo#Kryo(ReferenceResolver)}
+	 * @param referenceResolver The reference resolver
+	 * @see Kryo#Kryo(ReferenceResolver)
+	 */
 	public KryoBuilder (ReferenceResolver referenceResolver) {
 		this((ClassResolver) null, referenceResolver, (StreamFactory) null);
 	}
 
+	/**
+	 * Create a new {@link KryoBuilder} that constructs a {@link Kryo} by
+	 * calling {@link Kryo#Kryo(ClassResolver, ReferenceResolver)}
+	 * @param classResolver The class resolver
+	 * @param referenceResolver The reference resolver
+	 * @see Kryo#Kryo(ClassResolver, ReferenceResolver)
+	 */
 	public KryoBuilder (ClassResolver classResolver, ReferenceResolver referenceResolver) {
 		this(classResolver, referenceResolver, (StreamFactory) null);
 	}
 	
+	/**
+	 * Create a new {@link KryoBuilder} that constructs a {@link Kryo} by
+	 * calling {@link Kryo#Kryo(ClassResolver, ReferenceResolver, StreamFactory)}
+	 * @param classResolver The class resolver
+	 * @param referenceResolver The reference resolver
+	 * @param streamFactory The stream factory
+	 * @see Kryo#Kryo(ClassResolver, ReferenceResolver, StreamFactory)
+	 */
 	public KryoBuilder(ClassResolver classResolver, ReferenceResolver referenceResolver, StreamFactory streamFactory) {
 		head = this;
 		tail = null;
@@ -93,6 +248,12 @@ public final class KryoBuilder implements KryoFactory {
 		args = new Object[] {classResolver, referenceResolver, streamFactory};
 	}
 	
+	/**
+	 * Create a new {@link KryoBuilder} that constructs a {@link Kryo}
+	 * by calling {@link KryoFactory#create()} on the argument
+	 * @param factory The factory for new {@link Kryo}s
+	 * @see KryoFactory#create()
+	 */
 	public KryoBuilder(KryoFactory factory) {
 		head = this;
 		tail = null;
@@ -100,6 +261,12 @@ public final class KryoBuilder implements KryoFactory {
 		args = new Object[] { factory };
 	}
 	
+	/**
+	 * Constructor used when chaining a new step
+	 * @param prev The previous step
+	 * @param step The {@link Step} to chain
+	 * @param args Arguments to the {@link Step}
+	 */
 	private KryoBuilder(KryoBuilder prev, Step step, Object... args) {
 		head = prev.head;
 		tail = null;
@@ -110,6 +277,13 @@ public final class KryoBuilder implements KryoFactory {
 		prev.tail = this;
 	}
 	
+	/**
+	 * Constructor used during deserialization by {@link KryoBuilderSerializer}
+	 * @param head should be {@code null}
+	 * @param tail should be {@code null}
+	 * @param step should be {@code null}
+	 * @param args should be {@code null}
+	 */
 	private KryoBuilder(KryoBuilder head, KryoBuilder tail, Step step, Object[] args) {
 		this.head = head;
 		this.tail = tail;
@@ -147,15 +321,31 @@ public final class KryoBuilder implements KryoFactory {
 		}
 		return hash;
 	}
-	
+
+	/**
+	 * Create a new {@link Kryo}, applying the steps from this builder
+	 * @return A new {@link Kryo}
+	 */
+	@Override
 	public Kryo create() {
 		return head.step(null);
 	}
 	
+	/**
+	 * Configure an existing {@link Kryo}, applying the steps from this builder
+	 * @param kryo
+	 * @return
+	 */
 	public <T extends Kryo> T configure(T kryo) {
 		return (T) head.step(kryo);
 	}
 	
+	/**
+	 * Returns whether the objects in {@link #args} are all either instances of
+	 * the argument types (in order) or {@code null}
+	 * @param types The argument types to test for
+	 * @return {@code true} if each value in {@link #args} could be cast to the corresponding argument type
+	 */
 	private boolean argtypes(Class<?>... types) {
 		if(args.length != types.length)
 			return false;
@@ -165,10 +355,24 @@ public final class KryoBuilder implements KryoFactory {
 		return true;
 	}
 	
+	/**
+	 * Throws an {@link IllegalStateException} if a step cannot be applied
+	 * @return never returns
+	 */
+	private IllegalStateException illegalStep() throws IllegalStateException {
+		throw new IllegalStateException("Cannot apply " + step + " with arguments " + Arrays.toString(args));
+	}
+	
+	/**
+	 * Apply the configuration step for this {@link KryoBuilder} to the argument
+	 * @param kryo The {@link Kryo} to configure.  May be {@code null} for {@link Step#NEW_INSTANCE}
+	 * @return The configured {@link Kryo}, possibly created if {@link Step#NEW_INSTANCE}
+	 */
 	private Kryo step(Kryo kryo) {
 		switch(step) {
 		case NEW_INSTANCE:
-			if(kryo == null) {
+			if(kryo == null) { 
+				// create a new Kryo
 				if(argtypes(KryoFactory.class))
 					kryo = ((KryoFactory) args[0]).create();
 				else if(argtypes(ClassResolver.class, ReferenceResolver.class, StreamFactory.class)) {
@@ -181,8 +385,9 @@ public final class KryoBuilder implements KryoFactory {
 						args[2] = new DefaultStreamFactory();
 					kryo = new Kryo((ClassResolver) args[0], (ReferenceResolver) args[1], (StreamFactory) args[2]);
 				} else
-					throw new IllegalStateException();
-			}
+					throw illegalStep();
+			} else 
+				; // customize the provided argument Kryo
 			break;
 		case SET_DEFAULT_SERIALIZER:
 			if(argtypes(SerializerFactory.class))
@@ -190,7 +395,7 @@ public final class KryoBuilder implements KryoFactory {
 			else if(argtypes(Serializer.class))
 				kryo.setDefaultSerializer(((Class<?>) args[0]).asSubclass((Serializer.class)));
 			else
-				throw new IllegalStateException();
+				throw illegalStep();
 			break;
 		case ADD_DEFAULT_SERIALIZER:
 			if(argtypes(Class.class, Serializer.class))
@@ -200,7 +405,7 @@ public final class KryoBuilder implements KryoFactory {
 			else if(argtypes(Class.class, Class.class))
 				kryo.addDefaultSerializer((Class<?>) args[0], ((Class<?>) args[1]).asSubclass(Serializer.class));
 			else
-				throw new IllegalStateException();
+				throw illegalStep();
 			break;
 		case REGISTER:
 			if(argtypes(Class.class))
@@ -214,148 +419,255 @@ public final class KryoBuilder implements KryoFactory {
 			else if(argtypes(Registration.class))
 				kryo.register((Registration) args[0]);
 			else
-				throw new IllegalStateException();
+				throw illegalStep();
 			break;
 		case SET_CLASSLOADER:
 			if(argtypes(ClassLoader.class))
 				kryo.setClassLoader((ClassLoader) args[0]);
 			else
-				throw new IllegalStateException();
+				throw illegalStep();
 			break;
 		case SET_REGISTRATION_REQUIRED:
 			if(argtypes(Boolean.class))
 				kryo.setRegistrationRequired((Boolean) args[0]);
 			else
-				throw new IllegalStateException();
+				throw illegalStep();
 			break;
 		case SET_REFERENCES:
 			if(argtypes(Boolean.class))
 				kryo.setReferences((Boolean) args[0]);
 			else
-				throw new IllegalStateException();
+				throw illegalStep();
 			break;
 		case SET_COPY_REFERENCES:
 			if(argtypes(Boolean.class))
 				kryo.setCopyReferences((Boolean) args[0]);
 			else
-				throw new IllegalStateException();
+				throw illegalStep();
 			break;
 		case SET_REFERENCE_RESOLVER:
 			if(argtypes(ReferenceResolver.class))
 				kryo.setReferenceResolver((ReferenceResolver) args[0]);
 			else
-				throw new IllegalStateException();
+				throw illegalStep();
 			break;
 		case SET_INSTANTIATOR_STRATEGY:
 			if(argtypes(InstantiatorStrategy.class))
 				kryo.setInstantiatorStrategy((InstantiatorStrategy) args[0]);
 			else
-				throw new IllegalStateException();
+				throw illegalStep();
 			break;
 		case SET_AUTO_RESET:
 			if(argtypes(Boolean.class))
 				kryo.setAutoReset((Boolean) args[0]);
 			else
-				throw new IllegalStateException();
+				throw illegalStep();
 			break;
 		case SET_MAX_DEPTH:
 			if(argtypes(Integer.class))
 				kryo.setMaxDepth((Integer) args[0]);
 			else
-				throw new IllegalStateException();
+				throw illegalStep();
 			break;
 		case SET_STREAM_FACTORY:
 			if(argtypes(StreamFactory.class))
 				kryo.setStreamFactory((StreamFactory) args[0]);
 			else
-				throw new IllegalStateException();
+				throw illegalStep();
 			break;
 		case SET_ASM_ENABLED:
 			if(argtypes(Boolean.class))
 				kryo.setAsmEnabled((Boolean) args[0]);
 			else
-				throw new IllegalStateException();
+				throw illegalStep();
 			break;
 		}
 		return tail != null ? tail.step(kryo) : kryo;
 	}
 
+	/**
+	 * Step to call {@link Kryo#setDefaultSerializer(SerializerFactory)}
+	 * @param serializer
+	 * @return A chained {@link KryoBuilder} instance
+	 */
 	public KryoBuilder setDefaultSerializer (SerializerFactory serializer) {
 		return new KryoBuilder(this, Step.SET_DEFAULT_SERIALIZER, serializer);
 	}
 
+	/**
+	 * Step to call {@link Kryo#setDefaultSerializer(Class)}
+	 * @param serializer
+	 * @return A chained {@link KryoBuilder} instance
+	 */
 	public KryoBuilder setDefaultSerializer (Class<? extends Serializer> serializer) {
 		return new KryoBuilder(this, Step.SET_DEFAULT_SERIALIZER, serializer);
 	}
 
+	/**
+	 * Step to call {@link Kryo#addDefaultSerializer(Class, Serializer)}
+	 * @param type
+	 * @param serializer
+	 * @return A chained {@link KryoBuilder} instance
+	 */
 	public KryoBuilder addDefaultSerializer (Class type, Serializer serializer) {
 		return new KryoBuilder(this, Step.ADD_DEFAULT_SERIALIZER, type, serializer);
 	}
 
+	/**
+	 * Step to call {@link Kryo#addDefaultSerializer(Class, SerializerFactory)}
+	 * @param type
+	 * @param serializerFactory
+	 * @return A chained {@link KryoBuilder} instance
+	 */
 	public KryoBuilder addDefaultSerializer (Class type, SerializerFactory serializerFactory) {
 		return new KryoBuilder(this, Step.ADD_DEFAULT_SERIALIZER, type, serializerFactory);
 	}
 
+	/**
+	 * Step to call {@link Kryo#addDefaultSerializer(Class, Class)}
+	 * @param type
+	 * @param serializerClass
+	 * @return A chained {@link KryoBuilder} instance
+	 */
 	public KryoBuilder addDefaultSerializer (Class type, Class<? extends Serializer> serializerClass) {
 		return new KryoBuilder(this, Step.ADD_DEFAULT_SERIALIZER, type, serializerClass);
 	}
 
+	/**
+	 * Step to call {@link Kryo#register(Class)}
+	 * @param type
+	 * @return A chained {@link KryoBuilder} instance
+	 */
 	public KryoBuilder register (Class type) {
 		return new KryoBuilder(this, Step.REGISTER, type);
 	}
 
+	/**
+	 * Step to call {@link Kryo#register(Class, int)}
+	 * @param type
+	 * @param id
+	 * @return A chained {@link KryoBuilder} instance
+	 */
 	public KryoBuilder register (Class type, int id) {
 		return new KryoBuilder(this, Step.REGISTER, type, id);
 	}
 
+	/**
+	 * Step to call {@link Kryo#register(Class, Serializer)}
+	 * @param type
+	 * @param serializer
+	 * @return A chained {@link KryoBuilder} instance
+	 */
 	public KryoBuilder register (Class type, Serializer serializer) {
 		return new KryoBuilder(this, Step.REGISTER, type, serializer);
 	}
 
+	/**
+	 * Step to call {@link Kryo#register(Class, Serializer, int)}
+	 * @param type
+	 * @param serializer
+	 * @param id
+	 * @return A chained {@link KryoBuilder} instance
+	 */
 	public KryoBuilder register (Class type, Serializer serializer, int id) {
 		return new KryoBuilder(this, Step.REGISTER, type, serializer, id);
 	}
 
+	/**
+	 * Step to call {@link Kryo#register(Registration)}
+	 * @param registration
+	 * @return A chained {@link KryoBuilder} instance
+	 */
 	public KryoBuilder register (Registration registration) {
 		return new KryoBuilder(this, Step.REGISTER, registration);
 	}
 
+	/**
+	 * Step to call {@link Kryo#setClassLoader(ClassLoader)}
+	 * @param classLoader
+	 * @return A chained {@link KryoBuilder} instance
+	 */
 	public KryoBuilder setClassLoader (ClassLoader classLoader) {
 		return new KryoBuilder(this, Step.SET_CLASSLOADER, classLoader);
 	}
 
+	/**
+	 * Step to call {@link Kryo#setRegistrationRequired(boolean)}
+	 * @param registrationRequired
+	 * @return A chained {@link KryoBuilder} instance
+	 */
 	public KryoBuilder setRegistrationRequired (boolean registrationRequired) {
 		return new KryoBuilder(this, Step.SET_REGISTRATION_REQUIRED, registrationRequired);
 	}
 
+	/**
+	 * Step to call {@link Kryo#setReferences(boolean)}
+	 * @param references
+	 * @return A chained {@link KryoBuilder} instance
+	 */
 	public KryoBuilder setReferences (boolean references) {
 		return new KryoBuilder(this, Step.SET_REFERENCES, references);
 	}
 
+	/**
+	 * Step to call {@link Kryo#setCopyReferences(boolean)}
+	 * @param copyReferences
+	 * @return A chained {@link KryoBuilder} instance
+	 */
 	public KryoBuilder setCopyReferences (boolean copyReferences) {
 		return new KryoBuilder(this, Step.SET_COPY_REFERENCES, copyReferences);
 	}
 
+	/**
+	 * Step to call {@link Kryo#setReferenceResolver(ReferenceResolver)}
+	 * @param referenceResolver
+	 * @return A chained {@link KryoBuilder} instance
+	 */
 	public KryoBuilder setReferenceResolver (ReferenceResolver referenceResolver) {
 		return new KryoBuilder(this, Step.SET_REFERENCE_RESOLVER, referenceResolver);
 	}
 
+	/**
+	 * Step to call {@link Kryo#setInstantiatorStrategy(InstantiatorStrategy)}
+	 * @param strategy
+	 * @return A chained {@link KryoBuilder} instance
+	 */
 	public KryoBuilder setInstantiatorStrategy (InstantiatorStrategy strategy) {
 		return new KryoBuilder(this, Step.SET_INSTANTIATOR_STRATEGY, strategy);
 	}
 
+	/**
+	 * Step to call {@link Kryo#setAutoReset(boolean)}
+	 * @param autoReset
+	 * @return A chained {@link KryoBuilder} instance
+	 */
 	public KryoBuilder setAutoReset (boolean autoReset) {
 		return new KryoBuilder(this, Step.SET_AUTO_RESET, autoReset);
 	}
 
+	/**
+	 * Step to call {@link Kryo#setMaxDepth(int)}
+	 * @param maxDepth
+	 * @return A chained {@link KryoBuilder} instance
+	 */
 	public KryoBuilder setMaxDepth (int maxDepth) {
 		return new KryoBuilder(this, Step.SET_MAX_DEPTH, maxDepth);
 	}
 
+	/**
+	 * Step to call {@link Kryo#setStreamFactory(StreamFactory)}
+	 * @param streamFactory
+	 * @return A chained {@link KryoBuilder} instance
+	 */
 	public KryoBuilder setStreamFactory (StreamFactory streamFactory) {
 		return new KryoBuilder(this, Step.SET_STREAM_FACTORY, streamFactory);
 	}
 
+	/**
+	 * Step to call {@link Kryo#setAsmEnabled(boolean)}
+	 * @param flag
+	 * @return A chained {@link KryoBuilder} instance
+	 */
 	public KryoBuilder setAsmEnabled (boolean flag) {
 		return new KryoBuilder(this, Step.SET_ASM_ENABLED, flag);
 	}

--- a/src/com/esotericsoftware/kryo/KryoBuilder.java
+++ b/src/com/esotericsoftware/kryo/KryoBuilder.java
@@ -1,0 +1,268 @@
+package com.esotericsoftware.kryo;
+
+import org.objenesis.strategy.InstantiatorStrategy;
+
+import com.esotericsoftware.kryo.factories.SerializerFactory;
+import com.esotericsoftware.kryo.util.DefaultClassResolver;
+import com.esotericsoftware.kryo.util.DefaultStreamFactory;
+import com.esotericsoftware.kryo.util.MapReferenceResolver;
+
+public class KryoBuilder {
+
+	private static enum Step {
+		NEW_INSTANCE,
+		SET_DEFAULT_SERIALIZER,
+		ADD_DEFAULT_SERIALIZER,
+		REGISTER,
+		SET_CLASSLOADER,
+		SET_REGISTRATION_REQUIRED,
+		SET_REFERENCES,
+		SET_COPY_REFERENCES,
+		SET_REFERENCE_RESOLVER,
+		SET_INSTANTIATOR_STRATEGY,
+		SET_AUTO_RESET,
+		SET_MAX_DEPTH,
+		SET_STREAM_FACTORY,
+		SET_ASM_ENABLED,
+	}
+	
+	private KryoBuilder head;
+	private KryoBuilder tail;
+	private Step step;
+	private Object[] args;
+
+	public KryoBuilder () {
+		this(new DefaultClassResolver(), new MapReferenceResolver(), new DefaultStreamFactory());
+	}
+
+	public KryoBuilder (ReferenceResolver referenceResolver) {
+		this(new DefaultClassResolver(), referenceResolver, new DefaultStreamFactory());
+	}
+
+	public KryoBuilder (ClassResolver classResolver, ReferenceResolver referenceResolver) {
+		this(classResolver, referenceResolver, new DefaultStreamFactory());
+	}
+	
+	public KryoBuilder(ClassResolver classResolver, ReferenceResolver referenceResolver, StreamFactory streamFactory) {
+		head = this;
+		tail = null;
+		step = Step.NEW_INSTANCE;
+		args = new Object[] {classResolver, referenceResolver, streamFactory};
+	}
+	
+	private KryoBuilder(KryoBuilder prev, Step step, Object... args) {
+		head = prev.head;
+		tail = null;
+		this.step = step;
+		this.args = args;
+		while(prev.tail != null)
+			prev = prev.tail;
+		prev.tail = this;
+	}
+	
+	private KryoBuilder(KryoBuilder head, KryoBuilder tail, Step step, Object[] args) {
+		this.head = head;
+		this.tail = tail;
+		this.step = step;
+		this.args = args;
+	}
+	
+	public Kryo build() {
+		return head.step(null);
+	}
+	
+	public <T extends Kryo> T configure(T kryo) {
+		return (T) head.step(kryo);
+	}
+	
+	protected boolean argtypes(Class<?>... types) {
+		if(args.length != types.length)
+			return false;
+		for(int i = 0; i < args.length; i++)
+			if(!types[i].isInstance(args[i]))
+				return false;
+		return true;
+	}
+	
+	protected Kryo step(Kryo kryo) {
+		switch(step) {
+		case NEW_INSTANCE:
+			if(kryo == null)
+				kryo = new Kryo((ClassResolver) args[0], (ReferenceResolver) args[1], (StreamFactory) args[2]);
+			break;
+		case SET_DEFAULT_SERIALIZER:
+			if(argtypes(SerializerFactory.class))
+				kryo.setDefaultSerializer((SerializerFactory) args[0]);
+			else if(argtypes(Serializer.class))
+				kryo.setDefaultSerializer(((Class<?>) args[0]).asSubclass((Serializer.class)));
+			else
+				throw new IllegalStateException();
+			break;
+		case ADD_DEFAULT_SERIALIZER:
+			if(argtypes(Class.class, Serializer.class))
+				kryo.addDefaultSerializer((Class<?>) args[0], (Serializer) args[1]);
+			else if(argtypes(Class.class, SerializerFactory.class))
+				kryo.addDefaultSerializer((Class<?>) args[0], (SerializerFactory) args[1]);
+			else if(argtypes(Class.class, Class.class))
+				kryo.addDefaultSerializer((Class<?>) args[0], ((Class<?>) args[1]).asSubclass(Serializer.class));
+			else
+				throw new IllegalStateException();
+			break;
+		case REGISTER:
+			if(argtypes(Class.class))
+				kryo.register((Class<?>) args[0]);
+			else if(argtypes(Class.class, Integer.class))
+				kryo.register((Class<?>) args[0], (Integer) args[1]);
+			else if(argtypes(Class.class, Serializer.class))
+				kryo.register((Class<?>) args[0], (Serializer) args[1]);
+			else if(argtypes(Class.class, Serializer.class, Integer.class))
+				kryo.register((Class<?>) args[0], (Serializer) args[1], (Integer) args[2]);
+			else if(argtypes(Registration.class))
+				kryo.register((Registration) args[0]);
+			else
+				throw new IllegalStateException();
+			break;
+		case SET_CLASSLOADER:
+			if(argtypes(ClassLoader.class))
+				kryo.setClassLoader((ClassLoader) args[0]);
+			else
+				throw new IllegalStateException();
+			break;
+		case SET_REGISTRATION_REQUIRED:
+			if(argtypes(Boolean.class))
+				kryo.setRegistrationRequired((Boolean) args[0]);
+			else
+				throw new IllegalStateException();
+			break;
+		case SET_REFERENCES:
+			if(argtypes(Boolean.class))
+				kryo.setReferences((Boolean) args[0]);
+			else
+				throw new IllegalStateException();
+			break;
+		case SET_COPY_REFERENCES:
+			if(argtypes(Boolean.class))
+				kryo.setCopyReferences((Boolean) args[0]);
+			else
+				throw new IllegalStateException();
+			break;
+		case SET_REFERENCE_RESOLVER:
+			if(argtypes(ReferenceResolver.class))
+				kryo.setReferenceResolver((ReferenceResolver) args[0]);
+			else
+				throw new IllegalStateException();
+			break;
+		case SET_INSTANTIATOR_STRATEGY:
+			if(argtypes(InstantiatorStrategy.class))
+				kryo.setInstantiatorStrategy((InstantiatorStrategy) args[0]);
+			else
+				throw new IllegalStateException();
+			break;
+		case SET_AUTO_RESET:
+			if(argtypes(Boolean.class))
+				kryo.setAutoReset((Boolean) args[0]);
+			else
+				throw new IllegalStateException();
+			break;
+		case SET_MAX_DEPTH:
+			if(argtypes(Integer.class))
+				kryo.setMaxDepth((Integer) args[0]);
+			else
+				throw new IllegalStateException();
+			break;
+		case SET_STREAM_FACTORY:
+			if(argtypes(StreamFactory.class))
+				kryo.setStreamFactory((StreamFactory) args[0]);
+			else
+				throw new IllegalStateException();
+			break;
+		case SET_ASM_ENABLED:
+			if(argtypes(Boolean.class))
+				kryo.setAsmEnabled((Boolean) args[0]);
+			else
+				throw new IllegalStateException();
+			break;
+		}
+		return tail != null ? tail.step(kryo) : kryo;
+	}
+
+	public KryoBuilder setDefaultSerializer (SerializerFactory serializer) {
+		return new KryoBuilder(this, Step.SET_DEFAULT_SERIALIZER, serializer);
+	}
+
+	public KryoBuilder setDefaultSerializer (Class<? extends Serializer> serializer) {
+		return new KryoBuilder(this, Step.SET_DEFAULT_SERIALIZER, serializer);
+	}
+
+	public KryoBuilder addDefaultSerializer (Class type, Serializer serializer) {
+		return new KryoBuilder(this, Step.ADD_DEFAULT_SERIALIZER, type, serializer);
+	}
+
+	public KryoBuilder addDefaultSerializer (Class type, SerializerFactory serializerFactory) {
+		return new KryoBuilder(this, Step.ADD_DEFAULT_SERIALIZER, type, serializerFactory);
+	}
+
+	public KryoBuilder addDefaultSerializer (Class type, Class<? extends Serializer> serializerClass) {
+		return new KryoBuilder(this, Step.ADD_DEFAULT_SERIALIZER, type, serializerClass);
+	}
+
+	public KryoBuilder register (Class type) {
+		return new KryoBuilder(this, Step.REGISTER, type);
+	}
+
+	public KryoBuilder register (Class type, int id) {
+		return new KryoBuilder(this, Step.REGISTER, type, id);
+	}
+
+	public KryoBuilder register (Class type, Serializer serializer) {
+		return new KryoBuilder(this, Step.REGISTER, type, serializer);
+	}
+
+	public KryoBuilder register (Class type, Serializer serializer, int id) {
+		return new KryoBuilder(this, Step.REGISTER, type, serializer, id);
+	}
+
+	public KryoBuilder register (Registration registration) {
+		return new KryoBuilder(this, Step.REGISTER, registration);
+	}
+
+	public KryoBuilder setClassLoader (ClassLoader classLoader) {
+		return new KryoBuilder(this, Step.SET_CLASSLOADER, classLoader);
+	}
+
+	public KryoBuilder setRegistrationRequired (boolean registrationRequired) {
+		return new KryoBuilder(this, Step.SET_REGISTRATION_REQUIRED, registrationRequired);
+	}
+
+	public KryoBuilder setReferences (boolean references) {
+		return new KryoBuilder(this, Step.SET_REFERENCES, references);
+	}
+
+	public KryoBuilder setCopyReferences (boolean copyReferences) {
+		return new KryoBuilder(this, Step.SET_COPY_REFERENCES, copyReferences);
+	}
+
+	public KryoBuilder setReferenceResolver (ReferenceResolver referenceResolver) {
+		return new KryoBuilder(this, Step.SET_REFERENCE_RESOLVER, referenceResolver);
+	}
+
+	public KryoBuilder setInstantiatorStrategy (InstantiatorStrategy strategy) {
+		return new KryoBuilder(this, Step.SET_INSTANTIATOR_STRATEGY, strategy);
+	}
+
+	public KryoBuilder setAutoReset (boolean autoReset) {
+		return new KryoBuilder(this, Step.SET_AUTO_RESET, autoReset);
+	}
+
+	public KryoBuilder setMaxDepth (int maxDepth) {
+		return new KryoBuilder(this, Step.SET_MAX_DEPTH, maxDepth);
+	}
+
+	public KryoBuilder setStreamFactory (StreamFactory streamFactory) {
+		return new KryoBuilder(this, Step.SET_STREAM_FACTORY, streamFactory);
+	}
+
+	public KryoBuilder setAsmEnabled (boolean flag) {
+		return new KryoBuilder(this, Step.SET_ASM_ENABLED, flag);
+	}
+}

--- a/src/com/esotericsoftware/kryo/KryoBuilder.java
+++ b/src/com/esotericsoftware/kryo/KryoBuilder.java
@@ -40,7 +40,7 @@ public final class KryoBuilder implements KryoFactory {
 		@SuppressWarnings("synthetic-access")
 		@Override
 		public void write (Kryo kryo, Output output, KryoBuilder object) {
-			kryo.writeObject(output, object.head);
+			output.writeBoolean(object.head == object);
 			output.writeInt(object.step.ordinal(), true);
 			output.writeInt(object.args.length, true);
 			for(int i = 0; i < object.args.length; i++)
@@ -54,12 +54,17 @@ public final class KryoBuilder implements KryoFactory {
 			KryoBuilder object = new KryoBuilder(null, null, null, null);
 			kryo.reference(object);
 			
-			object.head = kryo.readObject(input, KryoBuilder.class);
+			boolean head = input.readBoolean();
 			object.step = Step.VALUES[input.readInt(true)];
 			object.args = new Object[input.readInt(true)];
 			for(int i = 0; i < object.args.length; i++)
 				object.args[i] = kryo.readClassAndObject(input);
 			object.tail = kryo.readObjectOrNull(input, KryoBuilder.class);
+
+			if(head) {
+				for(KryoBuilder h = object; h != null; h = h.tail)
+					h.head = object;
+			}
 			
 			return object;
 		}

--- a/src/com/esotericsoftware/kryo/KryoBuilder.java
+++ b/src/com/esotericsoftware/kryo/KryoBuilder.java
@@ -7,11 +7,12 @@ import org.objenesis.strategy.InstantiatorStrategy;
 import com.esotericsoftware.kryo.factories.SerializerFactory;
 import com.esotericsoftware.kryo.io.Input;
 import com.esotericsoftware.kryo.io.Output;
+import com.esotericsoftware.kryo.pool.KryoFactory;
 import com.esotericsoftware.kryo.util.DefaultClassResolver;
 import com.esotericsoftware.kryo.util.DefaultStreamFactory;
 import com.esotericsoftware.kryo.util.MapReferenceResolver;
 
-public final class KryoBuilder {
+public final class KryoBuilder implements KryoFactory {
 
 	private static enum Step {
 		NEW_INSTANCE,
@@ -135,7 +136,7 @@ public final class KryoBuilder {
 		return hash;
 	}
 	
-	public Kryo build() {
+	public Kryo create() {
 		return head.step(null);
 	}
 	

--- a/src/com/esotericsoftware/kryo/KryoBuilder.java
+++ b/src/com/esotericsoftware/kryo/KryoBuilder.java
@@ -40,7 +40,6 @@ public final class KryoBuilder implements KryoFactory {
 		@SuppressWarnings("synthetic-access")
 		@Override
 		public void write (Kryo kryo, Output output, KryoBuilder object) {
-			output.writeBoolean(object.head == object);
 			output.writeInt(object.step.ordinal(), true);
 			output.writeInt(object.args.length, true);
 			for(int i = 0; i < object.args.length; i++)
@@ -54,14 +53,13 @@ public final class KryoBuilder implements KryoFactory {
 			KryoBuilder object = new KryoBuilder(null, null, null, null);
 			kryo.reference(object);
 			
-			boolean head = input.readBoolean();
 			object.step = Step.VALUES[input.readInt(true)];
 			object.args = new Object[input.readInt(true)];
 			for(int i = 0; i < object.args.length; i++)
 				object.args[i] = kryo.readClassAndObject(input);
 			object.tail = kryo.readObjectOrNull(input, KryoBuilder.class);
 
-			if(head) {
+			if(object.step == Step.NEW_INSTANCE) {
 				for(KryoBuilder h = object; h != null; h = h.tail)
 					h.head = object;
 			}

--- a/src/com/esotericsoftware/kryo/KryoBuilder.java
+++ b/src/com/esotericsoftware/kryo/KryoBuilder.java
@@ -32,11 +32,12 @@ public final class KryoBuilder implements KryoFactory {
 		
 		;
 		
-		static final Step[] VALUES = values();
+		private static final Step[] VALUES = values();
 	}
 	
 	public static final class KryoBuilderSerializer extends Serializer<KryoBuilder> {
 
+		@SuppressWarnings("synthetic-access")
 		@Override
 		public void write (Kryo kryo, Output output, KryoBuilder object) {
 			kryo.writeObject(output, object.head);
@@ -47,6 +48,7 @@ public final class KryoBuilder implements KryoFactory {
 			kryo.writeObjectOrNull(output, object.tail, KryoBuilder.class);
 		}
 
+		@SuppressWarnings("synthetic-access")
 		@Override
 		public KryoBuilder read (Kryo kryo, Input input, Class<KryoBuilder> type) {
 			KryoBuilder object = new KryoBuilder(null, null, null, null);
@@ -64,10 +66,10 @@ public final class KryoBuilder implements KryoFactory {
 		
 	}
 	
-	KryoBuilder head;
-	KryoBuilder tail;
-	Step step;
-	Object[] args;
+	private KryoBuilder head;
+	private KryoBuilder tail;
+	private Step step;
+	private Object[] args;
 
 	public KryoBuilder () {
 		this((ClassResolver) null, (ReferenceResolver) null, (StreamFactory) null);
@@ -88,7 +90,7 @@ public final class KryoBuilder implements KryoFactory {
 		args = new Object[] {classResolver, referenceResolver, streamFactory};
 	}
 	
-	KryoBuilder(KryoBuilder prev, Step step, Object... args) {
+	private KryoBuilder(KryoBuilder prev, Step step, Object... args) {
 		head = prev.head;
 		tail = null;
 		this.step = step;
@@ -98,7 +100,7 @@ public final class KryoBuilder implements KryoFactory {
 		prev.tail = this;
 	}
 	
-	KryoBuilder(KryoBuilder head, KryoBuilder tail, Step step, Object[] args) {
+	private KryoBuilder(KryoBuilder head, KryoBuilder tail, Step step, Object[] args) {
 		this.head = head;
 		this.tail = tail;
 		this.step = step;
@@ -144,7 +146,7 @@ public final class KryoBuilder implements KryoFactory {
 		return (T) head.step(kryo);
 	}
 	
-	boolean argtypes(Class<?>... types) {
+	private boolean argtypes(Class<?>... types) {
 		if(args.length != types.length)
 			return false;
 		for(int i = 0; i < args.length; i++)
@@ -153,7 +155,7 @@ public final class KryoBuilder implements KryoFactory {
 		return true;
 	}
 	
-	Kryo step(Kryo kryo) {
+	private Kryo step(Kryo kryo) {
 		switch(step) {
 		case NEW_INSTANCE:
 			if(kryo == null) {

--- a/src/com/esotericsoftware/kryo/KryoBuilder.java
+++ b/src/com/esotericsoftware/kryo/KryoBuilder.java
@@ -35,7 +35,7 @@ public final class KryoBuilder implements KryoFactory {
 		static final Step[] VALUES = values();
 	}
 	
-	public static class KryoBuilderSerializer extends Serializer<KryoBuilder> {
+	public static final class KryoBuilderSerializer extends Serializer<KryoBuilder> {
 
 		@Override
 		public void write (Kryo kryo, Output output, KryoBuilder object) {

--- a/test/com/esotericsoftware/kryo/KryoBuilderTest.java
+++ b/test/com/esotericsoftware/kryo/KryoBuilderTest.java
@@ -29,12 +29,11 @@ public class KryoBuilderTest extends KryoTestCase {
 		setUp();
 		kryo.register(KryoBuilder.class, new KryoBuilder.KryoBuilderSerializer());
 		kryo.setRegistrationRequired(false);
-		kryo.setReferences(true);
 		
 		KryoBuilder builder = new KryoBuilder();
 		builder.setRegistrationRequired(true);
 		builder.register(int[].class);
 		
-		roundTrip(42, 60, builder);
+		roundTrip(40, 58, builder);
 	}
 }

--- a/test/com/esotericsoftware/kryo/KryoBuilderTest.java
+++ b/test/com/esotericsoftware/kryo/KryoBuilderTest.java
@@ -15,11 +15,11 @@ public class KryoBuilderTest extends KryoTestCase {
 		builder.register(int[].class);
 		
 		Output output = new Output(bytes);
-		builder.build().writeClassAndObject(output, new int[] {1,2,3});
+		builder.create().writeClassAndObject(output, new int[] {1,2,3});
 		output.close();
 		
 		Input input = new Input(bytes.toByteArray());
-		int[] ia = (int[]) builder.build().readClassAndObject(input);
+		int[] ia = (int[]) builder.create().readClassAndObject(input);
 		
 		assertEquals((Object) new int[] {1, 2,3}, (Object) ia);
 	}

--- a/test/com/esotericsoftware/kryo/KryoBuilderTest.java
+++ b/test/com/esotericsoftware/kryo/KryoBuilderTest.java
@@ -1,0 +1,40 @@
+package com.esotericsoftware.kryo;
+
+import java.io.ByteArrayOutputStream;
+
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+
+public class KryoBuilderTest extends KryoTestCase {
+
+	public void testBuilder() {
+		ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+		
+		KryoBuilder builder = new KryoBuilder();
+		builder.setRegistrationRequired(true);
+		builder.register(int[].class);
+		
+		Output output = new Output(bytes);
+		builder.build().writeClassAndObject(output, new int[] {1,2,3});
+		output.close();
+		
+		Input input = new Input(bytes.toByteArray());
+		int[] ia = (int[]) builder.build().readClassAndObject(input);
+		
+		assertEquals((Object) new int[] {1, 2,3}, (Object) ia);
+	}
+	
+	
+	public void testSerializeBuilder() throws Exception {
+		setUp();
+		kryo.register(KryoBuilder.class, new KryoBuilder.KryoBuilderSerializer());
+		kryo.setRegistrationRequired(false);
+		kryo.setReferences(true);
+		
+		KryoBuilder builder = new KryoBuilder();
+		builder.setRegistrationRequired(true);
+		builder.register(int[].class);
+		
+		roundTrip(42, 60, builder);
+	}
+}

--- a/test/com/esotericsoftware/kryo/KryoBuilderTest.java
+++ b/test/com/esotericsoftware/kryo/KryoBuilderTest.java
@@ -34,6 +34,6 @@ public class KryoBuilderTest extends KryoTestCase {
 		builder.setRegistrationRequired(true);
 		builder.register(int[].class);
 		
-		roundTrip(40, 58, builder);
+		roundTrip(37, 55, builder);
 	}
 }


### PR DESCRIPTION
One of the things I frequently find myself wishing for is a way to persist Kryo instances themselves, so that a blob of data can include not only the data but a Kryo used to read that data.  Modifying Kryo.java to be itself serializable in a useful way seems fruitless, but I struck across another idea that works: a serializable "builder" for kryos.  Instead of serializing a fully configured Kryo, we can serialize the steps used to configure a Kryo for use.

This pull request is for KryoBuilder (and the very small KryoBuilderTest) classes.  KryoBuilder implements KryoFactory, and provides KryoBuilder.KryoBuilderSerializer for its own serialization.

The source is not currently commented in any useful way, but I will be more than happy to document and clean it however necessary if this pull request is worth considering.
