### PR TITLE
Make Map clear resize value configurable

### DIFF
--- a/src/com/esotericsoftware/kryo/Kryo.java
+++ b/src/com/esotericsoftware/kryo/Kryo.java
@@ -124,8 +124,6 @@ public class Kryo {
 	static private final int REF = -1;
 	static private final int NO_REF = -2;
 
-	private static final int DEFAULT_IOIM_CLEAR_MAX_SIZE = 2048;
-
 	private SerializerFactory defaultSerializer = new ReflectionSerializerFactory(FieldSerializer.class);
 	private final ArrayList<DefaultSerializerEntry> defaultSerializers = new ArrayList(33);
 	private final int lowPriorityDefaultSerializerCount;
@@ -157,8 +155,6 @@ public class Kryo {
 	private TaggedFieldSerializerConfig taggedFieldSerializerConfig = new TaggedFieldSerializerConfig();
 
 	private StreamFactory streamFactory;
-
-	private int ioimClearSize = DEFAULT_IOIM_CLEAR_MAX_SIZE;
 
 	/** Creates a new Kryo with a {@link DefaultClassResolver} and a {@link MapReferenceResolver}. */
 	public Kryo () {
@@ -1088,15 +1084,6 @@ public class Kryo {
 		this.copyReferences = copyReferences;
 	}
 
-	/**
-	 * This method sets the the size of resolver maps when they are reset/cleared.
-	 *
-	 * @param ioimClearSize
-	 */
-	public void setIdenityObjectIntMapClearSize(int ioimClearSize) {
-		this.ioimClearSize = ioimClearSize;
-	}
-
 	/** The default configuration for {@link FieldSerializer} instances. Already existing serializer instances (e.g. implicitely
 	 * created for already registered classes) are not affected by this configuration. You can override the configuration for a
 	 * single {@link FieldSerializer}. */
@@ -1168,11 +1155,6 @@ public class Kryo {
 	/** Returns the number of child objects away from the object graph root. */
 	public int getDepth () {
 		return depth;
-	}
-
-	/** Returns the size to resize to when clearing a resolver map if the map. */
-	public int getIdenityObjectIntMapClearSize() {
-		return this.ioimClearSize;
 	}
 
 	/** Returns the internal map of original to copy objects when a copy method is used. This can be used after a copy to map old

--- a/src/com/esotericsoftware/kryo/Kryo.java
+++ b/src/com/esotericsoftware/kryo/Kryo.java
@@ -124,6 +124,8 @@ public class Kryo {
 	static private final int REF = -1;
 	static private final int NO_REF = -2;
 
+	private static final int DEFAULT_IOIM_CLEAR_MAX_SIZE = 2048;
+
 	private SerializerFactory defaultSerializer = new ReflectionSerializerFactory(FieldSerializer.class);
 	private final ArrayList<DefaultSerializerEntry> defaultSerializers = new ArrayList(33);
 	private final int lowPriorityDefaultSerializerCount;
@@ -155,6 +157,8 @@ public class Kryo {
 	private TaggedFieldSerializerConfig taggedFieldSerializerConfig = new TaggedFieldSerializerConfig();
 
 	private StreamFactory streamFactory;
+
+	private int ioimClearSize = DEFAULT_IOIM_CLEAR_MAX_SIZE;
 
 	/** Creates a new Kryo with a {@link DefaultClassResolver} and a {@link MapReferenceResolver}. */
 	public Kryo () {
@@ -1084,6 +1088,15 @@ public class Kryo {
 		this.copyReferences = copyReferences;
 	}
 
+	/**
+	 * This method sets the the size of resolver maps when they are reset/cleared.
+	 *
+	 * @param ioimClearSize
+	 */
+	public void setIdenityObjectIntMapClearSize(int ioimClearSize) {
+		this.ioimClearSize = ioimClearSize;
+	}
+
 	/** The default configuration for {@link FieldSerializer} instances. Already existing serializer instances (e.g. implicitely
 	 * created for already registered classes) are not affected by this configuration. You can override the configuration for a
 	 * single {@link FieldSerializer}. */
@@ -1155,6 +1168,11 @@ public class Kryo {
 	/** Returns the number of child objects away from the object graph root. */
 	public int getDepth () {
 		return depth;
+	}
+
+	/** Returns the size to resize to when clearing a resolver map if the map. */
+	public int getIdenityObjectIntMapClearSize() {
+		return this.ioimClearSize;
 	}
 
 	/** Returns the internal map of original to copy objects when a copy method is used. This can be used after a copy to map old

--- a/src/com/esotericsoftware/kryo/util/DefaultClassResolver.java
+++ b/src/com/esotericsoftware/kryo/util/DefaultClassResolver.java
@@ -177,7 +177,7 @@ public class DefaultClassResolver implements ClassResolver {
 
 	public void reset () {
 		if (!kryo.isRegistrationRequired()) {
-			if (classToNameId != null) classToNameId.clear(kryo.getIdenityObjectIntMapClearSize());
+			if (classToNameId != null) classToNameId.clearAndResize();
 			if (nameIdToClass != null) nameIdToClass.clear();
 			nextNameId = 0;
 		}

--- a/src/com/esotericsoftware/kryo/util/DefaultClassResolver.java
+++ b/src/com/esotericsoftware/kryo/util/DefaultClassResolver.java
@@ -177,7 +177,7 @@ public class DefaultClassResolver implements ClassResolver {
 
 	public void reset () {
 		if (!kryo.isRegistrationRequired()) {
-			if (classToNameId != null) classToNameId.clear(2048);
+			if (classToNameId != null) classToNameId.clear(kryo.getIdenityObjectIntMapClearSize());
 			if (nameIdToClass != null) nameIdToClass.clear();
 			nextNameId = 0;
 		}

--- a/src/com/esotericsoftware/kryo/util/IdentityObjectIntMap.java
+++ b/src/com/esotericsoftware/kryo/util/IdentityObjectIntMap.java
@@ -34,11 +34,11 @@ public class IdentityObjectIntMap<K> {
 	private static final int PRIME3 = 0xb4b82e39;
 	private static final int PRIME4 = 0xced1c241;
 
-	public int size;
+	private int size;
 
-	K[] keyTable;
-	int[] valueTable;
-	int capacity, stashSize;
+	private K[] keyTable;
+	private int[] valueTable;
+	private int capacity, stashSize;
 
 	private float loadFactor;
 	private int hashShift, mask, threshold;
@@ -521,6 +521,15 @@ public class IdentityObjectIntMap<K> {
 	public void ensureCapacity (int additionalCapacity) {
 		int sizeNeeded = size + additionalCapacity;
 		if (sizeNeeded >= threshold) resize(ObjectMap.nextPowerOfTwo((int)(sizeNeeded / loadFactor)));
+	}
+
+	/**
+	 * This method returns the current size of the map.
+	 *
+	 * @return The size of the map.
+	 */
+	public int size() {
+		return this.size();
 	}
 
 	private void resize (int newSize) {

--- a/src/com/esotericsoftware/kryo/util/IdentityObjectIntMap.java
+++ b/src/com/esotericsoftware/kryo/util/IdentityObjectIntMap.java
@@ -34,6 +34,8 @@ public class IdentityObjectIntMap<K> {
 	private static final int PRIME3 = 0xb4b82e39;
 	private static final int PRIME4 = 0xced1c241;
 
+	private static final int CLEAR_SIZE = 2048;
+
 	private int size;
 
 	private K[] keyTable;
@@ -452,13 +454,13 @@ public class IdentityObjectIntMap<K> {
 	}
 
 	/** Clears the map and reduces the size of the backing arrays to be the specified capacity if they are larger. */
-	public void clear (int maximumCapacity) {
-		if (capacity <= maximumCapacity) {
+	public void clearAndResize () {
+		if (capacity <= CLEAR_SIZE) {
 			clear();
 			return;
 		}
 		size = 0;
-		resize(maximumCapacity);
+		resize(CLEAR_SIZE);
 	}
 
 	public void clear () {
@@ -523,12 +525,8 @@ public class IdentityObjectIntMap<K> {
 		if (sizeNeeded >= threshold) resize(ObjectMap.nextPowerOfTwo((int)(sizeNeeded / loadFactor)));
 	}
 
-	/**
-	 * This method returns the current size of the map.
-	 *
-	 * @return The size of the map.
-	 */
-	public int size() {
+	/** This method returns the current size of the map. */
+	public int size () {
 		return this.size();
 	}
 

--- a/src/com/esotericsoftware/kryo/util/MapReferenceResolver.java
+++ b/src/com/esotericsoftware/kryo/util/MapReferenceResolver.java
@@ -62,7 +62,7 @@ public class MapReferenceResolver implements ReferenceResolver {
 
 	public void reset () {
 		readObjects.clear();
-		writtenObjects.clear(kryo.getIdenityObjectIntMapClearSize());
+		writtenObjects.clearAndResize();
 	}
 
 	/** Returns false for all primitive wrappers. */

--- a/src/com/esotericsoftware/kryo/util/MapReferenceResolver.java
+++ b/src/com/esotericsoftware/kryo/util/MapReferenceResolver.java
@@ -37,7 +37,7 @@ public class MapReferenceResolver implements ReferenceResolver {
 	}
 
 	public int addWrittenObject (Object object) {
-		int id = writtenObjects.size;
+		int id = writtenObjects.size();
 		writtenObjects.put(object, id);
 		return id;
 	}
@@ -62,7 +62,7 @@ public class MapReferenceResolver implements ReferenceResolver {
 
 	public void reset () {
 		readObjects.clear();
-		writtenObjects.clear(2048);
+		writtenObjects.clear(kryo.getIdenityObjectIntMapClearSize());
 	}
 
 	/** Returns false for all primitive wrappers. */


### PR DESCRIPTION
There was a recent change to use a default size of 2048 when reseting the backing map for resolvers. I have made this a configurable option in the Kryo class. Additionally, I have made several core fields in IndentityObjectIntMap private. This actually causes issues with the build as it detects I have taken something away when it does compatibility checks. If you give me a hint how to fix that, I will. Also, feel free to suggest better names for everything.