### PR TITLE
[BugFix] Reset the serializer generics when returning a previously read object

### DIFF
--- a/src/com/esotericsoftware/kryo/Kryo.java
+++ b/src/com/esotericsoftware/kryo/Kryo.java
@@ -704,7 +704,10 @@ public class Kryo {
 			T object;
 			if (references) {
 				int stackSize = readReferenceOrNull(input, type, false);
-				if (stackSize == REF) return (T)readObject;
+				if (stackSize == REF) {
+					serializer.setGenerics(this, null);
+					return (T)readObject;
+				}
 				object = (T)serializer.read(this, input, type);
 				if (stackSize == readReferenceIds.size) reference(object);
 			} else

--- a/test/com/esotericsoftware/kryo/MapSerializerTest.java
+++ b/test/com/esotericsoftware/kryo/MapSerializerTest.java
@@ -19,9 +19,13 @@
 
 package com.esotericsoftware.kryo;
 
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.TreeMap;
@@ -167,7 +171,32 @@ public class MapSerializerTest extends KryoTestCase {
 		map.put("4", 44);
 		roundTrip(29, 43, map);
 	}
-	
+
+	public void testSerializingMapAfterDeserializingMultipleReferencesToSameMap() throws Exception {
+		Kryo kryo = new Kryo();
+		Output output = new Output(4096);
+
+		kryo.writeClassAndObject(output, new HasMultipleReferenceToSameMap());
+		kryo.readClassAndObject(new Input(new ByteArrayInputStream(output.getBuffer())));
+		output.clear();
+
+		Map<Integer, List<String>> mapOfLists = new HashMap<Integer, List<String>>();
+		mapOfLists.put(1, new ArrayList<String>());
+		kryo.writeClassAndObject(output, mapOfLists);
+
+		@SuppressWarnings("unchecked")
+		Map<Integer, List<String>> deserializedMap =
+				(Map<Integer, List<String>>) kryo.readClassAndObject(new Input(new ByteArrayInputStream(output.getBuffer())));
+		assertEquals(1, deserializedMap.size());
+	}
+
+	@SuppressWarnings("unused")
+	static class HasMultipleReferenceToSameMap {
+		private Map<Integer, String> mapOne = new HashMap<Integer, String>();
+		private Map<Integer, String> mapTwo = this.mapOne;
+	}
+
+
 	static public class HasGenerics {
 		public HashMap<String, Integer[]> map = new HashMap();
 		public HashMap<String, ?> map2 = new HashMap();

--- a/test/com/esotericsoftware/kryo/MapSerializerTest.java
+++ b/test/com/esotericsoftware/kryo/MapSerializerTest.java
@@ -19,212 +19,180 @@
 
 package com.esotericsoftware.kryo;
 
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.TreeMap;
 import java.util.concurrent.ConcurrentHashMap;
+
+import junit.framework.Assert;
+
 import com.esotericsoftware.kryo.io.Input;
 import com.esotericsoftware.kryo.io.Output;
 import com.esotericsoftware.kryo.serializers.MapSerializer;
-import junit.framework.Assert;
 
-/**
- * @author Nathan Sweet <misc@n4te.com>
- */
+/** @author Nathan Sweet <misc@n4te.com> */
 public class MapSerializerTest extends KryoTestCase {
-    {
-        supportsCopy = true;
-    }
+	{
+		supportsCopy = true;
+	}
 
-    public void testMaps() {
-        kryo.register(HashMap.class);
-        kryo.register(LinkedHashMap.class);
-        HashMap map = new HashMap();
-        map.put("123", "456");
-        map.put("789", "abc");
-        roundTrip(18, 21, map);
-        roundTrip(2, 5, new LinkedHashMap());
-        roundTrip(18, 21, new LinkedHashMap(map));
+	public void testMaps () {
+		kryo.register(HashMap.class);
+		kryo.register(LinkedHashMap.class);
+		HashMap map = new HashMap();
+		map.put("123", "456");
+		map.put("789", "abc");
+		roundTrip(18, 21, map);
+		roundTrip(2, 5, new LinkedHashMap());
+		roundTrip(18, 21, new LinkedHashMap(map));
 
-        MapSerializer serializer = new MapSerializer();
-        kryo.register(HashMap.class, serializer);
-        kryo.register(LinkedHashMap.class, serializer);
-        serializer.setKeyClass(String.class, kryo.getSerializer(String.class));
-        serializer.setKeysCanBeNull(false);
-        serializer.setValueClass(String.class, kryo.getSerializer(String.class));
-        roundTrip(14, 17, map);
-        serializer.setValuesCanBeNull(false);
-        roundTrip(14, 17, map);
-    }
+		MapSerializer serializer = new MapSerializer();
+		kryo.register(HashMap.class, serializer);
+		kryo.register(LinkedHashMap.class, serializer);
+		serializer.setKeyClass(String.class, kryo.getSerializer(String.class));
+		serializer.setKeysCanBeNull(false);
+		serializer.setValueClass(String.class, kryo.getSerializer(String.class));
+		roundTrip(14, 17, map);
+		serializer.setValuesCanBeNull(false);
+		roundTrip(14, 17, map);
+	}
 
-    public void testEmptyHashMap() {
-        execute(new HashMap<Object, Object>(), 0);
-    }
+	public void testEmptyHashMap () {
+		execute(new HashMap<Object, Object>(), 0);
+	}
 
-    public void testNotEmptyHashMap() {
-        execute(new HashMap<Object, Object>(), 1000);
-    }
+	public void testNotEmptyHashMap () {
+		execute(new HashMap<Object, Object>(), 1000);
+	}
 
-    public void testEmptyConcurrentHashMap() {
-        execute(new ConcurrentHashMap<Object, Object>(), 0);
-    }
+	public void testEmptyConcurrentHashMap () {
+		execute(new ConcurrentHashMap<Object, Object>(), 0);
+	}
 
-    public void testNotEmptyConcurrentHashMap() {
-        execute(new ConcurrentHashMap<Object, Object>(), 1000);
-    }
+	public void testNotEmptyConcurrentHashMap () {
+		execute(new ConcurrentHashMap<Object, Object>(), 1000);
+	}
 
-    public void testGenerics() {
-        kryo.register(HasGenerics.class);
-        kryo.register(Integer[].class);
-        kryo.register(HashMap.class);
+	public void testGenerics () {
+		kryo.register(HasGenerics.class);
+		kryo.register(Integer[].class);
+		kryo.register(HashMap.class);
 
-        HasGenerics test = new HasGenerics();
-        test.map.put("moo", new Integer[]{1, 2});
+		HasGenerics test = new HasGenerics();
+		test.map.put("moo", new Integer[] {1, 2});
 
-        output = new Output(4096);
-        kryo.writeClassAndObject(output, test);
-        output.flush();
+		output = new Output(4096);
+		kryo.writeClassAndObject(output, test);
+		output.flush();
 
-        input = new Input(output.toBytes());
-        HasGenerics test2 = (HasGenerics) kryo.readClassAndObject(input);
-        assertEquals(test.map.get("moo"), test2.map.get("moo"));
-    }
+		input = new Input(output.toBytes());
+		HasGenerics test2 = (HasGenerics)kryo.readClassAndObject(input);
+		assertEquals(test.map.get("moo"), test2.map.get("moo"));
+	}
 
-    private void execute(Map<Object, Object> map, int inserts) {
-        Random random = new Random();
-        for (int i = 0; i < inserts; i++) {
-            map.put(random.nextLong(), random.nextBoolean());
-        }
+	private void execute (Map<Object, Object> map, int inserts) {
+		Random random = new Random();
+		for (int i = 0; i < inserts; i++)
+			map.put(random.nextLong(), random.nextBoolean());
 
-        Kryo kryo = new Kryo();
-        kryo.register(HashMap.class, new MapSerializer());
-        kryo.register(ConcurrentHashMap.class, new MapSerializer());
+		Kryo kryo = new Kryo();
+		kryo.register(HashMap.class, new MapSerializer());
+		kryo.register(ConcurrentHashMap.class, new MapSerializer());
 
-        Output output = new Output(2048, -1);
-        kryo.writeClassAndObject(output, map);
-        output.close();
+		Output output = new Output(2048, -1);
+		kryo.writeClassAndObject(output, map);
+		output.close();
 
-        Input input = new Input(output.toBytes());
-        Object deserialized = kryo.readClassAndObject(input);
-        input.close();
+		Input input = new Input(output.toBytes());
+		Object deserialized = kryo.readClassAndObject(input);
+		input.close();
 
-        Assert.assertEquals(map, deserialized);
-    }
+		Assert.assertEquals(map, deserialized);
+	}
 
-    public void testTreeMap() {
-        kryo.register(TreeMap.class);
-        TreeMap map = new TreeMap();
-        map.put("123", "456");
-        map.put("789", "abc");
-        roundTrip(19, 22, map);
+	public void testTreeMap () {
+		kryo.register(TreeMap.class);
+		TreeMap map = new TreeMap();
+		map.put("123", "456");
+		map.put("789", "abc");
+		roundTrip(19, 22, map);
 
-        kryo.register(KeyThatIsntComparable.class);
-        kryo.register(KeyComparator.class);
-        map = new TreeMap(new KeyComparator());
-        KeyThatIsntComparable key1 = new KeyThatIsntComparable();
-        KeyThatIsntComparable key2 = new KeyThatIsntComparable();
-        key1.value = "123";
-        map.put(key1, "456");
-        key2.value = "1234";
-        map.put(key2, "4567");
-        roundTrip(21, 24, map);
+		kryo.register(KeyThatIsntComparable.class);
+		kryo.register(KeyComparator.class);
+		map = new TreeMap(new KeyComparator());
+		KeyThatIsntComparable key1 = new KeyThatIsntComparable();
+		KeyThatIsntComparable key2 = new KeyThatIsntComparable();
+		key1.value = "123";
+		map.put(key1, "456");
+		key2.value = "1234";
+		map.put(key2, "4567");
+		roundTrip(21, 24, map);
 
-        kryo.register(TreeMapSubclass.class);
-        map = new TreeMapSubclass<String, Integer>();
-        map.put("1", 47);
-        map.put("2", 34);
-        map.put("3", 65);
-        map.put("4", 44);
-        roundTrip(24, 38, map);
-    }
+		kryo.register(TreeMapSubclass.class);
+		map = new TreeMapSubclass<String, Integer>();
+		map.put("1", 47);
+		map.put("2", 34);
+		map.put("3", 65);
+		map.put("4", 44);
+		roundTrip(24, 38, map);
+	}
 
-    public void testTreeMapWithReferences() {
-        kryo.setReferences(true);
-        kryo.register(TreeMap.class);
-        TreeMap map = new TreeMap();
-        map.put("123", "456");
-        map.put("789", "abc");
-        roundTrip(24, 27, map);
+	public void testTreeMapWithReferences () {
+		kryo.setReferences(true);
+		kryo.register(TreeMap.class);
+		TreeMap map = new TreeMap();
+		map.put("123", "456");
+		map.put("789", "abc");
+		roundTrip(24, 27, map);
 
-        kryo.register(KeyThatIsntComparable.class);
-        kryo.register(KeyComparator.class);
-        map = new TreeMap(new KeyComparator());
-        KeyThatIsntComparable key1 = new KeyThatIsntComparable();
-        KeyThatIsntComparable key2 = new KeyThatIsntComparable();
-        key1.value = "123";
-        map.put(key1, "456");
-        key2.value = "1234";
-        map.put(key2, "4567");
-        roundTrip(29, 32, map);
+		kryo.register(KeyThatIsntComparable.class);
+		kryo.register(KeyComparator.class);
+		map = new TreeMap(new KeyComparator());
+		KeyThatIsntComparable key1 = new KeyThatIsntComparable();
+		KeyThatIsntComparable key2 = new KeyThatIsntComparable();
+		key1.value = "123";
+		map.put(key1, "456");
+		key2.value = "1234";
+		map.put(key2, "4567");
+		roundTrip(29, 32, map);
 
-        kryo.register(TreeMapSubclass.class);
-        map = new TreeMapSubclass<String, Integer>();
-        map.put("1", 47);
-        map.put("2", 34);
-        map.put("3", 65);
-        map.put("4", 44);
-        roundTrip(29, 43, map);
-    }
+		kryo.register(TreeMapSubclass.class);
+		map = new TreeMapSubclass<String, Integer>();
+		map.put("1", 47);
+		map.put("2", 34);
+		map.put("3", 65);
+		map.put("4", 44);
+		roundTrip(29, 43, map);
+	}
+	
+	static public class HasGenerics {
+		public HashMap<String, Integer[]> map = new HashMap();
+		public HashMap<String, ?> map2 = new HashMap();
+	}
 
-    public void testSerializingMapAfterDeserializingMultipleReferencesToSameMap() throws IOException {
-        Kryo kryo = new Kryo();
-        Output output = new Output(4096);
+	static public class KeyComparator implements Comparator<KeyThatIsntComparable> {
+		public int compare (KeyThatIsntComparable o1, KeyThatIsntComparable o2) {
+			return o1.value.compareTo(o2.value);
+		}
+	}
 
-        kryo.writeClassAndObject(output, new HasMultipleReferenceToSameMap());
-        kryo.readClassAndObject(new Input(new ByteArrayInputStream(output.getBuffer())));
-        output.clear();
+	static public class KeyThatIsntComparable {
+		public String value;
+		public KeyThatIsntComparable () {
+		}
+		public KeyThatIsntComparable (String value) {
+			this.value = value;
+		}
+	}
 
-        Map<Integer, List<String>> mapOfLists = new HashMap<Integer, List<String>>();
-        mapOfLists.put(1, new ArrayList<String>());
-        kryo.writeClassAndObject(output, mapOfLists);
-
-        @SuppressWarnings("unchecked")
-        Map<Integer, List<String>> deserializedMap =
-            (Map<Integer, List<String>>) kryo.readClassAndObject(new Input(new ByteArrayInputStream(output.getBuffer())));
-        assertEquals(1, deserializedMap.size());
-    }
-
-    @SuppressWarnings("unused")
-    static class HasMultipleReferenceToSameMap {
-        private Map<Integer, String> mapOne = new HashMap<Integer, String>();
-        private Map<Integer, String> mapTwo = this.mapOne;
-    }
-
-    static public class HasGenerics {
-        public HashMap<String, Integer[]> map = new HashMap();
-        public HashMap<String, ?> map2 = new HashMap();
-    }
-
-    static public class KeyComparator implements Comparator<KeyThatIsntComparable> {
-        public int compare(KeyThatIsntComparable o1, KeyThatIsntComparable o2) {
-            return o1.value.compareTo(o2.value);
-        }
-    }
-
-    static public class KeyThatIsntComparable {
-        public String value;
-
-        public KeyThatIsntComparable() {
-        }
-
-        public KeyThatIsntComparable(String value) {
-            this.value = value;
-        }
-    }
-
-    static public class TreeMapSubclass<K, V> extends TreeMap<K, V> {
-        public TreeMapSubclass() {
-        }
-
-        public TreeMapSubclass(Comparator<? super K> comparator) {
-            super(comparator);
-        }
-    }
+	static public class TreeMapSubclass<K,V> extends TreeMap<K,V> {
+		public TreeMapSubclass() {
+		}
+		public TreeMapSubclass(Comparator<? super K> comparator) {
+			super(comparator);
+		}
+	}
 }

--- a/test/com/esotericsoftware/kryo/MapSerializerTest.java
+++ b/test/com/esotericsoftware/kryo/MapSerializerTest.java
@@ -19,180 +19,212 @@
 
 package com.esotericsoftware.kryo;
 
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.TreeMap;
 import java.util.concurrent.ConcurrentHashMap;
-
-import junit.framework.Assert;
-
 import com.esotericsoftware.kryo.io.Input;
 import com.esotericsoftware.kryo.io.Output;
 import com.esotericsoftware.kryo.serializers.MapSerializer;
+import junit.framework.Assert;
 
-/** @author Nathan Sweet <misc@n4te.com> */
+/**
+ * @author Nathan Sweet <misc@n4te.com>
+ */
 public class MapSerializerTest extends KryoTestCase {
-	{
-		supportsCopy = true;
-	}
+    {
+        supportsCopy = true;
+    }
 
-	public void testMaps () {
-		kryo.register(HashMap.class);
-		kryo.register(LinkedHashMap.class);
-		HashMap map = new HashMap();
-		map.put("123", "456");
-		map.put("789", "abc");
-		roundTrip(18, 21, map);
-		roundTrip(2, 5, new LinkedHashMap());
-		roundTrip(18, 21, new LinkedHashMap(map));
+    public void testMaps() {
+        kryo.register(HashMap.class);
+        kryo.register(LinkedHashMap.class);
+        HashMap map = new HashMap();
+        map.put("123", "456");
+        map.put("789", "abc");
+        roundTrip(18, 21, map);
+        roundTrip(2, 5, new LinkedHashMap());
+        roundTrip(18, 21, new LinkedHashMap(map));
 
-		MapSerializer serializer = new MapSerializer();
-		kryo.register(HashMap.class, serializer);
-		kryo.register(LinkedHashMap.class, serializer);
-		serializer.setKeyClass(String.class, kryo.getSerializer(String.class));
-		serializer.setKeysCanBeNull(false);
-		serializer.setValueClass(String.class, kryo.getSerializer(String.class));
-		roundTrip(14, 17, map);
-		serializer.setValuesCanBeNull(false);
-		roundTrip(14, 17, map);
-	}
+        MapSerializer serializer = new MapSerializer();
+        kryo.register(HashMap.class, serializer);
+        kryo.register(LinkedHashMap.class, serializer);
+        serializer.setKeyClass(String.class, kryo.getSerializer(String.class));
+        serializer.setKeysCanBeNull(false);
+        serializer.setValueClass(String.class, kryo.getSerializer(String.class));
+        roundTrip(14, 17, map);
+        serializer.setValuesCanBeNull(false);
+        roundTrip(14, 17, map);
+    }
 
-	public void testEmptyHashMap () {
-		execute(new HashMap<Object, Object>(), 0);
-	}
+    public void testEmptyHashMap() {
+        execute(new HashMap<Object, Object>(), 0);
+    }
 
-	public void testNotEmptyHashMap () {
-		execute(new HashMap<Object, Object>(), 1000);
-	}
+    public void testNotEmptyHashMap() {
+        execute(new HashMap<Object, Object>(), 1000);
+    }
 
-	public void testEmptyConcurrentHashMap () {
-		execute(new ConcurrentHashMap<Object, Object>(), 0);
-	}
+    public void testEmptyConcurrentHashMap() {
+        execute(new ConcurrentHashMap<Object, Object>(), 0);
+    }
 
-	public void testNotEmptyConcurrentHashMap () {
-		execute(new ConcurrentHashMap<Object, Object>(), 1000);
-	}
+    public void testNotEmptyConcurrentHashMap() {
+        execute(new ConcurrentHashMap<Object, Object>(), 1000);
+    }
 
-	public void testGenerics () {
-		kryo.register(HasGenerics.class);
-		kryo.register(Integer[].class);
-		kryo.register(HashMap.class);
+    public void testGenerics() {
+        kryo.register(HasGenerics.class);
+        kryo.register(Integer[].class);
+        kryo.register(HashMap.class);
 
-		HasGenerics test = new HasGenerics();
-		test.map.put("moo", new Integer[] {1, 2});
+        HasGenerics test = new HasGenerics();
+        test.map.put("moo", new Integer[]{1, 2});
 
-		output = new Output(4096);
-		kryo.writeClassAndObject(output, test);
-		output.flush();
+        output = new Output(4096);
+        kryo.writeClassAndObject(output, test);
+        output.flush();
 
-		input = new Input(output.toBytes());
-		HasGenerics test2 = (HasGenerics)kryo.readClassAndObject(input);
-		assertEquals(test.map.get("moo"), test2.map.get("moo"));
-	}
+        input = new Input(output.toBytes());
+        HasGenerics test2 = (HasGenerics) kryo.readClassAndObject(input);
+        assertEquals(test.map.get("moo"), test2.map.get("moo"));
+    }
 
-	private void execute (Map<Object, Object> map, int inserts) {
-		Random random = new Random();
-		for (int i = 0; i < inserts; i++)
-			map.put(random.nextLong(), random.nextBoolean());
+    private void execute(Map<Object, Object> map, int inserts) {
+        Random random = new Random();
+        for (int i = 0; i < inserts; i++) {
+            map.put(random.nextLong(), random.nextBoolean());
+        }
 
-		Kryo kryo = new Kryo();
-		kryo.register(HashMap.class, new MapSerializer());
-		kryo.register(ConcurrentHashMap.class, new MapSerializer());
+        Kryo kryo = new Kryo();
+        kryo.register(HashMap.class, new MapSerializer());
+        kryo.register(ConcurrentHashMap.class, new MapSerializer());
 
-		Output output = new Output(2048, -1);
-		kryo.writeClassAndObject(output, map);
-		output.close();
+        Output output = new Output(2048, -1);
+        kryo.writeClassAndObject(output, map);
+        output.close();
 
-		Input input = new Input(output.toBytes());
-		Object deserialized = kryo.readClassAndObject(input);
-		input.close();
+        Input input = new Input(output.toBytes());
+        Object deserialized = kryo.readClassAndObject(input);
+        input.close();
 
-		Assert.assertEquals(map, deserialized);
-	}
+        Assert.assertEquals(map, deserialized);
+    }
 
-	public void testTreeMap () {
-		kryo.register(TreeMap.class);
-		TreeMap map = new TreeMap();
-		map.put("123", "456");
-		map.put("789", "abc");
-		roundTrip(19, 22, map);
+    public void testTreeMap() {
+        kryo.register(TreeMap.class);
+        TreeMap map = new TreeMap();
+        map.put("123", "456");
+        map.put("789", "abc");
+        roundTrip(19, 22, map);
 
-		kryo.register(KeyThatIsntComparable.class);
-		kryo.register(KeyComparator.class);
-		map = new TreeMap(new KeyComparator());
-		KeyThatIsntComparable key1 = new KeyThatIsntComparable();
-		KeyThatIsntComparable key2 = new KeyThatIsntComparable();
-		key1.value = "123";
-		map.put(key1, "456");
-		key2.value = "1234";
-		map.put(key2, "4567");
-		roundTrip(21, 24, map);
+        kryo.register(KeyThatIsntComparable.class);
+        kryo.register(KeyComparator.class);
+        map = new TreeMap(new KeyComparator());
+        KeyThatIsntComparable key1 = new KeyThatIsntComparable();
+        KeyThatIsntComparable key2 = new KeyThatIsntComparable();
+        key1.value = "123";
+        map.put(key1, "456");
+        key2.value = "1234";
+        map.put(key2, "4567");
+        roundTrip(21, 24, map);
 
-		kryo.register(TreeMapSubclass.class);
-		map = new TreeMapSubclass<String, Integer>();
-		map.put("1", 47);
-		map.put("2", 34);
-		map.put("3", 65);
-		map.put("4", 44);
-		roundTrip(24, 38, map);
-	}
+        kryo.register(TreeMapSubclass.class);
+        map = new TreeMapSubclass<String, Integer>();
+        map.put("1", 47);
+        map.put("2", 34);
+        map.put("3", 65);
+        map.put("4", 44);
+        roundTrip(24, 38, map);
+    }
 
-	public void testTreeMapWithReferences () {
-		kryo.setReferences(true);
-		kryo.register(TreeMap.class);
-		TreeMap map = new TreeMap();
-		map.put("123", "456");
-		map.put("789", "abc");
-		roundTrip(24, 27, map);
+    public void testTreeMapWithReferences() {
+        kryo.setReferences(true);
+        kryo.register(TreeMap.class);
+        TreeMap map = new TreeMap();
+        map.put("123", "456");
+        map.put("789", "abc");
+        roundTrip(24, 27, map);
 
-		kryo.register(KeyThatIsntComparable.class);
-		kryo.register(KeyComparator.class);
-		map = new TreeMap(new KeyComparator());
-		KeyThatIsntComparable key1 = new KeyThatIsntComparable();
-		KeyThatIsntComparable key2 = new KeyThatIsntComparable();
-		key1.value = "123";
-		map.put(key1, "456");
-		key2.value = "1234";
-		map.put(key2, "4567");
-		roundTrip(29, 32, map);
+        kryo.register(KeyThatIsntComparable.class);
+        kryo.register(KeyComparator.class);
+        map = new TreeMap(new KeyComparator());
+        KeyThatIsntComparable key1 = new KeyThatIsntComparable();
+        KeyThatIsntComparable key2 = new KeyThatIsntComparable();
+        key1.value = "123";
+        map.put(key1, "456");
+        key2.value = "1234";
+        map.put(key2, "4567");
+        roundTrip(29, 32, map);
 
-		kryo.register(TreeMapSubclass.class);
-		map = new TreeMapSubclass<String, Integer>();
-		map.put("1", 47);
-		map.put("2", 34);
-		map.put("3", 65);
-		map.put("4", 44);
-		roundTrip(29, 43, map);
-	}
-	
-	static public class HasGenerics {
-		public HashMap<String, Integer[]> map = new HashMap();
-		public HashMap<String, ?> map2 = new HashMap();
-	}
+        kryo.register(TreeMapSubclass.class);
+        map = new TreeMapSubclass<String, Integer>();
+        map.put("1", 47);
+        map.put("2", 34);
+        map.put("3", 65);
+        map.put("4", 44);
+        roundTrip(29, 43, map);
+    }
 
-	static public class KeyComparator implements Comparator<KeyThatIsntComparable> {
-		public int compare (KeyThatIsntComparable o1, KeyThatIsntComparable o2) {
-			return o1.value.compareTo(o2.value);
-		}
-	}
+    public void testSerializingMapAfterDeserializingMultipleReferencesToSameMap() throws IOException {
+        Kryo kryo = new Kryo();
+        Output output = new Output(4096);
 
-	static public class KeyThatIsntComparable {
-		public String value;
-		public KeyThatIsntComparable () {
-		}
-		public KeyThatIsntComparable (String value) {
-			this.value = value;
-		}
-	}
+        kryo.writeClassAndObject(output, new HasMultipleReferenceToSameMap());
+        kryo.readClassAndObject(new Input(new ByteArrayInputStream(output.getBuffer())));
+        output.clear();
 
-	static public class TreeMapSubclass<K,V> extends TreeMap<K,V> {
-		public TreeMapSubclass() {
-		}
-		public TreeMapSubclass(Comparator<? super K> comparator) {
-			super(comparator);
-		}
-	}
+        Map<Integer, List<String>> mapOfLists = new HashMap<Integer, List<String>>();
+        mapOfLists.put(1, new ArrayList<String>());
+        kryo.writeClassAndObject(output, mapOfLists);
+
+        @SuppressWarnings("unchecked")
+        Map<Integer, List<String>> deserializedMap =
+            (Map<Integer, List<String>>) kryo.readClassAndObject(new Input(new ByteArrayInputStream(output.getBuffer())));
+        assertEquals(1, deserializedMap.size());
+    }
+
+    @SuppressWarnings("unused")
+    static class HasMultipleReferenceToSameMap {
+        private Map<Integer, String> mapOne = new HashMap<Integer, String>();
+        private Map<Integer, String> mapTwo = this.mapOne;
+    }
+
+    static public class HasGenerics {
+        public HashMap<String, Integer[]> map = new HashMap();
+        public HashMap<String, ?> map2 = new HashMap();
+    }
+
+    static public class KeyComparator implements Comparator<KeyThatIsntComparable> {
+        public int compare(KeyThatIsntComparable o1, KeyThatIsntComparable o2) {
+            return o1.value.compareTo(o2.value);
+        }
+    }
+
+    static public class KeyThatIsntComparable {
+        public String value;
+
+        public KeyThatIsntComparable() {
+        }
+
+        public KeyThatIsntComparable(String value) {
+            this.value = value;
+        }
+    }
+
+    static public class TreeMapSubclass<K, V> extends TreeMap<K, V> {
+        public TreeMapSubclass() {
+        }
+
+        public TreeMapSubclass(Comparator<? super K> comparator) {
+            super(comparator);
+        }
+    }
 }


### PR DESCRIPTION
This pull request fixes the bug described in issue: https://github.com/EsotericSoftware/kryo/issues/384
