### PR TITLE
backport fix for Output reuse in JavaSerializer

### DIFF
--- a/src/com/esotericsoftware/kryo/serializers/JavaSerializer.java
+++ b/src/com/esotericsoftware/kryo/serializers/JavaSerializer.java
@@ -10,6 +10,7 @@ import com.esotericsoftware.kryo.KryoSerializable;
 import com.esotericsoftware.kryo.Serializer;
 import com.esotericsoftware.kryo.io.Input;
 import com.esotericsoftware.kryo.io.Output;
+import com.esotericsoftware.kryo.util.ObjectMap;
 
 /** Serializes objects using Java's built in serialization mechanism. Note that this is very inefficient and should be avoided if
  * possible.
@@ -18,16 +19,14 @@ import com.esotericsoftware.kryo.io.Output;
  * @see KryoSerializable
  * @author Nathan Sweet <misc@n4te.com> */
 public class JavaSerializer extends Serializer {
-	private ObjectOutputStream objectStream;
-	private Output lastOutput;
-
 	public void write (Kryo kryo, Output output, Object object) {
 		try {
-			if (output != lastOutput) {
+			ObjectMap graphContext = kryo.getGraphContext();
+			ObjectOutputStream objectStream = (ObjectOutputStream)graphContext.get(this);
+			if (objectStream == null) {
 				objectStream = new ObjectOutputStream(output);
-				lastOutput = output;
-			} else
-				objectStream.reset();
+				graphContext.put(this, objectStream);
+			}
 			objectStream.writeObject(object);
 			objectStream.flush();
 		} catch (Exception ex) {
@@ -37,7 +36,13 @@ public class JavaSerializer extends Serializer {
 
 	public Object read (Kryo kryo, Input input, Class type) {
 		try {
-			return new ObjectInputStream(input).readObject();
+			ObjectMap graphContext = kryo.getGraphContext();
+			ObjectInputStream objectStream = (ObjectInputStream)graphContext.get(this);
+			if (objectStream == null) {
+				objectStream = new ObjectInputStream(input);
+				graphContext.put(this, objectStream);
+			}
+			return objectStream.readObject();
 		} catch (Exception ex) {
 			throw new KryoException("Error during Java deserialization.", ex);
 		}


### PR DESCRIPTION
This PR backports a change in `JavaSerializer` that fixes a problem with reusing an `Output` for serialization. See https://github.com/EsotericSoftware/kryo/issues/312 for details.