### PR TITLE
updating the bcel version since the 6.0-SNAPSHOT no longer resolves

### DIFF
--- a/pom-main.xml
+++ b/pom-main.xml
@@ -122,7 +122,7 @@
 					<dependency>
 						<groupId>org.apache.bcel</groupId>
 						<artifactId>bcel</artifactId>
-						<version>6.0-SNAPSHOT</version>
+						<version>6.0</version>
 					</dependency>
 				</dependencies>
 			</plugin>


### PR DESCRIPTION
as discussed on gitter, this fixes a build failure