### PR TITLE
fix compatible field serializer binary search bugs

### DIFF
--- a/src/com/esotericsoftware/kryo/serializers/CompatibleFieldSerializer.java
+++ b/src/com/esotericsoftware/kryo/serializers/CompatibleFieldSerializer.java
@@ -98,7 +98,7 @@ public class CompatibleFieldSerializer<T> extends FieldSerializer<T> {
 				// binary search for schemaName
 				int low, mid, high;
 				int compare;
-				int maxFieldLength = allFields.length > length ? allFields.length : length;
+				int maxFieldLength = allFields.length;
 				outerBinarySearch:
 				for (int i = 0; i < length; i++) {
 					String schemaName = names[i];

--- a/test/com/esotericsoftware/kryo/CompatibleFieldSerializerTest.java
+++ b/test/com/esotericsoftware/kryo/CompatibleFieldSerializerTest.java
@@ -176,12 +176,15 @@ public class CompatibleFieldSerializerTest extends KryoTestCase {
 
 		CompatibleFieldSerializer serializer = new CompatibleFieldSerializer(kryo, ClassWithManyFields.class);
 		serializer.removeField("bAdd");
+		serializer.removeField("zz");
 		kryo.register(ClassWithManyFields.class, serializer);
 		Object object2 = kryo.readClassAndObject(input);
 		assertTrue(object2 instanceof ClassWithManyFields);
 		assertNull("the bAdd field should be null", ((ClassWithManyFields) object2).bAdd);
+		assertNull("the zz field should be null", ((ClassWithManyFields) object2).zz);
 		// update the field in order to verify the remainder of the object was deserialized correctly
 		((ClassWithManyFields) object2).bAdd = object1.bAdd;
+		((ClassWithManyFields) object2).zz = object1.zz;
 		assertEquals(object1, object2);
 	}
 


### PR DESCRIPTION
Fix deserializing bugs using CompatibleFieldSerializer with object which can trigger binary search. Just set the max boundary of binary search to the length of target array. I also update the unit test for this situation.