### PR TITLE
Make Closure public, moving it to ClosureSerializer

### DIFF
--- a/pom-main.xml
+++ b/pom-main.xml
@@ -109,6 +109,11 @@
 							<className>com/esotericsoftware/reflectasm/**</className>
 							<differenceType>8001</differenceType>
 						</difference>
+						<difference>
+							<className>com/esotericsoftware/kryo/Kryo</className>
+							<method>*isClousre*</method>
+							<differenceType>7002</differenceType>
+						</difference>
 					</ignored>
 				</configuration>
 				<!-- prevent "clirr-maven-plugin:2.6.1:check failed: Invalid byte tag in constant pool: 18" -->

--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,7 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<versions.reflectasm>1.10.1</versions.reflectasm>
+		<test.exclude>**/Java8*Test.java</test.exclude>
 	</properties>
 	
 	<modules>
@@ -101,6 +102,9 @@
 						<source>1.5</source>
 						<target>1.5</target>
 						<encoding>utf-8</encoding>
+						<testExcludes>
+							<testExclude>${test.exclude}</testExclude>
+						</testExcludes>
 					</configuration>
 				</plugin>
 				<plugin>
@@ -205,6 +209,18 @@
 					</plugin>
 				</plugins>
 			</build>
+		</profile>
+		<profile>
+			<id>java8</id>
+			<!-- To disable this profile run mvn with '-P !java8' (maybe escape the exclamation mark) -->
+			<activation><jdk>[1.8,)</jdk></activation>
+			<!-- use properties to change compiler configuration because overriding build/plugin config just did not work -->
+			<properties>
+				<!-- Setting an empty values does not override/set the property -->
+				<test.exclude>someValueWhichDoesNotExist</test.exclude>
+				<maven.compiler.testSource>1.8</maven.compiler.testSource>
+				<maven.compiler.testTarget>1.8</maven.compiler.testTarget>
+			</properties>
 		</profile>
 	</profiles>
 

--- a/src/com/esotericsoftware/kryo/Kryo.java
+++ b/src/com/esotericsoftware/kryo/Kryo.java
@@ -44,6 +44,7 @@ import java.util.TimeZone;
 import java.util.TreeMap;
 import java.util.TreeSet;
 
+import com.esotericsoftware.kryo.serializers.ClosureSerializer;
 import com.esotericsoftware.kryo.serializers.DefaultSerializers.URLSerializer;
 import com.esotericsoftware.kryo.serializers.OptionalSerializers;
 import com.esotericsoftware.kryo.serializers.GenericsResolver;
@@ -491,8 +492,8 @@ public class Kryo {
 				registration = getRegistration(type.getEnclosingClass());
 			} else if (EnumSet.class.isAssignableFrom(type)) {
 				registration = classResolver.getRegistration(EnumSet.class);
-			} else if (isClousre(type)) {
-				registration = classResolver.getRegistration(Closure.class);
+			} else if (isClosure(type)) {
+				registration = classResolver.getRegistration(ClosureSerializer.Closure.class);
 			}
 			if (registration == null) {
 				if (registrationRequired) {
@@ -1174,7 +1175,7 @@ public class Kryo {
 	/** Returns true if the specified type is a closure.
 	 * <p>
 	 * This can be overridden to support alternative implementations of clousres. Current version supports Oracle's Java8 only */
-	public boolean isClousre (Class type) {
+	protected boolean isClosure(Class type) {
 		if (type == null) throw new IllegalArgumentException("type cannot be null.");
 		return type.getName().indexOf('/') >= 0;
 	}
@@ -1290,6 +1291,4 @@ public class Kryo {
 		}
 	}
 
-	private static class Closure {
-	}
 }

--- a/src/com/esotericsoftware/kryo/serializers/ClosureSerializer.java
+++ b/src/com/esotericsoftware/kryo/serializers/ClosureSerializer.java
@@ -30,15 +30,18 @@ import com.esotericsoftware.kryo.io.Output;
  * <p>
  * <code>
  * kryo.register(java.lang.invoke.SerializedLambda.class);<br>
- * kryo.register(Closure.class, new ClosureSerializer());</code>
+ * kryo.register(ClosureSerializer.Closure.class, new ClosureSerializer());</code>
  * @author Roman Levenstein <romixlev@gmail.com> */
 public class ClosureSerializer extends Serializer {
 
+	/** Marker class to bind ClosureSerializer to. See also {@link Kryo#isClosure(Class)} and {@link Kryo#getRegistration(Class)} */
+	public static class Closure {
+	}
+
 	private static Method readResolve;
-	private static Class serializedLambda;
+	private static Class serializedLambda = java.lang.invoke.SerializedLambda.class;
 	static {
 		try {
-			serializedLambda = Class.forName("java.lang.invoke.SerializedLambda");
 			readResolve = serializedLambda.getDeclaredMethod("readResolve");
 			readResolve.setAccessible(true);
 		} catch (Exception e) {

--- a/test/com/esotericsoftware/kryo/serializers/Java8ClosureSerializerTest.java
+++ b/test/com/esotericsoftware/kryo/serializers/Java8ClosureSerializerTest.java
@@ -1,0 +1,69 @@
+/* Copyright (c) 2016, Martin Grotzke
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following
+ * conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the distribution.
+ * - Neither the name of Esoteric Software nor the names of its contributors may be used to endorse or promote products derived
+ * from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
+ * BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. */
+
+package com.esotericsoftware.kryo.serializers;
+
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.KryoTestCase;
+import org.junit.Assert;
+import org.junit.Test;
+import org.objenesis.strategy.StdInstantiatorStrategy;
+
+import java.lang.invoke.SerializedLambda;
+import java.util.Arrays;
+import java.util.concurrent.Callable;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Test for java 8 closures.
+ *
+ * For jdk < 1.8 excluded from surefire tests via the "until-java8" profile in pom.xml which excludes "Java8*Tests".
+ */
+public class Java8ClosureSerializerTest extends KryoTestCase {
+
+    public void setUp() throws Exception {
+        super.setUp();
+        kryo.setInstantiatorStrategy(new Kryo.DefaultInstantiatorStrategy(new StdInstantiatorStrategy()));
+        // the following registrations are needed because registration is required
+        kryo.register(Object[].class);
+        kryo.register(java.lang.Class.class);
+        kryo.register(getClass()); // closure capturing class (in this test `this`), it would usually already be registered
+        kryo.register(SerializedLambda.class);
+        // always needed for closure serialization, also if registrationRequired=false
+        kryo.register(ClosureSerializer.Closure.class, new ClosureSerializer());
+    }
+
+    public void testSerializeSerializableLambdaWithKryo() throws Exception {
+        Callable<Boolean> doNothing = (Callable<Boolean> & java.io.Serializable)(() -> true);
+        roundTrip(222, 225, doNothing);
+    }
+
+    // we must override equals as lambdas have no equals check built in...
+    @Override
+    protected void doAssertEquals(Object object1, Object object2) {
+        try {
+            Assert.assertEquals(((Callable<?>)object1).call(), ((Callable<?>)object2).call());
+        } catch (Exception e) {
+            throw new RuntimeException(e.getMessage());
+        }
+    }
+
+}


### PR DESCRIPTION
Closure is moved to ClosureSerializer because they're tightly coupled and this makes the connection more obvious.

This also renames `Kryo.isClousre` to `isClosure`, assuming that it was not used until now it's ignored regarding binary compatibility.

A test for closure serialization is added together with the required maven foo for compiler settings.

Fixes #299, refs #215