### PR TITLE
adding CollectionsNCopiesSerializer

### DIFF
--- a/src/com/esotericsoftware/kryo/serializers/CollectionsNCopiesSerializer.java
+++ b/src/com/esotericsoftware/kryo/serializers/CollectionsNCopiesSerializer.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Changes:
+ * this was modified from the original found at https://github.com/apache/giraph/blob/release-1.2/giraph-core/src/main/java/org/apache/giraph/writable/kryo/serializers/CollectionsNCopiesSerializer.java
+ * by changing the package to match the default kryo package scheme
+ */
+
+package com.esotericsoftware.kryo.serializers;
+
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.Serializer;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Special serializer for Collections.nCopies
+ *
+ * @param <T> Element type
+ */
+public class CollectionsNCopiesSerializer<T> extends Serializer<List<T>> {
+  @Override
+  public void write(Kryo kryo, Output output, List<T> object) {
+    output.writeInt(object.size(), true);
+    if (object.size() > 0) {
+      kryo.writeClassAndObject(output, object.get(0));
+    }
+  }
+
+  @Override
+  public List<T> read(Kryo kryo, Input input, Class<List<T>> type) {
+    int size = input.readInt(true);
+    if (size > 0) {
+      T object = (T) kryo.readClassAndObject(input);
+      return Collections.nCopies(size, object);
+    } else {
+      return Collections.emptyList();
+    }
+  }
+}


### PR DESCRIPTION
This is copied from the Apache Giraph project (http://giraph.apache.org/)
the serializer is taken from with minimal modification
https://github.com/apache/giraph/blob/release-1.2/giraph-core/src/main/java/org/apache/giraph/writable/kryo/serializers/CollectionsNCopiesSerializer.java

The initial files are under the Apache 2.0 license, so technically it means this project should probably include a copy of the apache 2 `LICENSE` and `NOTICE` file.  The original contributor seems to be @ikabiljo, so maybe he could give a thumbs up to include this under bsd license directly?  It is very simple code, so I'm not sure how to reimplement it in a way that isn't just a copy.

It didn't come with any tests.  I'd like to write one but I'm not totally clear on how to do so.  It looks like all of the serializer tests check the expected size in bytes of the serialized object, but I'm not sure how I should calculate that exactly, and it seems wrong to just run it and use the generated values...
