### PR TITLE
Fix #389 ByteBufferOutput: revert ByteOrder on overflow in require during writeVar*()

### DIFF
--- a/src/com/esotericsoftware/kryo/io/ByteBufferOutput.java
+++ b/src/com/esotericsoftware/kryo/io/ByteBufferOutput.java
@@ -200,12 +200,16 @@ public class ByteBufferOutput extends Output {
 	/** @return true if the buffer has been resized. */
 	protected boolean require (int required) throws KryoException {
 		if (capacity - position >= required) return false;
-		if (required > maxCapacity)
+		if (required > maxCapacity) {
+			niobuffer.order(byteOrder);
 			throw new KryoException("Buffer overflow. Max capacity: " + maxCapacity + ", required: " + required);
+		}
 		flush();
 		while (capacity - position < required) {
-			if (capacity == maxCapacity)
+			if (capacity == maxCapacity) {
+				niobuffer.order(byteOrder);
 				throw new KryoException("Buffer overflow. Available: " + (capacity - position) + ", required: " + required);
+			}
 			// Grow buffer.
 			if (capacity == 0) capacity = 1;
 			capacity = Math.min(capacity * 2, maxCapacity);

--- a/test/com/esotericsoftware/kryo/ByteBufferInputOutputTest.java
+++ b/test/com/esotericsoftware/kryo/ByteBufferInputOutputTest.java
@@ -8,6 +8,32 @@ import java.nio.ByteOrder;
 
 public class ByteBufferInputOutputTest extends KryoTestCase {
 
+	public void testByteBufferOutputResetEndiannessAfterException() {
+		ByteBufferOutput outputBuffer = new ByteBufferOutput(10, 10);
+		boolean exceptionTriggered = false;
+		try {
+			for (int i = 0; i < 10; i++) {
+				outputBuffer.writeVarInt(1234, true);
+			}
+		} catch (KryoException exception) {
+			exceptionTriggered = true;
+			assertEquals(outputBuffer.order(), outputBuffer.getByteBuffer().order());
+		}
+
+		assertTrue(exceptionTriggered);
+
+		exceptionTriggered = false;
+		try {
+			for (int i = 0; i < 10; i++) {
+				outputBuffer.writeVarLong(1234L, true);
+			}
+		} catch (KryoException exception) {
+			assertEquals(outputBuffer.order(), outputBuffer.getByteBuffer().order());
+			exceptionTriggered = true;
+		}
+		assertTrue(exceptionTriggered);
+	}
+
 	public void testByteBufferInputPosition() {
 		ByteBuffer byteBuffer = ByteBuffer.allocateDirect(4096);
 		ByteBufferInput inputBuffer = new ByteBufferInput(byteBuffer);


### PR DESCRIPTION
Test:
A case for when writing 
 - varInt causes an overflow in the buffer
 - varLong causes an overflow in the buffer

during writeVar*() a KryoException caused by require(int) did not revert the byteOrder