### PR TITLE
Try to load classes with fallback that uses current ClassLoader.

### DIFF
--- a/src/com/esotericsoftware/kryo/util/DefaultClassResolver.java
+++ b/src/com/esotericsoftware/kryo/util/DefaultClassResolver.java
@@ -153,7 +153,12 @@ public class DefaultClassResolver implements ClassResolver {
 				try {
 					type = Class.forName(className, false, kryo.getClassLoader());
 				} catch (ClassNotFoundException ex) {
-					throw new KryoException("Unable to find class: " + className, ex);
+					if (WARN) warn("kryo", "Unable to load class " + className + " with kryo's ClassLoader. Retrying with current..");
+					try {
+						type = Class.forName(className);
+					} catch (ClassNotFoundException e) {
+						throw new KryoException("Unable to find class: " + className, ex);
+					}
 				}
 				if (nameToClass == null) nameToClass = new ObjectMap();
 				nameToClass.put(className, type);


### PR DESCRIPTION
If running in an osgi environment the class loader that started kryo
can differ from the one that contains the class we want to load.
This introduces a fallback when class loading fails that
attempts to load the class with an osgi provided class loader.