### PR TITLE
don't set parent of genericsScope if equals (#462)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 	</parent>
 	<groupId>com.esotericsoftware.kryo</groupId>
 	<artifactId>kryo</artifactId>
-	<version>2.24.0</version>
+	<version>2.24.1</version>
 	<packaging>bundle</packaging>
 	<name>Kryo</name>
 	<description>Fast, efficient Java serialization</description>

--- a/src/com/esotericsoftware/kryo/Kryo.java
+++ b/src/com/esotericsoftware/kryo/Kryo.java
@@ -1129,7 +1129,9 @@ public class Kryo {
 			generics = new Generics(generics.getMappings());
 		}
 		genericsScope = generics;
-		genericsScope.setParentScope(currentScope);
+		if (genericsScope != currentScope) {
+			genericsScope.setParentScope(currentScope);
+		}
 	}
 
 	public void popGenericsScope () {


### PR DESCRIPTION
this avoids a StackOverflowError when calling kryo.Generics.getConcreteClass

NOTE: this PR must be merged on top of kryo-2.24.0, the same patch should be applied on top of 3.0.3

I can also update the pom to 2.24.1 in this PR if needed
