### PR TITLE
Introduce FieldSerializerConfig to encapsulate config in Kryo

### DIFF
--- a/src/com/esotericsoftware/kryo/Kryo.java
+++ b/src/com/esotericsoftware/kryo/Kryo.java
@@ -45,6 +45,7 @@ import java.util.TreeMap;
 import java.util.TreeSet;
 
 import com.esotericsoftware.kryo.serializers.DefaultSerializers.URLSerializer;
+import com.esotericsoftware.kryo.serializers.FieldSerializerConfig;
 import com.esotericsoftware.kryo.serializers.OptionalSerializers;
 import com.esotericsoftware.kryo.serializers.GenericsResolver;
 import com.esotericsoftware.kryo.serializers.TimeSerializers;
@@ -143,12 +144,11 @@ public class Kryo {
 
 	private int copyDepth;
 	private boolean copyShallow;
-	private boolean copyTransient = true;
 	private IdentityMap originalToCopy;
 	private Object needsCopyReference;
 	private GenericsResolver genericsResolver = new GenericsResolver();
-	/** Tells if ASM-based backend should be used by new serializer instances created using this Kryo instance. */
-	private boolean asmEnabled = false;
+
+	private FieldSerializerConfig fieldSerializerConfig = new FieldSerializerConfig();
 
 	private StreamFactory streamFactory;
 
@@ -1058,22 +1058,11 @@ public class Kryo {
 		this.copyReferences = copyReferences;
 	}
 
-	/**
-	 * If false, when {@link #copy(Object)} is called all transient fields that are accessible will be ignored from
-	 * being copied. This has to be set before registering classes with kryo for it to be used by all field
-	 * serializers. If transient fields has to be copied for specific classes then use {@link FieldSerializer#setCopyTransient(boolean)}.
-	 * Default is true.
-	 */
-	public void setCopyTransient(boolean copyTransient) {
-		this.copyTransient = copyTransient;
-	}
-
-	/**
-	 * Returns true if copying of transient fields is enabled for {@link #copy(Object)}.
-	 * @return true if transient field copy is enable
-	 */
-	public boolean getCopyTransient() {
-		return copyTransient;
+	/** The default configuration for {@link FieldSerializer} instances. Already existing serializer instances (e.g.
+	 * implicitely created for already registered classes) are not affected by this configuration. You can override
+	 * the configuration for a single {@link FieldSerializer}. */
+	public FieldSerializerConfig getFieldSerializerConfig() {
+		return fieldSerializerConfig;
 	}
 
 	/** Sets the reference resolver and enables references. */
@@ -1209,13 +1198,18 @@ public class Kryo {
 	 * </p>
 	 * 
 	 * @param flag if true, ASM-based backend will be used. Otherwise Unsafe-based backend could be used by some serializers, e.g.
-	 *           FieldSerializer */
+	 *           FieldSerializer
+	 *
+	 * @deprecated Use {@link #getFieldSerializerConfig()} to change the default {@link FieldSerializer} configuration. */
+	@Deprecated
 	public void setAsmEnabled (boolean flag) {
-		this.asmEnabled = flag;
+		fieldSerializerConfig.setUseAsm(flag);
 	}
 
+	/** @deprecated Use {@link #getFieldSerializerConfig()} to change the default {@link FieldSerializer} configuration. */
+	@Deprecated
 	public boolean getAsmEnabled () {
-		return asmEnabled;
+		return fieldSerializerConfig.isUseAsm();
 	}
 
 	static public class DefaultInstantiatorStrategy implements org.objenesis.strategy.InstantiatorStrategy {

--- a/src/com/esotericsoftware/kryo/serializers/FieldSerializerConfig.java
+++ b/src/com/esotericsoftware/kryo/serializers/FieldSerializerConfig.java
@@ -1,0 +1,124 @@
+/* Copyright (c) 2016, Martin Grotzke
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following
+ * conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the distribution.
+ * - Neither the name of Esoteric Software nor the names of its contributors may be used to endorse or promote products derived
+ * from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
+ * BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. */
+
+package com.esotericsoftware.kryo.serializers;
+
+import com.esotericsoftware.kryo.Kryo;
+
+import static com.esotericsoftware.minlog.Log.TRACE;
+import static com.esotericsoftware.minlog.Log.trace;
+
+/** Configuration for FieldSerializer instances. To configure defaults for new FieldSerializer instances
+ * use {@link Kryo#getFieldSerializerConfig()}, to configure a specific FieldSerializer instance use setters
+ * for configuration settings on this specific FieldSerializer. */
+public final class FieldSerializerConfig implements Cloneable {
+    private boolean fieldsCanBeNull = true, setFieldsAsAccessible = true;
+    private boolean ignoreSyntheticFields = true;
+    private boolean fixedFieldTypes;
+    /** If set, ASM-backend is used. Otherwise Unsafe-based backend or reflection is used */
+    private boolean useAsm;
+    /** If set, transient fields will be copied */
+    private boolean copyTransient = true;
+
+    {
+        useAsm = !FieldSerializer.unsafeAvailable;
+        if (TRACE) trace("kryo.FieldSerializerConfig", "useAsm: " + useAsm);
+    }
+
+    @Override
+    protected FieldSerializerConfig clone() {
+        // clone is ok here as we have only primitive fields
+        try { return (FieldSerializerConfig) super.clone(); }
+        catch (CloneNotSupportedException e) { throw new RuntimeException(e); }
+    }
+
+    /** Sets the default value for {@link FieldSerializer.CachedField#setCanBeNull(boolean)}.
+     * @param fieldsCanBeNull False if none of the fields are null. Saves 0-1 byte per field. True if it is not known (default). */
+    public void setFieldsCanBeNull (boolean fieldsCanBeNull) {
+        this.fieldsCanBeNull = fieldsCanBeNull;
+        if (TRACE) trace("kryo.FieldSerializerConfig", "setFieldsCanBeNull: " + fieldsCanBeNull);
+    }
+
+    /** Controls which fields are serialized.
+     * @param setFieldsAsAccessible If true, all non-transient fields (inlcuding private fields) will be serialized and
+	 *                              {@link java.lang.reflect.Field#setAccessible(boolean) set as accessible} if necessary (default).
+	 *                              If false, only fields in the public API will be serialized. */
+    public void setFieldsAsAccessible (boolean setFieldsAsAccessible) {
+        this.setFieldsAsAccessible = setFieldsAsAccessible;
+        if (TRACE) trace("kryo.FieldSerializerConfig", "setFieldsAsAccessible: " + setFieldsAsAccessible);
+    }
+
+    /** Controls if synthetic fields are serialized. Default is true.
+     * @param ignoreSyntheticFields If true, only non-synthetic fields will be serialized. */
+    public void setIgnoreSyntheticFields (boolean ignoreSyntheticFields) {
+        this.ignoreSyntheticFields = ignoreSyntheticFields;
+        if (TRACE) trace("kryo.FieldSerializerConfig", "setIgnoreSyntheticFields: " + ignoreSyntheticFields);
+    }
+
+    /** Sets the default value for {@link FieldSerializer.CachedField#setClass(Class)} to the field's declared type. This allows FieldSerializer to
+     * be more efficient, since it knows field values will not be a subclass of their declared type. Default is false. */
+    public void setFixedFieldTypes (boolean fixedFieldTypes) {
+        this.fixedFieldTypes = fixedFieldTypes;
+        if (TRACE) trace("kryo.FieldSerializerConfig", "setFixedFieldTypes: " + fixedFieldTypes);
+    }
+
+    /** Controls whether ASM should be used.
+     * @param setUseAsm If true, ASM will be used for fast serialization. If false, Unsafe will be used (default) */
+    public void setUseAsm (boolean setUseAsm) {
+        useAsm = setUseAsm;
+        if (!useAsm && !FieldSerializer.unsafeAvailable) {
+            useAsm = true;
+            if (TRACE) trace("kryo.FieldSerializerConfig", "sun.misc.Unsafe is unavailable, using ASM.");
+        }
+        if (TRACE) trace("kryo.FieldSerializerConfig", "setUseAsm: " + setUseAsm);
+    }
+
+    /** If false, when {@link Kryo#copy(Object)} is called all transient fields that are accessible will be ignored from
+     * being copied. This has to be set before registering classes with kryo for it to be used by all field
+     * serializers. If transient fields has to be copied for specific classes then use {@link FieldSerializer#setCopyTransient(boolean)}.
+     * Default is true.
+     */
+    public void setCopyTransient (boolean setCopyTransient) {
+        copyTransient = setCopyTransient;
+    }
+
+    public boolean isFieldsCanBeNull() {
+        return fieldsCanBeNull;
+    }
+
+    public boolean isSetFieldsAsAccessible() {
+        return setFieldsAsAccessible;
+    }
+
+    public boolean isIgnoreSyntheticFields() {
+        return ignoreSyntheticFields;
+    }
+
+    public boolean isFixedFieldTypes() {
+        return fixedFieldTypes;
+    }
+
+    public boolean isUseAsm() {
+        return useAsm;
+    }
+
+    public boolean isCopyTransient() {
+        return copyTransient;
+    }
+}

--- a/test/com/esotericsoftware/kryo/FieldSerializerTest.java
+++ b/test/com/esotericsoftware/kryo/FieldSerializerTest.java
@@ -461,7 +461,7 @@ public class FieldSerializerTest extends KryoTestCase {
 	}
 
 	public void testTransientsUsingGlobalConfig () {
-		kryo.setCopyTransient(false);
+		kryo.getFieldSerializerConfig().setCopyTransient(false);
 		kryo.register(HasTransients.class);
 		HasTransients objectWithTransients1 = new HasTransients();
 		objectWithTransients1.transientField1 = "Test";


### PR DESCRIPTION
(As adressed on the mailing list: https://groups.google.com/d/msg/kryo-users/G16daCijbWo/1igHI7WcBgAJ)

The `Kryo` class is more and more used for "global" configuration of serializers like `FieldSerializer` etc (here's another PR: #365). The semantics of such settings and especially for which serializer it's applied can often only be clarified via documentation.

This change introduces a `FieldSerializerConfig` class that encapsulates configuration for `FieldSerializer`. It allows to configure settings for all `FieldSerializer` instances created via `Kryo.getFieldSerializerConfig`. On each `FieldSerializer` the config can be changed/overridden, this is done directly on the serializer (instead e.g. requiring to invoke `fieldSerializer.getConfig.setSomeThing`) to stay binary compatible and because forcing to use the config here does not seem to be of much value.
The `FieldSerializer` internally uses the config object so that any further settings are directly added to `FieldSerializerConfig` and there's only a single place to keep config settings.

`Kryo.asmEnabled` might be used by different serializers, but because until now it was only used by `FieldSerializer` this setting is also kept in `FieldSerializerConfig`. `Kryo.set/getAsmEnabled` is marked as deprecated with a hint to use `getFieldSerializerConfig` instead - this is done to stay binary compatible.

`Kryo.setCopyTransient` is removed because it was introduced after the latest release 3.0.3 and therefore not yet a published/released. Now `Kryo.getFieldSerializerConfig.setCopyTransient` has to be used.

If this is considered to be merged then #365 should also follow this approach.