### PR TITLE
Fix warning on instantiate object on Android N+

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
 		<dependency>
 			<groupId>org.objenesis</groupId>
 			<artifactId>objenesis</artifactId>
-			<version>2.3</version>
+			<version>2.5.1</version>
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
 		<dependency>
 			<groupId>org.objenesis</groupId>
 			<artifactId>objenesis</artifactId>
-			<version>2.2</version>
+			<version>2.3</version>
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>


### PR DESCRIPTION
objenesis in the version 2.3 (https://github.com/easymock/objenesis/releases/tag/2.3) fixed important warning caused by using private ObjectStream api on Android N+. 

I'm a developer of Paper DB lib (https://github.com/pilgr/Paper) and happy to use Kryo serialization!
But I noticed users started to failing issues with a warning happening on read data on Android N and above `ObjectStreamClass.newInstance(Class<?>, long) is private API and will be removed in a future Android release`. 
I realized Objenesis fixed it, but Kryo 4.0 unfortunately uses outdated version. I temporary fixed this warning in the lib by forcing use of Objenesis 2.3. But would be awesome to have a new version of Kryo to include such dependency update. 

Thanks!