### PR TITLE
Use system property to detect Android

### DIFF
--- a/src/com/esotericsoftware/kryo/util/Util.java
+++ b/src/com/esotericsoftware/kryo/util/Util.java
@@ -24,14 +24,7 @@ import static com.esotericsoftware.minlog.Log.*;
 /** A few utility methods, mostly for private use.
  * @author Nathan Sweet <misc@n4te.com> */
 public class Util {
-	static public boolean isAndroid;
-	static {
-		try {
-			Class.forName("android.os.Process");
-			isAndroid = true;
-		} catch (Exception ignored) {
-		}
-	}
+	static public boolean isAndroid = "Dalvik".equals(System.getProperty("java.vm.name"));
 
 	/** Returns the primitive wrapper class for a primitive class.
 	 * @param type Must be a primitive class. */


### PR DESCRIPTION
Using existing classes might actually lead to the wrong result when used with other libraries like Robotium that provide those classes for non-Android systems.