### PR TITLE
Add travis build config

### DIFF
--- a/.settings.xml
+++ b/.settings.xml
@@ -1,0 +1,11 @@
+<!-- settings.xml -->
+<settings>
+<servers>
+    <server>
+        <!-- Maven Central Deployment -->
+        <id>sonatype-nexus-snapshots</id>
+        <username>${env.SONATYPE_USERNAME}</username>
+        <password>${env.SONATYPE_PASSWORD}</password>
+    </server>
+</servers>
+</settings>

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,35 @@
+language: java
+
+env:
+  global:
+    - SONATYPE_USERNAME=martin.grotzke
+    - secure: "IYbrSnn752JOqst10hQ/8DdLvP5vOr+xmM8fgkz8jwUqWhjdz47Hrw+X/uzNx+U4FfaDQeWKBHzb/ysxBDXf0X1NBzRN8vWXUCe6vo/mp+lCXLCzpDk0tBCJFauw9lMpIWqSdAA9X9MMvAUyb9Iux4Rgj+ZCobzdomSkSI0HVFs="
+  
+jdk:
+  #- openjdk7
+  - oraclejdk8
+
+install:
+  # compile and test java 8
+  - mvn -B -V -f pom-main.xml clean test
+
+script:
+  # compile tests with java 8, but with testSource/testTarget 1.7 (disabled java8 profile), so that we can run tests with java 7
+  - jdk_switcher use oraclejdk8
+  - mvn -B -f pom-main.xml -P!java8 clean install
+  # test java 7
+  - jdk_switcher use openjdk7
+  - mvn -B -f pom-main.xml surefire:test
+
+after_success:
+  # install and publish snapshot with java 8
+  - jdk_switcher use oraclejdk8
+  - test $TRAVIS_BRANCH = "master" && test $TRAVIS_PULL_REQUEST = "false" && mvn -B -P requireSnapshot -DskipTests=true deploy --settings .settings.xml
+  #- mvn -B -P requireSnapshot -DskipTests=true deploy --settings .settings.xml
+
+cache:
+  directories:
+    - $HOME/.m2
+
+# use container
+sudo: false

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![KryoNet](https://raw.github.com/wiki/EsotericSoftware/kryo/images/logo.jpg)
 
-[![Build Status](https://jenkins.inoio.de/buildStatus/icon?job=kryo&foo=bar)](https://jenkins.inoio.de/job/kryo/)
+[![Build Status](https://travis-ci.org/EsotericSoftware/kryo.png?branch=master)](https://travis-ci.org/EsotericSoftware/kryo)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.esotericsoftware/kryo/badge.svg)](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22com.esotericsoftware%22%20AND%20a%3Akryo)
 [![Join the chat at https://gitter.im/EsotericSoftware/kryo](https://badges.gitter.im/EsotericSoftware/kryo.svg)](https://gitter.im/EsotericSoftware/kryo)
 


### PR DESCRIPTION
Tests with java8 and java7, on successful build publishes the artifacts to sonatype snapshots.

The inoio jenkins required too much maintenance and became unstable the last days.
We also need travis to be able to build/test with jdk 9/10.
An additional advantage of Travis are PR verification builds, so that it's immediately clear if anything got broken. 

@NathanSweet can you please activate the Travis build according to 2. from the [Getting Started guide](https://docs.travis-ci.com/user/getting-started/#To-get-started-with-Travis-CI)?