### PR TITLE
Faster unsafe serialization/deserialization of byte and boolean

### DIFF
--- a/src/com/esotericsoftware/kryo/io/UnsafeInput.java
+++ b/src/com/esotericsoftware/kryo/io/UnsafeInput.java
@@ -75,6 +75,26 @@ public final class UnsafeInput extends Input {
 		super(inputStream, bufferSize);
 	}
 
+	// byte
+
+	/** Reads a single byte. */
+	public byte readByte () throws KryoException {
+		require(1);
+		byte result = unsafe().getByte(buffer, byteArrayBaseOffset + position);
+		position++;
+		return result;
+	}
+
+	// boolean
+
+	/** Reads a 1 byte boolean. */
+	public boolean readBoolean () throws KryoException {
+		require(1);
+		boolean result = unsafe().getBoolean(buffer, byteArrayBaseOffset + position);
+		position++;
+		return result;
+	}
+
 	// int
 
 	/** Reads a 4 byte int. */

--- a/src/com/esotericsoftware/kryo/io/UnsafeOutput.java
+++ b/src/com/esotericsoftware/kryo/io/UnsafeOutput.java
@@ -93,6 +93,26 @@ public final class UnsafeOutput extends Output {
 		super(outputStream, bufferSize);
 	}
 
+	/** Writes a single byte. */
+	final public void writeByte (byte value) throws KryoException {
+		require(1);
+		unsafe().putByte(buffer, byteArrayBaseOffset + position, value);
+		position++;
+	}
+
+	final public void writeByte (int value) throws KryoException {
+		require(1);
+		unsafe().putByte(buffer, byteArrayBaseOffset + position, (byte)value);
+		position++;
+	}
+
+	/** Writes a 1 byte boolean.*/
+	final public void writeBoolean (boolean value) throws KryoException {
+		require(1);
+		unsafe().putBoolean(buffer, byteArrayBaseOffset + position, value);
+		position++;
+	}
+
 	/** Writes a 4 byte int. */
 	final public void writeInt (int value) throws KryoException {
 		require(4);


### PR DESCRIPTION
The current code does not use unsafe for (de)serialization of bytes and booleans in `UnsafeInput`
and `UnsafeOutput`. Instead, it uses the old mechanism of writing/reading to/from the byte array
buffer for bytes and booleans. Dealing with array poses some overhead compared to unsafe. For
instance, JVM adds boundary checks internally when dealing with arrays. Through detailed
performance profiling it is noticeable that replacing array operations with unsafe operations
for bytes and booleans improves the performance.

For the purpose of performance measurement, we use a micro-benchmark in which a sequence
of bytes/booleans are serialized and written/read to/from a file. The size of the file is twice the
size of the available RAM to reduce/avoid the effect of OS cache. We use UnsafeInput/UnsafeOutput with
a buffer size of 4MB, over FileOutputStream/FileInputStream created from RandomAccessFile
(despite the use of RandomAccessFile, the benchmark only does sequential read/write to file).
Here are the performance results on a machine with Intel Core i7-2.8Ghz and SSD (about 800MB/s read,
and about 700MB/s write bandwidth):

old code using array operation:
read bandwidth: ~650MB/s
write bandwidth: ~550MB/s

changed code using unsafe for byte/boolean:
read bandwidth: ~750 MB/s
write bandwidth: ~650 MB/s

It seems that using unsafe operation improves the IO bandwidth by about 15%.

Test Plan:
mvn clean verify
