### PR TITLE
Use public member instead of private field to resolve immutability

### DIFF
--- a/src/com/esotericsoftware/kryo/Serializer.java
+++ b/src/com/esotericsoftware/kryo/Serializer.java
@@ -100,7 +100,7 @@ public abstract class Serializer<T> {
 	 * This method should not be called directly, instead this serializer can be passed to {@link Kryo} copy methods that accept a
 	 * serialier. */
 	public T copy (Kryo kryo, T original) {
-		if (immutable) return original;
+		if (isImmutable()) return original;
 		throw new KryoException("Serializer does not support copy: " + getClass().getName());
 	}
 }


### PR DESCRIPTION
Current com.esotericsoftware.kryo.Serializer::copy function determines immutability through its private field instead of it's public isImmutable() member (which docs actually mention). Since isImmutable() is virtual, this could break the copy api.

Note that this actually occurs in the Scala serializers provided by Twitter's Chill ([Traversable.scala](https://github.com/twitter/chill/blob/master/chill-scala/src/main/scala/com/twitter/chill/Traversable.scala)) and causes lot's of KryoException to be thrown in Apache Flink + Scala usage (one could argue the Twitter serializer implementations are to blame.. or chaning member isImmutable() to be **final** would be a preferred option, but that would break API compatibility)