### PR TITLE
Fix growing ByteBufferOutput while writing varint (#464)

### DIFF
--- a/src/com/esotericsoftware/kryo/io/ByteBufferOutput.java
+++ b/src/com/esotericsoftware/kryo/io/ByteBufferOutput.java
@@ -221,7 +221,11 @@ public class ByteBufferOutput extends Output {
 			niobuffer.limit(position);
 			newBuffer.put(niobuffer);
 			newBuffer.order(niobuffer.order());
+
+			// writeVarInt & writeVarLong mess with the byte order. need to keep track of the current byte order when growing
+			final ByteOrder currentByteOrder = byteOrder;
 			setBuffer(newBuffer, maxCapacity);
+			byteOrder = currentByteOrder;
 		}
 		return true;
 	}

--- a/test/com/esotericsoftware/kryo/ByteBufferInputOutputTest.java
+++ b/test/com/esotericsoftware/kryo/ByteBufferInputOutputTest.java
@@ -102,4 +102,11 @@ public class ByteBufferInputOutputTest extends KryoTestCase {
 		assertEquals(ByteOrder.LITTLE_ENDIAN, outputBuffer.order());
 		assertEquals(ByteOrder.LITTLE_ENDIAN, outputBuffer.getByteBuffer().order());
 	}
+
+	public void testByteBufferByteOrderTheSameAfterGrowingForVarInt() {
+		final ByteBufferOutput outputBuffer = new ByteBufferOutput(1, -1);
+		final ByteOrder byteOrder = outputBuffer.order();
+		outputBuffer.writeVarInt(300, true);
+		assertEquals(byteOrder, outputBuffer.order());
+	}
 }


### PR DESCRIPTION
Growing the ByteBuffer while writing varInt or varLong will change the byte order first, and then perform the require.

If the ByteBuffer needs to grow the setBuffer will again change the ByteOrder, but this time the one set by the varInt method. Thus the final ByteOrder was incorrect. (see [#464](https://github.com/EsotericSoftware/kryo/issues/464))