### PR TITLE
Move Generics(Resolver) to serializers, reduce visibility, go back to 3.1.0-SNAPSHOT

### DIFF
--- a/pom-main.xml
+++ b/pom-main.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>com.esotericsoftware</groupId>
 		<artifactId>kryo-parent</artifactId>
-		<version>4.0.0-SNAPSHOT</version>
+		<version>3.1.0-SNAPSHOT</version>
 		<relativePath>./pom.xml</relativePath>
 	</parent>
 	<artifactId>kryo</artifactId>
@@ -77,11 +77,33 @@
 				</executions>
 				<!-- See http://mojo.codehaus.org/clirr-maven-plugin/check-mojo.html -->
 				<configuration>
-					<skip>true</skip>
+					<skip>false</skip>
 					<logResults>true</logResults>
 					<minSeverity>warning</minSeverity>
 					<!-- Configure ignored differences: http://mojo.codehaus.org/clirr-maven-plugin/examples/ignored-differences.html -->
 					<ignored>
+						<!-- Internal APIs -->
+						<difference>
+							<className>com/esotericsoftware/kryo/Kryo</className>
+							<method>*GenericsScope*</method>
+							<differenceType>7002</differenceType>
+						</difference>
+						<difference>
+							<className>com/esotericsoftware/kryo/serializers/FieldSerializer</className>
+							<method>*getGenericsScope*</method>
+							<differenceType>7006</differenceType>
+							<to>*</to>
+						</difference>
+						<difference>
+							<className>com/esotericsoftware/kryo/serializers/FieldSerializer</className>
+							<method>*getGenericsScope*</method>
+							<differenceType>7009</differenceType>
+							<to>*</to>
+						</difference>
+						<difference>
+							<className>com/esotericsoftware/kryo/Generics</className>
+							<differenceType>8001</differenceType>
+						</difference>
 						<!-- reflectasm classes are reported to be removed (as they're added by shade/bundle plugin during packaging) -->
 						<difference>
 							<className>com/esotericsoftware/reflectasm/**</className>

--- a/pom-shaded.xml
+++ b/pom-shaded.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>com.esotericsoftware</groupId>
 		<artifactId>kryo-parent</artifactId>
-		<version>4.0.0-SNAPSHOT</version>
+		<version>3.1.0-SNAPSHOT</version>
 		<relativePath>./pom.xml</relativePath>
 	</parent>
 	<artifactId>kryo-shaded</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 	</parent>
 	<groupId>com.esotericsoftware</groupId>
 	<artifactId>kryo-parent</artifactId>
-	<version>4.0.0-SNAPSHOT</version>
+	<version>3.1.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<name>Kryo Parent</name>
 	<description>Fast, efficient Java serialization. This is the parent pom that assembles the main kryo and shaded kryo artifacts.</description>

--- a/src/com/esotericsoftware/kryo/Kryo.java
+++ b/src/com/esotericsoftware/kryo/Kryo.java
@@ -43,6 +43,7 @@ import java.util.TreeMap;
 import java.util.TreeSet;
 
 import com.esotericsoftware.kryo.serializers.OptionalSerializers;
+import com.esotericsoftware.kryo.serializers.GenericsResolver;
 import org.objenesis.instantiator.ObjectInstantiator;
 import org.objenesis.strategy.InstantiatorStrategy;
 import org.objenesis.strategy.SerializingInstantiatorStrategy;
@@ -1178,15 +1179,6 @@ public class Kryo {
 			this.type = type;
 			this.serializerFactory = serializerFactory;
 		}
-	}
-
-	public void pushGenericsScope (Class type, Generics generics) {
-		if (TRACE) trace("kryo", "Settting a new generics scope for class " + type.getName() + ": " + generics);
-		genericsResolver.pushScope(generics);
-	}
-
-	public void popGenericsScope () {
-		genericsResolver.popScope();
 	}
 
 	public GenericsResolver getGenericsResolver () {

--- a/src/com/esotericsoftware/kryo/serializers/DefaultArraySerializers.java
+++ b/src/com/esotericsoftware/kryo/serializers/DefaultArraySerializers.java
@@ -20,12 +20,8 @@
 package com.esotericsoftware.kryo.serializers;
 
 import java.lang.reflect.Array;
-import java.lang.reflect.GenericArrayType;
 import java.lang.reflect.Modifier;
-import java.lang.reflect.TypeVariable;
-import java.util.Arrays;
 
-import com.esotericsoftware.kryo.Generics;
 import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.Registration;
 import com.esotericsoftware.kryo.Serializer;

--- a/src/com/esotericsoftware/kryo/serializers/FieldSerializer.java
+++ b/src/com/esotericsoftware/kryo/serializers/FieldSerializer.java
@@ -38,7 +38,6 @@ import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 
-import com.esotericsoftware.kryo.Generics;
 import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.NotNull;
 import com.esotericsoftware.kryo.Serializer;
@@ -203,7 +202,7 @@ public class FieldSerializer<T> extends Serializer<T> implements Comparator<Fiel
 		genericsScope = genScope;
 
 		// Push proper scopes at serializer construction time
-		if (genericsScope != null) kryo.pushGenericsScope(type, genericsScope);
+		if (genericsScope != null) kryo.getGenericsResolver().pushScope(type, genericsScope);
 
 		List<Field> validFields;
 		List<Field> validTransientFields;
@@ -272,7 +271,7 @@ public class FieldSerializer<T> extends Serializer<T> implements Comparator<Fiel
 
 		initializeCachedFields();
 
-		if (genericsScope != null) kryo.popGenericsScope();
+		if (genericsScope != null) kryo.getGenericsResolver().popScope();
 
 		if (!minorRebuild) {
 			for (CachedField field : removedFields)
@@ -512,7 +511,7 @@ public class FieldSerializer<T> extends Serializer<T> implements Comparator<Fiel
 
 		if (genericsScope != null) {
 			// Push proper scopes at serializer usage time
-			kryo.pushGenericsScope(type, genericsScope);
+			kryo.getGenericsResolver().pushScope(type, genericsScope);
 		}
 
 		CachedField[] fields = this.fields;
@@ -527,7 +526,7 @@ public class FieldSerializer<T> extends Serializer<T> implements Comparator<Fiel
 
 		if (genericsScope != null) {
 			// Pop the scope for generics
-			kryo.popGenericsScope();
+			kryo.getGenericsResolver().popScope();
 		}
 	}
 
@@ -542,7 +541,7 @@ public class FieldSerializer<T> extends Serializer<T> implements Comparator<Fiel
 
 			if (genericsScope != null) {
 				// Push a new scope for generics
-				kryo.pushGenericsScope(type, genericsScope);
+				kryo.getGenericsResolver().pushScope(type, genericsScope);
 			}
 
 			T object = create(kryo, input, type);
@@ -561,7 +560,7 @@ public class FieldSerializer<T> extends Serializer<T> implements Comparator<Fiel
 		} finally {
 			if (genericsScope != null && kryo.getGenericsResolver() != null) {
 				// Pop the scope for generics
-				kryo.popGenericsScope();
+				kryo.getGenericsResolver().popScope();
 			}
 		}
 	}
@@ -683,7 +682,7 @@ public class FieldSerializer<T> extends Serializer<T> implements Comparator<Fiel
 		return copy;
 	}
 
-	public final Generics getGenericsScope () {
+	final Generics getGenericsScope () {
 		return genericsScope;
 	}
 

--- a/src/com/esotericsoftware/kryo/serializers/FieldSerializerAnnotationsUtil.java
+++ b/src/com/esotericsoftware/kryo/serializers/FieldSerializerAnnotationsUtil.java
@@ -22,23 +22,12 @@ package com.esotericsoftware.kryo.serializers;
 import static com.esotericsoftware.minlog.Log.TRACE;
 import static com.esotericsoftware.minlog.Log.trace;
 
-import java.lang.reflect.Array;
 import java.lang.reflect.Field;
-import java.lang.reflect.GenericArrayType;
-import java.lang.reflect.ParameterizedType;
-import java.lang.reflect.Type;
-import java.lang.reflect.TypeVariable;
-import java.lang.reflect.WildcardType;
-import java.util.Arrays;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.Map;
 
-import com.esotericsoftware.kryo.Generics;
-import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.Serializer;
 import com.esotericsoftware.kryo.factories.ReflectionSerializerFactory;
-import com.esotericsoftware.kryo.serializers.FieldSerializer.Bind;
 import com.esotericsoftware.kryo.serializers.FieldSerializer.CachedField;
 
 /**

--- a/src/com/esotericsoftware/kryo/serializers/FieldSerializerGenericsUtil.java
+++ b/src/com/esotericsoftware/kryo/serializers/FieldSerializerGenericsUtil.java
@@ -33,8 +33,6 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
-import com.esotericsoftware.kryo.Generics;
-import com.esotericsoftware.kryo.GenericsResolver;
 import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.serializers.FieldSerializer.CachedField;
 

--- a/src/com/esotericsoftware/kryo/serializers/Generics.java
+++ b/src/com/esotericsoftware/kryo/serializers/Generics.java
@@ -17,15 +17,18 @@
  * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
  * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. */
 
-package com.esotericsoftware.kryo;
+package com.esotericsoftware.kryo.serializers;
 
 import java.util.HashMap;
 import java.util.Map;
 
-/*** Helper class to map type name variables to concrete classes that are used during instantiation
+/**
+ * INTERNAL API
+ *
+ * Helper class to map type name variables to concrete classes that are used during instantiation
  * 
  * @author Roman Levenstein <romixlev@gmail.com> */
-public class Generics {
+final class Generics {
 	private Map<String, Class> typeVar2class;
 
 	public Generics () {

--- a/src/com/esotericsoftware/kryo/serializers/GenericsResolver.java
+++ b/src/com/esotericsoftware/kryo/serializers/GenericsResolver.java
@@ -17,20 +17,26 @@
  * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
  * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. */
 
-package com.esotericsoftware.kryo;
+package com.esotericsoftware.kryo.serializers;
 
 import java.util.LinkedList;
 
-/** Helper class that resolves a type name variable to a concrete class using the current class serialization stack
+import static com.esotericsoftware.minlog.Log.TRACE;
+import static com.esotericsoftware.minlog.Log.trace;
+
+/**
+ * INTERNAL API
+ *
+ * Helper class that resolves a type name variable to a concrete class using the current class serialization stack
  *
  * @author Jeroen van Erp <jeroen@hierynomus.com> */
-public class GenericsResolver {
+public final class GenericsResolver {
     private LinkedList<Generics> stack = new LinkedList<Generics>();
 
-    GenericsResolver () {
+    public GenericsResolver () {
     }
 
-    public Class getConcreteClass (String typeVar) {
+    Class getConcreteClass(String typeVar) {
         for (Generics generics : stack) {
             Class clazz = generics.getConcreteClass(typeVar);
             if (clazz != null) return clazz;
@@ -38,15 +44,16 @@ public class GenericsResolver {
         return null;
     }
 
-    public boolean isSet () {
+    boolean isSet () {
         return !stack.isEmpty();
     }
 
-    void pushScope (Generics scope) {
+    void pushScope(Class type, Generics scope) {
+        if (TRACE) trace("generics", "Settting a new generics scope for class " + type.getName() + ": " + scope);
         stack.addFirst(scope);
     }
 
-    void popScope () {
+    void popScope() {
         stack.removeFirst();
     }
 }


### PR DESCRIPTION
This is related to #342 (last change to Generics), and also related to #343 (reduce api).

Because Generics(Resolver) related methods are not considered to be part of the public api, no user should be affected. The removed methods and moved classes are added to the clirr ignore list.

The project version is changed back to 3.1.0-SNAPSHOT, because it had been accidentally incremented to 4.0.0 (now it's clear that the major version shall only be increased when serialization compatibility is
broken).

Btw, license header is changed because it had inconsistent line endings (and I don't know how to convince intellij to leave them inconsistent).