### PR TITLE
copyTransient is not global

### DIFF
--- a/src/com/esotericsoftware/kryo/Kryo.java
+++ b/src/com/esotericsoftware/kryo/Kryo.java
@@ -1052,7 +1052,7 @@ public class Kryo {
 	 * being copied. This has to be set before registering classes with kryo for it to be used by all field
 	 * serializers. If transient fields has to be copied for specific classes then use {@link FieldSerializer#setCopyTransient(boolean)}.
 	 * Default is true.
-   */
+	 */
 	public void setCopyTransient(boolean copyTransient) {
 		this.copyTransient = copyTransient;
 	}

--- a/src/com/esotericsoftware/kryo/Kryo.java
+++ b/src/com/esotericsoftware/kryo/Kryo.java
@@ -1048,8 +1048,10 @@ public class Kryo {
 	}
 
 	/**
-	 * If true, when {@link #copy(Object)} is called all transient fields that are accessible will be ignored from
-	 * being copied. Default is true.
+	 * If false, when {@link #copy(Object)} is called all transient fields that are accessible will be ignored from
+	 * being copied. This has to be set before registering classes with kryo for it to be used by all field
+	 * serializers. If transient fields has to be copied for specific classes then use {@link FieldSerializer#setCopyTransient(boolean)}.
+	 * Default is true.
    */
 	public void setCopyTransient(boolean copyTransient) {
 		this.copyTransient = copyTransient;

--- a/src/com/esotericsoftware/kryo/Kryo.java
+++ b/src/com/esotericsoftware/kryo/Kryo.java
@@ -136,6 +136,7 @@ public class Kryo {
 
 	private int copyDepth;
 	private boolean copyShallow;
+	private boolean copyTransient = true;
 	private IdentityMap originalToCopy;
 	private Object needsCopyReference;
 	private GenericsResolver genericsResolver = new GenericsResolver();
@@ -1044,6 +1045,22 @@ public class Kryo {
 	 * object graph is copied that contains a circular reference. Default is true. */
 	public void setCopyReferences (boolean copyReferences) {
 		this.copyReferences = copyReferences;
+	}
+
+	/**
+	 * If true, when {@link #copy(Object)} is called all transient fields that are accessible will be ignored from
+	 * being copied. Default is true.
+   */
+	public void setCopyTransient(boolean copyTransient) {
+		this.copyTransient = copyTransient;
+	}
+
+	/**
+	 * Returns true if copying of transient fields is enabled for {@link #copy(Object)}.
+	 * @return true if transient field copy is enable
+	 */
+	public boolean getCopyTransient() {
+		return copyTransient;
 	}
 
 	/** Sets the reference resolver and enables references. */

--- a/src/com/esotericsoftware/kryo/serializers/FieldSerializer.java
+++ b/src/com/esotericsoftware/kryo/serializers/FieldSerializer.java
@@ -102,6 +102,9 @@ public class FieldSerializer<T> extends Serializer<T> implements Comparator<Fiel
 	 * </p> */
 	private boolean useMemRegions = false;
 
+	/** If set, transient fields will be copied */
+	private boolean copyTransient = true;
+
 	/** If set, transient fields will be serialized */
 	private final boolean serializeTransient = false;
 
@@ -149,6 +152,7 @@ public class FieldSerializer<T> extends Serializer<T> implements Comparator<Fiel
 		this.genericsUtil = new FieldSerializerGenericsUtil(this);
 		this.unsafeUtil = FieldSerializerUnsafeUtil.Factory.getInstance(this);
 		this.annotationsUtil = new FieldSerializerAnnotationsUtil(this);
+		this.copyTransient = kryo.getCopyTransient();
 		rebuildCachedFields();
 	}
 
@@ -486,6 +490,11 @@ public class FieldSerializer<T> extends Serializer<T> implements Comparator<Fiel
 		rebuildCachedFields();
 	}
 
+	// Enable/disable copying of transient fields
+	public void setCopyTransient (boolean setCopyTransient) {
+		copyTransient = setCopyTransient;
+	}
+
 	/** This method can be called for different fields having the same type. Even though the raw type is the same, if the type is
 	 * generic, it could happen that different concrete classes are used to instantiate it. Therefore, in case of different
 	 * instantiation parameters, the fields analysis should be repeated.
@@ -647,6 +656,10 @@ public class FieldSerializer<T> extends Serializer<T> implements Comparator<Fiel
 		return useMemRegions;
 	}
 
+	public boolean getCopyTransient () {
+		return copyTransient;
+	}
+
 	/** Used by {@link #copy(Kryo, Object)} to create the new object. This can be overridden to customize object creation, eg to
 	 * call a constructor with arguments. The default implementation uses {@link Kryo#newInstance(Class)}. */
 	protected T createCopy (Kryo kryo, T original) {
@@ -658,7 +671,7 @@ public class FieldSerializer<T> extends Serializer<T> implements Comparator<Fiel
 		kryo.reference(copy);
 
 		// Copy transient fields
-		if (kryo.getCopyTransient()) {
+		if (copyTransient) {
 			for (int i = 0, n = transientFields.length; i < n; i++)
 				transientFields[i].copy(original, copy);
 		}

--- a/src/com/esotericsoftware/kryo/serializers/FieldSerializer.java
+++ b/src/com/esotericsoftware/kryo/serializers/FieldSerializer.java
@@ -102,9 +102,6 @@ public class FieldSerializer<T> extends Serializer<T> implements Comparator<Fiel
 	 * </p> */
 	private boolean useMemRegions = false;
 
-	/** If set, transient fields will be copied */
-	private boolean copyTransient = true;
-
 	/** If set, transient fields will be serialized */
 	private final boolean serializeTransient = false;
 
@@ -489,11 +486,6 @@ public class FieldSerializer<T> extends Serializer<T> implements Comparator<Fiel
 		rebuildCachedFields();
 	}
 
-	// Enable/disable copying of transient fields
-	public void setCopyTransient (boolean setCopyTransient) {
-		copyTransient = setCopyTransient;
-	}
-
 	/** This method can be called for different fields having the same type. Even though the raw type is the same, if the type is
 	 * generic, it could happen that different concrete classes are used to instantiate it. Therefore, in case of different
 	 * instantiation parameters, the fields analysis should be repeated.
@@ -655,10 +647,6 @@ public class FieldSerializer<T> extends Serializer<T> implements Comparator<Fiel
 		return useMemRegions;
 	}
 
-	public boolean getCopyTransient () {
-		return copyTransient;
-	}
-
 	/** Used by {@link #copy(Kryo, Object)} to create the new object. This can be overridden to customize object creation, eg to
 	 * call a constructor with arguments. The default implementation uses {@link Kryo#newInstance(Class)}. */
 	protected T createCopy (Kryo kryo, T original) {
@@ -670,7 +658,7 @@ public class FieldSerializer<T> extends Serializer<T> implements Comparator<Fiel
 		kryo.reference(copy);
 
 		// Copy transient fields
-		if (copyTransient) {
+		if (kryo.getCopyTransient()) {
 			for (int i = 0, n = transientFields.length; i < n; i++)
 				transientFields[i].copy(original, copy);
 		}

--- a/src/com/esotericsoftware/kryo/serializers/FieldSerializer.java
+++ b/src/com/esotericsoftware/kryo/serializers/FieldSerializer.java
@@ -173,6 +173,7 @@ public class FieldSerializer<T> extends Serializer<T> implements Comparator<Fiel
 		this.genericsUtil = new FieldSerializerGenericsUtil(this);
 		this.unsafeUtil = FieldSerializerUnsafeUtil.Factory.getInstance(this);
 		this.annotationsUtil = new FieldSerializerAnnotationsUtil(this);
+		this.copyTransient = kryo.getCopyTransient();
 		rebuildCachedFields();
 	}
 

--- a/test/com/esotericsoftware/kryo/FieldSerializerTest.java
+++ b/test/com/esotericsoftware/kryo/FieldSerializerTest.java
@@ -26,22 +26,19 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 
 import org.objenesis.strategy.StdInstantiatorStrategy;
 
 import com.esotericsoftware.kryo.io.Input;
 import com.esotericsoftware.kryo.io.Output;
+import com.esotericsoftware.kryo.serializers.CollectionSerializer;
 import com.esotericsoftware.kryo.serializers.CollectionSerializer.BindCollection;
 import com.esotericsoftware.kryo.serializers.DefaultArraySerializers.IntArraySerializer;
 import com.esotericsoftware.kryo.serializers.DefaultArraySerializers.LongArraySerializer;
-import com.esotericsoftware.kryo.serializers.DefaultArraySerializers.ObjectArraySerializer;
 import com.esotericsoftware.kryo.serializers.DefaultSerializers.StringSerializer;
 import com.esotericsoftware.kryo.serializers.FieldSerializer;
 import com.esotericsoftware.kryo.serializers.FieldSerializer.Bind;
 import com.esotericsoftware.kryo.serializers.FieldSerializer.Optional;
-import com.esotericsoftware.kryo.serializers.MapSerializer;
-import com.esotericsoftware.kryo.serializers.CollectionSerializer;
 import com.esotericsoftware.kryo.serializers.MapSerializer.BindMap;
 
 /** @author Nathan Sweet <misc@n4te.com> */
@@ -450,15 +447,13 @@ public class FieldSerializerTest extends KryoTestCase {
 		objectWithTransients1.anotherField2 = 5;
 		objectWithTransients1.anotherField3 = "Field2";
 
-		FieldSerializer<HasTransients> ser = (FieldSerializer<HasTransients>)kryo.getSerializer(HasTransients.class);
-		ser.setCopyTransient(false);
-
+		kryo.setCopyTransient(false);
 		HasTransients objectWithTransients3 = kryo.copy(objectWithTransients1);
 		assertTrue("Objects should be different if copy does not include transient fields",
 			!objectWithTransients3.equals(objectWithTransients1));
 		assertEquals("transient fields should be null", objectWithTransients3.transientField1, null);
 
-		ser.setCopyTransient(true);
+		kryo.setCopyTransient(true);
 		HasTransients objectWithTransients2 = kryo.copy(objectWithTransients1);
 		assertEquals("Objects should be equal if copy includes transient fields", objectWithTransients2, objectWithTransients1);
 	}

--- a/test/com/esotericsoftware/kryo/FieldSerializerTest.java
+++ b/test/com/esotericsoftware/kryo/FieldSerializerTest.java
@@ -26,22 +26,19 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 
 import org.objenesis.strategy.StdInstantiatorStrategy;
 
 import com.esotericsoftware.kryo.io.Input;
 import com.esotericsoftware.kryo.io.Output;
+import com.esotericsoftware.kryo.serializers.CollectionSerializer;
 import com.esotericsoftware.kryo.serializers.CollectionSerializer.BindCollection;
 import com.esotericsoftware.kryo.serializers.DefaultArraySerializers.IntArraySerializer;
 import com.esotericsoftware.kryo.serializers.DefaultArraySerializers.LongArraySerializer;
-import com.esotericsoftware.kryo.serializers.DefaultArraySerializers.ObjectArraySerializer;
 import com.esotericsoftware.kryo.serializers.DefaultSerializers.StringSerializer;
 import com.esotericsoftware.kryo.serializers.FieldSerializer;
 import com.esotericsoftware.kryo.serializers.FieldSerializer.Bind;
 import com.esotericsoftware.kryo.serializers.FieldSerializer.Optional;
-import com.esotericsoftware.kryo.serializers.MapSerializer;
-import com.esotericsoftware.kryo.serializers.CollectionSerializer;
 import com.esotericsoftware.kryo.serializers.MapSerializer.BindMap;
 
 /** @author Nathan Sweet <misc@n4te.com> */
@@ -462,7 +459,26 @@ public class FieldSerializerTest extends KryoTestCase {
 		HasTransients objectWithTransients2 = kryo.copy(objectWithTransients1);
 		assertEquals("Objects should be equal if copy includes transient fields", objectWithTransients2, objectWithTransients1);
 	}
-	
+
+	public void testTransientsUsingGlobalConfig () {
+		kryo.setCopyTransient(false);
+		kryo.register(HasTransients.class);
+		HasTransients objectWithTransients1 = new HasTransients();
+		objectWithTransients1.transientField1 = "Test";
+		objectWithTransients1.anotherField2 = 5;
+		objectWithTransients1.anotherField3 = "Field2";
+
+		FieldSerializer<HasTransients> ser = (FieldSerializer<HasTransients>)kryo.getSerializer(HasTransients.class);
+		HasTransients objectWithTransients3 = kryo.copy(objectWithTransients1);
+		assertTrue("Objects should be different if copy does not include transient fields",
+				!objectWithTransients3.equals(objectWithTransients1));
+		assertEquals("transient fields should be null", objectWithTransients3.transientField1, null);
+
+		ser.setCopyTransient(true);
+		HasTransients objectWithTransients2 = kryo.copy(objectWithTransients1);
+		assertEquals("Objects should be equal if copy includes transient fields", objectWithTransients2, objectWithTransients1);
+	}
+
 	public void testCorrectlyAnnotatedFields () {
 		kryo.register(int[].class);
 		kryo.register(long[].class);

--- a/test/com/esotericsoftware/kryo/FieldSerializerTest.java
+++ b/test/com/esotericsoftware/kryo/FieldSerializerTest.java
@@ -26,19 +26,22 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 
 import org.objenesis.strategy.StdInstantiatorStrategy;
 
 import com.esotericsoftware.kryo.io.Input;
 import com.esotericsoftware.kryo.io.Output;
-import com.esotericsoftware.kryo.serializers.CollectionSerializer;
 import com.esotericsoftware.kryo.serializers.CollectionSerializer.BindCollection;
 import com.esotericsoftware.kryo.serializers.DefaultArraySerializers.IntArraySerializer;
 import com.esotericsoftware.kryo.serializers.DefaultArraySerializers.LongArraySerializer;
+import com.esotericsoftware.kryo.serializers.DefaultArraySerializers.ObjectArraySerializer;
 import com.esotericsoftware.kryo.serializers.DefaultSerializers.StringSerializer;
 import com.esotericsoftware.kryo.serializers.FieldSerializer;
 import com.esotericsoftware.kryo.serializers.FieldSerializer.Bind;
 import com.esotericsoftware.kryo.serializers.FieldSerializer.Optional;
+import com.esotericsoftware.kryo.serializers.MapSerializer;
+import com.esotericsoftware.kryo.serializers.CollectionSerializer;
 import com.esotericsoftware.kryo.serializers.MapSerializer.BindMap;
 
 /** @author Nathan Sweet <misc@n4te.com> */
@@ -447,13 +450,15 @@ public class FieldSerializerTest extends KryoTestCase {
 		objectWithTransients1.anotherField2 = 5;
 		objectWithTransients1.anotherField3 = "Field2";
 
-		kryo.setCopyTransient(false);
+		FieldSerializer<HasTransients> ser = (FieldSerializer<HasTransients>)kryo.getSerializer(HasTransients.class);
+		ser.setCopyTransient(false);
+
 		HasTransients objectWithTransients3 = kryo.copy(objectWithTransients1);
 		assertTrue("Objects should be different if copy does not include transient fields",
 			!objectWithTransients3.equals(objectWithTransients1));
 		assertEquals("transient fields should be null", objectWithTransients3.transientField1, null);
 
-		kryo.setCopyTransient(true);
+		ser.setCopyTransient(true);
 		HasTransients objectWithTransients2 = kryo.copy(objectWithTransients1);
 		assertEquals("Objects should be equal if copy includes transient fields", objectWithTransients2, objectWithTransients1);
 	}


### PR DESCRIPTION
Fix for #370 

There were couple of approaches discussed in mailing list. Making it a config in kryo object seems to be easier. 