### PR TITLE
Resolve #389  ByteBufferOutput writeVar*() changes endianness underlying nioBuffer + minor fixes

### DIFF
--- a/src/com/esotericsoftware/kryo/io/ByteBufferInput.java
+++ b/src/com/esotericsoftware/kryo/io/ByteBufferInput.java
@@ -109,6 +109,7 @@ public class ByteBufferInput extends Input {
 		position = buffer.position();
 		limit = buffer.limit();
 		capacity = buffer.capacity();
+		byteOrder = buffer.order();
 		total = 0;
 		inputStream = null;
 	}
@@ -293,6 +294,23 @@ public class ByteBufferInput extends Input {
 			if (position == limit) break;
 		}
 		return startingCount - count;
+	}
+
+	public void setPosition (int position) {
+		this.position = position;
+		this.niobuffer.position(position);
+	}
+
+
+	/** Sets the limit in the buffer. */
+	public void setLimit (int limit) {
+		this.limit = limit;
+		this.niobuffer.limit(limit);
+	}
+
+	public void skip(int count) throws KryoException {
+		super.skip(count);
+		niobuffer.position(this.position());
 	}
 
 	/** Discards the specified number of bytes. */

--- a/src/com/esotericsoftware/kryo/io/ByteBufferOutput.java
+++ b/src/com/esotericsoftware/kryo/io/ByteBufferOutput.java
@@ -134,6 +134,7 @@ public class ByteBufferOutput extends Output {
 
 	public void order (ByteOrder byteOrder) {
 		this.byteOrder = byteOrder;
+		this.niobuffer.order(byteOrder);
 	}
 
 	public OutputStream getOutputStream () {
@@ -186,6 +187,7 @@ public class ByteBufferOutput extends Output {
 	/** Sets the current position in the buffer. */
 	public void setPosition (int position) {
 		this.position = position;
+		this.niobuffer.position(position);
 	}
 
 	/** Sets the position and total to zero. */
@@ -198,12 +200,16 @@ public class ByteBufferOutput extends Output {
 	/** @return true if the buffer has been resized. */
 	protected boolean require (int required) throws KryoException {
 		if (capacity - position >= required) return false;
-		if (required > maxCapacity)
+		if (required > maxCapacity) {
+			niobuffer.order(byteOrder);
 			throw new KryoException("Buffer overflow. Max capacity: " + maxCapacity + ", required: " + required);
+		}
 		flush();
 		while (capacity - position < required) {
-			if (capacity == maxCapacity)
+			if (capacity == maxCapacity) {
+				niobuffer.order(byteOrder);
 				throw new KryoException("Buffer overflow. Available: " + (capacity - position) + ", required: " + required);
+			}
 			// Grow buffer.
 			if (capacity == 0) capacity = 1;
 			capacity = Math.min(capacity * 2, maxCapacity);

--- a/test/com/esotericsoftware/kryo/ByteBufferInputOutputTest.java
+++ b/test/com/esotericsoftware/kryo/ByteBufferInputOutputTest.java
@@ -1,0 +1,106 @@
+package com.esotericsoftware.kryo;
+
+import com.esotericsoftware.kryo.io.ByteBufferInput;
+import com.esotericsoftware.kryo.io.ByteBufferOutput;
+import org.junit.Test;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+public class ByteBufferInputOutputTest extends KryoTestCase {
+
+    public void testByteBufferInputPosition() {
+        ByteBuffer byteBuffer = ByteBuffer.allocateDirect(4096);
+        ByteBufferInput inputBuffer = new ByteBufferInput(byteBuffer);
+        assertEquals(0, inputBuffer.position());
+        assertEquals(0, inputBuffer.getByteBuffer().position());
+        inputBuffer.setPosition(5);
+        assertEquals(5, inputBuffer.position());
+        assertEquals(5, inputBuffer.getByteBuffer().position());
+    }
+
+    public void testByteBufferInputLimit() {
+        ByteBuffer byteBuffer = ByteBuffer.allocateDirect(4096);
+        ByteBufferInput inputBuffer = new ByteBufferInput(byteBuffer);
+        assertEquals(4096, inputBuffer.limit());
+        assertEquals(4096, inputBuffer.getByteBuffer().limit());
+        inputBuffer.setLimit(1000);
+        assertEquals(1000, inputBuffer.limit());
+        assertEquals(1000, inputBuffer.getByteBuffer().limit());
+    }
+
+    public void testByteBufferInputSetBufferEndianness() {
+        ByteBufferInput inputBuffer = new ByteBufferInput();
+        assertEquals(ByteOrder.BIG_ENDIAN, inputBuffer.order());
+
+        ByteBuffer byteBuffer = ByteBuffer.allocateDirect(4096);
+        assertEquals(ByteOrder.BIG_ENDIAN, byteBuffer.order());
+        byteBuffer.order(ByteOrder.LITTLE_ENDIAN);
+        assertEquals(ByteOrder.LITTLE_ENDIAN, byteBuffer.order());
+
+        inputBuffer.setBuffer(byteBuffer);
+        assertEquals(byteBuffer.order(), inputBuffer.order());
+    }
+
+    public void testByteBufferInputSkip() {
+        ByteBuffer buffer = ByteBuffer.allocateDirect(4096);
+        ByteBufferInput inputBuffer = new ByteBufferInput(buffer);
+        assertEquals(0, inputBuffer.getByteBuffer().position());
+        inputBuffer.skip(5);
+        assertEquals(5, inputBuffer.getByteBuffer().position());
+    }
+
+    public void testByteBufferOutputPosition() {
+        ByteBufferOutput outputBuffer = new ByteBufferOutput(4096);
+        assertEquals(0, outputBuffer.position());
+        assertEquals(0, outputBuffer.getByteBuffer().position());
+        outputBuffer.setPosition(5);
+        assertEquals(5, outputBuffer.position());
+        outputBuffer.writeInt(10);
+
+        ByteBuffer byteBuffer = outputBuffer.getByteBuffer().duplicate();
+        byteBuffer.flip();
+
+        ByteBufferInput inputBuffer = new ByteBufferInput(byteBuffer);
+        inputBuffer.skip(5);
+        assertEquals(5, byteBuffer.position());
+        assertEquals(10, inputBuffer.readInt());
+        assertEquals(9, byteBuffer.position());
+    }
+
+    public void testByteBufferOutputResetEndiannessAfterException() {
+        ByteBufferOutput outputBuffer = new ByteBufferOutput(10, 10);
+        boolean exceptionTriggered = false;
+        try {
+            for (int i = 0; i < 10; i++) {
+                outputBuffer.writeVarInt(1234, true);
+            }
+        } catch (KryoException exception) {
+            exceptionTriggered = true;
+            assertEquals(outputBuffer.order(), outputBuffer.getByteBuffer().order());
+        }
+
+        assertTrue(exceptionTriggered);
+
+        exceptionTriggered = false;
+        try {
+            for (int i = 0; i < 10; i++) {
+                outputBuffer.writeVarLong(1234L, true);
+            }
+        } catch (KryoException exception) {
+            assertEquals(outputBuffer.order(), outputBuffer.getByteBuffer().order());
+            exceptionTriggered = true;
+        }
+        assertTrue(exceptionTriggered);
+    }
+
+    public void testByteBufferOutputSetOrder() {
+        ByteBufferOutput outputBuffer = new ByteBufferOutput(4096);
+        assertEquals(ByteOrder.BIG_ENDIAN, outputBuffer.order());
+        assertEquals(ByteOrder.BIG_ENDIAN, outputBuffer.getByteBuffer().order());
+
+        outputBuffer.order(ByteOrder.LITTLE_ENDIAN);
+        assertEquals(ByteOrder.LITTLE_ENDIAN, outputBuffer.order());
+        assertEquals(ByteOrder.LITTLE_ENDIAN, outputBuffer.getByteBuffer().order());
+    }
+}


### PR DESCRIPTION
Tests: 
Each of the bottom cases 

Fixes: 
- ByteBufferInput
setBuffer did not take the byteOrder from ByteBuffer
setPosition did not set the position in ByteBuffer
skip did not skip bytes in ByteBuffer
setLimit did not set limit in ByteBuffer

- ByteBufferOutput
during writeVar*() a KryoException caused by require(int) did not reverse the byteOrder
order did not set order in ByteBuffer
setPosition did not set position in ByteBuffer

@romix 
Please take a look when you have time :)