### PR TITLE
Throw exception if output buffer size is greater than max buffer size

### DIFF
--- a/src/com/esotericsoftware/kryo/io/Output.java
+++ b/src/com/esotericsoftware/kryo/io/Output.java
@@ -54,6 +54,8 @@ public class Output extends OutputStream {
 	 * @param maxBufferSize The buffer is doubled as needed until it exceeds maxBufferSize and an exception is thrown. Can be -1
 	 *           for no maximum. */
 	public Output (int bufferSize, int maxBufferSize) {
+		if (bufferSize > maxBufferSize && maxBufferSize != -1)
+			throw new IllegalArgumentException("bufferSize: " + bufferSize + " cannot be greater than maxBufferSize: " + maxBufferSize);
 		if (maxBufferSize < -1) throw new IllegalArgumentException("maxBufferSize cannot be < -1: " + maxBufferSize);
 		this.capacity = bufferSize;
 		this.maxCapacity = maxBufferSize == -1 ? Integer.MAX_VALUE : maxBufferSize;
@@ -110,6 +112,8 @@ public class Output extends OutputStream {
 	 * @param maxBufferSize The buffer is doubled as needed until it exceeds maxBufferSize and an exception is thrown. */
 	public void setBuffer (byte[] buffer, int maxBufferSize) {
 		if (buffer == null) throw new IllegalArgumentException("buffer cannot be null.");
+		if (buffer.length > maxBufferSize && maxBufferSize != -1)
+			throw new IllegalArgumentException("buffer has length: " + buffer.length + " cannot be greater than maxBufferSize: " + maxBufferSize);
 		if (maxBufferSize < -1) throw new IllegalArgumentException("maxBufferSize cannot be < -1: " + maxBufferSize);
 		this.buffer = buffer;
 		this.maxCapacity = maxBufferSize == -1 ? Integer.MAX_VALUE : maxBufferSize;

--- a/test/com/esotericsoftware/kryo/InputOutputTest.java
+++ b/test/com/esotericsoftware/kryo/InputOutputTest.java
@@ -869,4 +869,52 @@ public class InputOutputTest extends KryoTestCase {
 		assertEquals(s1, s2);
 
 	}
+
+	public void testNewOutputMaxBufferSizeLessThanBufferSize() {
+		int bufferSize = 2;
+		int maxBufferSize = 1;
+
+		try {
+			new Output(bufferSize, maxBufferSize);
+			fail("Expecting IllegalArgumentException not thrown");
+		} catch (IllegalArgumentException e) {
+			// This exception is expected
+		}
+	}
+
+	public void testSetOutputMaxBufferSizeLessThanBufferSize() {
+		int bufferSize = 2;
+		int maxBufferSize = 1;
+
+		Output output = new Output(bufferSize, bufferSize);
+		assertNotNull(output);
+
+		try {
+			output.setBuffer(new byte[bufferSize], maxBufferSize);
+			fail("Expecting IllegalArgumentException not thrown");
+		} catch (IllegalArgumentException e) {
+			// This exception is expected
+		}
+
+	}
+
+	public void testNewOutputMaxBufferSizeIsMinusOne() {
+		int bufferSize = 2;
+		int maxBufferSize = -1;
+
+		Output output = new Output(bufferSize, maxBufferSize);
+		assertNotNull(output);
+		// This test should pass as long as no exception thrown
+	}
+
+	public void testSetOutputMaxBufferSizeIsMinusOne() {
+		int bufferSize = 2;
+		int maxBufferSize = -1;
+
+		Output output = new Output(bufferSize, bufferSize);
+		assertNotNull(output);
+		output.setBuffer(new byte[bufferSize], maxBufferSize);
+		// This test should pass as long as no exception thrown
+	}
+
 }


### PR DESCRIPTION
Currently, the Output class allows the initial buffer size to be greater than the max buffer size. In some cases, we can observe an ArrayIndexOutOfBoundsException during an attempt to expand the buffer. The following test cases demonstrate the behaviour.

```
    @Test
    public void testNewOutputMaxBufferSizeLessThanBufferSize() {
        int bufferSize = 2;
        int maxBufferSize = 1;

        Output output = new Output(bufferSize, maxBufferSize);

        for (int i = 0; i < bufferSize; i++) {
            output.writeByte(0);
        }

        output.writeByte(0);

    }

    @Test
    public void testSetOutputMaxBufferSizeLessThanBufferSize() {
        int bufferSize = 2;
        int maxBufferSize = 1;

        Output output = new Output(bufferSize, bufferSize);
        output.setBuffer(new byte[bufferSize], maxBufferSize);

        for (int i = 0; i < bufferSize; i++) {
            output.writeByte(0);
        }

        output.writeByte(0);

    }

```
Suggestion is to throw an IllegalArgumentException when setting the buffer sizes to pre-empt this error.