### PR TITLE
Clarify default used registrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,18 +226,18 @@ Here SomeClass is registered with Kryo, which associates the class with an int I
 
 ```java
     Kryo kryo = new Kryo();
-    kryo.register(SomeClass.class, 0);
-    kryo.register(AnotherClass.class, 1);
-    kryo.register(YetAnotherClass.class, 2);
+    kryo.register(SomeClass.class, 10);
+    kryo.register(AnotherClass.class, 11);
+    kryo.register(YetAnotherClass.class, 12);
 ```
 
 The IDs are written most efficiently when they are small, positive integers. Negative IDs are not serialized efficiently. -1 and -2 are reserved.
 
-Use of registered and unregistered classes can be mixed. All primitives, primitive wrappers, and String are registered by default.
+Use of registered and unregistered classes can be mixed. All primitives, primitive wrappers, String, and void are registered by default using IDs 0-9. Carefully consider registering anything else in this range, as it will overwrite one of these registrations.
 
-Kryo#setRegistrationRequired can be set to true to throw an exception when any unregistered class is encountered. This prevents an application from accidentally using class name strings.
+`Kryo#setRegistrationRequired` can be set to true to throw an exception when any unregistered class is encountered. This prevents an application from accidentally using class name strings.
 
-If using unregistered classes, short package names could be considered.
+If using unregistered classes, short package names should be considered.
 
 ## Default serializers
 

--- a/src/com/esotericsoftware/kryo/Kryo.java
+++ b/src/com/esotericsoftware/kryo/Kryo.java
@@ -442,8 +442,8 @@ public class Kryo {
 	 * cause the old entry to be overwritten. Registering a primitive also affects the corresponding primitive wrapper.
 	 * <p>
 	 * IDs must be the same at deserialization as they were for serialization.
-	 * @param id Must be >= 0. Smaller IDs are serialized more efficiently. IDs 0-8 are used by default for primitive types and
-	 *           String, but these IDs can be repurposed. */
+	 * @param id Must be >= 0. Smaller IDs are serialized more efficiently. IDs 0-9 are used by default for primitive types
+	 *           and their wrappers, String, and void, but these IDs can be repurposed. */
 	public Registration register (Class type, Serializer serializer, int id) {
 		if (id < 0) throw new IllegalArgumentException("id must be >= 0: " + id);
 		return register(new Registration(type, serializer, id));


### PR DESCRIPTION
Addresses #430 

The readme originally led me down the path of starting my registrations at 0 and wiping out the primitive registrations.

I suppose we could also log a warning if the ID is between 0 and 9.