### PR TITLE
WIP: Pooled IO objects.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,8 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<versions.reflectasm>1.11.3</versions.reflectasm>
+		<reflectasm.version>1.11.3</reflectasm.version>
+		<jmh.version>1.19</jmh.version>
 		<test.exclude>**/Java8*Test.java</test.exclude>
 	</properties>
 	
@@ -51,13 +52,13 @@
 			<dependency>
 				<groupId>com.esotericsoftware</groupId>
 				<artifactId>reflectasm</artifactId>
-				<version>${versions.reflectasm}</version>
+				<version>${reflectasm.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>com.esotericsoftware</groupId>
 				<artifactId>reflectasm</artifactId>
 				<classifier>shaded</classifier>
-				<version>${versions.reflectasm}</version>
+				<version>${reflectasm.version}</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>
@@ -83,6 +84,18 @@
 			<groupId>commons-lang</groupId>
 			<artifactId>commons-lang</artifactId>
 			<version>2.6</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.openjdk.jmh</groupId>
+			<artifactId>jmh-core</artifactId>
+			<version>${jmh.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.openjdk.jmh</groupId>
+			<artifactId>jmh-generator-annprocess</artifactId>
+			<version>${jmh.version}</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
@@ -115,6 +128,23 @@
 			</plugins>
 		</pluginManagement>
 		<plugins>
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>build-helper-maven-plugin</artifactId>
+				<executions>
+					<execution>
+						<phase>generate-sources</phase>
+						<goals>
+							<goal>add-test-source</goal>
+						</goals>
+						<configuration>
+							<sources>
+								<source>pref</source>
+							</sources>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
 			<!-- Disable resources (project has none) -->
 			<plugin>
 				<artifactId>maven-resources-plugin</artifactId>

--- a/pref/com/esotericsoftware/kryo/pool/KryoIOPoolTest.java
+++ b/pref/com/esotericsoftware/kryo/pool/KryoIOPoolTest.java
@@ -1,0 +1,132 @@
+/* Copyright (c) 2008, Nathan Sweet
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following
+ * conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the distribution.
+ * - Neither the name of Esoteric Software nor the names of its contributors may be used to endorse or promote products derived
+ * from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
+ * BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. */
+
+package com.esotericsoftware.kryo.pool;
+
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+
+/** @author Johno Crawford (johno.crawford@gmail.com) */
+@Fork(5)
+@State(Scope.Thread)
+public class KryoIOPoolTest {
+
+    @Param({ "1024", "4096" })
+    public int bufferSize;
+
+    private KryoPool kryoPool;
+    private KryoOutputPool outputPool;
+    private KryoInputPool inputPool;
+    private Message message;
+    private byte[] messageBytes;
+
+    @Setup
+    public void setup() {
+        kryoPool = new KryoPool.Builder(new KryoFactory() {
+            public Kryo create () {
+                return new Kryo();
+            }
+        }).softReferences().build();
+        outputPool = new KryoOutputPool.Builder().softReferences().maxPooledBufferSize(512 * 1024).maxBufferSize(768 * 1024).build();
+        inputPool = new KryoInputPool.Builder().softReferences().maxPooledBufferSize(512 * 1024).build();
+        message = new Message();
+        message.payload = new byte[4 * 1024];
+        messageBytes = outputPool.run(new KryoIOCallback<Output, byte[]>() {
+            public byte[] apply(final Output output) {
+                return kryoPool.run(new KryoCallback<byte[]>() {
+                    public byte[] execute(Kryo kryo) {
+                        kryo.writeClassAndObject(output, message);
+                        return output.toBytes();
+                    }
+                });
+            }
+        }, bufferSize);
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    public byte[] testPooledOutput() throws Exception {
+        return outputPool.run(new KryoIOCallback<Output, byte[]>() {
+            public byte[] apply(final Output output) {
+                return kryoPool.run(new KryoCallback<byte[]>() {
+                    public byte[] execute(Kryo kryo) {
+                        kryo.writeClassAndObject(output, "huuhaa");
+                        return output.toBytes();
+                    }
+                });
+            }
+        }, bufferSize);
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    public byte[] testOutput() throws Exception {
+        return kryoPool.run(new KryoCallback<byte[]>() {
+            public byte[] execute(Kryo kryo) {
+                Output output = new Output(bufferSize);
+                kryo.writeClassAndObject(output, "huuhaa");
+                return output.toBytes();
+            }
+        });
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    public Message testPooledInput() throws Exception {
+        return inputPool.run(new KryoIOCallback<Input, Message>() {
+            public Message apply(final Input input) {
+                input.setBuffer(messageBytes);
+                return kryoPool.run(new KryoCallback<Message>() {
+                    public Message execute(Kryo kryo) {
+                        @SuppressWarnings("unchecked")
+                        Message obj = (Message) kryo.readClassAndObject(input);
+                        return obj;
+                    }
+                });
+            }
+        }, bufferSize);
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    public Message testInput() throws Exception {
+        final Input input = new Input(bufferSize);
+        input.setBuffer(messageBytes);
+        return kryoPool.run(new KryoCallback<Message>() {
+            public Message execute(Kryo kryo) {
+                @SuppressWarnings("unchecked")
+                Message obj = (Message) kryo.readClassAndObject(input);
+                return obj;
+            }
+        });
+    }
+
+    public static final class Message {
+        public byte[] payload;
+    }
+}

--- a/src/com/esotericsoftware/kryo/pool/KryoIOCallback.java
+++ b/src/com/esotericsoftware/kryo/pool/KryoIOCallback.java
@@ -1,0 +1,27 @@
+/* Copyright (c) 2008, Nathan Sweet
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following
+ * conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the distribution.
+ * - Neither the name of Esoteric Software nor the names of its contributors may be used to endorse or promote products derived
+ * from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
+ * BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. */
+
+package com.esotericsoftware.kryo.pool;
+
+/** Callback to run with a provided Kryo IO object.
+ *
+ * @author Johno Crawford (johno.crawford@gmail.com) */
+public interface KryoIOCallback<T, R> {
+    R apply(T t);
+}

--- a/src/com/esotericsoftware/kryo/pool/KryoIOPoolQueueImpl.java
+++ b/src/com/esotericsoftware/kryo/pool/KryoIOPoolQueueImpl.java
@@ -1,0 +1,57 @@
+/* Copyright (c) 2008, Nathan Sweet
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following
+ * conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the distribution.
+ * - Neither the name of Esoteric Software nor the names of its contributors may be used to endorse or promote products derived
+ * from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
+ * BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. */
+
+package com.esotericsoftware.kryo.pool;
+
+import java.util.Queue;
+
+/** A simple {@link Queue} based pool.
+ *
+ * @author Johno Crawford (johno.crawford@gmail.com) */
+abstract class KryoIOPoolQueueImpl<T> {
+
+    private final Queue<T> queue;
+
+    KryoIOPoolQueueImpl(Queue<T> queue) {
+        this.queue = queue;
+    }
+
+    private T borrow(final int bufferSize) {
+        final T element = queue.poll();
+        if (element != null) {
+            return element;
+        }
+        return create(bufferSize);
+    }
+
+    protected abstract T create(final int bufferSize);
+
+    protected void release(final T element) {
+        queue.offer(element);
+    }
+
+    public <R> R run(final KryoIOCallback<T, R> callback, final int bufferSize) {
+        final T element = borrow(bufferSize);
+        try {
+            return callback.apply(element);
+        } finally {
+            release(element);
+        }
+    }
+}

--- a/src/com/esotericsoftware/kryo/pool/KryoInputPool.java
+++ b/src/com/esotericsoftware/kryo/pool/KryoInputPool.java
@@ -1,0 +1,62 @@
+/* Copyright (c) 2008, Nathan Sweet
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following
+ * conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the distribution.
+ * - Neither the name of Esoteric Software nor the names of its contributors may be used to endorse or promote products derived
+ * from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
+ * BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. */
+
+package com.esotericsoftware.kryo.pool;
+
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.io.Input;
+
+import java.lang.ref.SoftReference;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+/** A simple pool interface for {@link Input} instances. Use the {@link KryoInputPool.Builder} to construct a pool instance.
+ *
+ * @author Johno Crawford (johno.crawford@gmail.com) */
+public interface KryoInputPool {
+
+    int DEFAULT_MAX_POOLED_BUFFER_SIZE = 512 * 1024;
+
+    <R> R run(final KryoIOCallback<Input, R> callback, final int bufferSize);
+
+    class Builder {
+
+        private int maxPooledBufferSize = DEFAULT_MAX_POOLED_BUFFER_SIZE;
+        private boolean softReferences;
+
+        /** Use {@link SoftReference}s for pooled {@link Kryo} instances, so that instances may be garbage collected when there's
+         * memory demand (by default disabled). */
+        public KryoInputPool.Builder softReferences() {
+            softReferences = true;
+            return this;
+        }
+
+        /** Objects larger than <code>maxPooledBufferSize</code> will not be recycled. */
+        public KryoInputPool.Builder maxPooledBufferSize(int maxPooledBufferSize) {
+            this.maxPooledBufferSize = maxPooledBufferSize;
+            return this;
+        }
+
+        /** Build the pool. */
+        public KryoInputPool build () {
+            return new KryoInputPoolImpl(softReferences ?
+                    new SoftReferenceQueue<Input>(new ConcurrentLinkedQueue<Input>()) :
+                    new ConcurrentLinkedQueue<Input>(), maxPooledBufferSize);
+        }
+    }
+}

--- a/src/com/esotericsoftware/kryo/pool/KryoInputPoolImpl.java
+++ b/src/com/esotericsoftware/kryo/pool/KryoInputPoolImpl.java
@@ -1,0 +1,50 @@
+/* Copyright (c) 2008, Nathan Sweet
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following
+ * conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the distribution.
+ * - Neither the name of Esoteric Software nor the names of its contributors may be used to endorse or promote products derived
+ * from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
+ * BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. */
+
+package com.esotericsoftware.kryo.pool;
+
+import com.esotericsoftware.kryo.io.Input;
+
+import java.util.Queue;
+
+/** A simple {@link Queue} based {@link KryoInputPool} implementation, should be built using the KryoInputPool.Builder.
+ *
+ * @author Johno Crawford (johno.crawford@gmail.com) */
+class KryoInputPoolImpl extends KryoIOPoolQueueImpl<Input> implements KryoInputPool {
+
+    private final int maxPooledBufferSize;
+
+    KryoInputPoolImpl(Queue<Input> queue, int maxPooledBufferSize) {
+        super(queue);
+        this.maxPooledBufferSize = maxPooledBufferSize;
+    }
+
+    @Override
+    protected Input create(final int bufferSize) {
+        return new Input(bufferSize);
+    }
+
+    @Override
+    protected void release(Input input) {
+        if (input.getBuffer().length < maxPooledBufferSize) {
+            input.setInputStream(null);
+            super.release(input);
+        }
+    }
+}

--- a/src/com/esotericsoftware/kryo/pool/KryoOutputPool.java
+++ b/src/com/esotericsoftware/kryo/pool/KryoOutputPool.java
@@ -1,0 +1,70 @@
+/* Copyright (c) 2008, Nathan Sweet
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following
+ * conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the distribution.
+ * - Neither the name of Esoteric Software nor the names of its contributors may be used to endorse or promote products derived
+ * from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
+ * BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. */
+
+package com.esotericsoftware.kryo.pool;
+
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.io.Output;
+
+import java.lang.ref.SoftReference;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+/** A simple pool interface for {@link Output} instances. Use the {@link KryoOutputPool.Builder} to construct a pool instance.
+ *
+ * @author Johno Crawford (johno.crawford@gmail.com) */
+public interface KryoOutputPool {
+
+    int DEFAULT_MAX_POOLED_BUFFER_SIZE = 512 * 1024;
+    int DEFAULT_MAX_BUFFER_SIZE = 768 * 1024;
+
+    <R> R run(final KryoIOCallback<Output, R> callback, final int bufferSize);
+
+    class Builder {
+
+        private int maxPooledBufferSize = DEFAULT_MAX_POOLED_BUFFER_SIZE;
+        private int maxBufferSize = DEFAULT_MAX_BUFFER_SIZE;
+        private boolean softReferences;
+
+        /** Use {@link SoftReference}s for pooled {@link Kryo} instances, so that instances may be garbage collected when there's
+         * memory demand (by default disabled). */
+        public KryoOutputPool.Builder softReferences() {
+            softReferences = true;
+            return this;
+        }
+
+        /** Objects larger than <code>maxPooledBufferSize</code> will not be recycled. */
+        public KryoOutputPool.Builder maxPooledBufferSize(int maxPooledBufferSize) {
+            this.maxPooledBufferSize = maxPooledBufferSize;
+            return this;
+        }
+
+        /** The maximum buffer size for the underlying {@link Output}. */
+        public KryoOutputPool.Builder maxBufferSize(int maxBufferSize) {
+            this.maxBufferSize = maxBufferSize;
+            return this;
+        }
+
+        /** Build the pool. */
+        public KryoOutputPool build () {
+            return new KryoOutputPoolImpl(softReferences ?
+                    new SoftReferenceQueue<Output>(new ConcurrentLinkedQueue<Output>()) :
+                    new ConcurrentLinkedQueue<Output>(), maxPooledBufferSize, maxBufferSize);
+        }
+    }
+}

--- a/src/com/esotericsoftware/kryo/pool/KryoOutputPoolImpl.java
+++ b/src/com/esotericsoftware/kryo/pool/KryoOutputPoolImpl.java
@@ -1,0 +1,52 @@
+/* Copyright (c) 2008, Nathan Sweet
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following
+ * conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the distribution.
+ * - Neither the name of Esoteric Software nor the names of its contributors may be used to endorse or promote products derived
+ * from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
+ * BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. */
+
+package com.esotericsoftware.kryo.pool;
+
+import com.esotericsoftware.kryo.io.Output;
+
+import java.util.Queue;
+
+/** A simple {@link Queue} based {@link KryoOutputPool} implementation, should be built using the KryoOutputPool.Builder.
+ *
+ * @author Johno Crawford (johno.crawford@gmail.com) */
+class KryoOutputPoolImpl extends KryoIOPoolQueueImpl<Output> implements KryoOutputPool {
+
+    private final int maxPooledBufferSize;
+    private final int maxBufferSize;
+
+    KryoOutputPoolImpl(Queue<Output> queue, int maxPooledBufferSize, int maxBufferSize) {
+        super(queue);
+        this.maxPooledBufferSize = maxPooledBufferSize;
+        this.maxBufferSize = maxBufferSize;
+    }
+
+    @Override
+    protected Output create(final int bufferSize) {
+        return new Output(bufferSize, maxBufferSize);
+    }
+
+    @Override
+    protected void release(Output output) {
+        if (output.getBuffer().length < maxPooledBufferSize) {
+            output.clear();
+            super.release(output);
+        }
+    }
+}

--- a/src/com/esotericsoftware/kryo/pool/SoftReferenceQueue.java
+++ b/src/com/esotericsoftware/kryo/pool/SoftReferenceQueue.java
@@ -24,23 +24,21 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.Queue;
 
-import com.esotericsoftware.kryo.Kryo;
-
-/** Internally uses {@link SoftReference}s for queued Kryo instances, most importantly adjusts the {@link Queue#poll() poll}
- * behavior so that gc'ed Kryo instances are skipped. Most other methods are unsupported.
+/** Internally uses {@link SoftReference}s for queued objects, most importantly adjusts the {@link Queue#poll() poll}
+ * behavior so that gc'ed objects are skipped. Most other methods are unsupported.
  *
  * @author Martin Grotzke */
-class SoftReferenceQueue implements Queue<Kryo> {
+class SoftReferenceQueue<T> implements Queue<T> {
 
-	private Queue<SoftReference<Kryo>> delegate;
+	private final Queue<SoftReference<T>> delegate;
 
-	public SoftReferenceQueue (Queue<?> delegate) {
-		this.delegate = (Queue<SoftReference<Kryo>>)delegate;
+	public SoftReferenceQueue (Queue<T> delegate) {
+		this.delegate = (Queue<SoftReference<T>>)delegate;
 	}
 
-	public Kryo poll () {
-		Kryo res;
-		SoftReference<Kryo> ref;
+	public T poll () {
+		T res;
+		SoftReference<T> ref;
 		while ((ref = delegate.poll()) != null) {
 			if ((res = ref.get()) != null) {
 				return res;
@@ -49,12 +47,12 @@ class SoftReferenceQueue implements Queue<Kryo> {
 		return null;
 	}
 
-	public boolean offer (Kryo e) {
-		return delegate.offer(new SoftReference(e));
+	public boolean offer (T e) {
+		return delegate.offer(new SoftReference<T>(e));
 	}
 
-	public boolean add (Kryo e) {
-		return delegate.add(new SoftReference(e));
+	public boolean add (T e) {
+		return delegate.add(new SoftReference<T>(e));
 	}
 
 	public int size () {
@@ -86,11 +84,11 @@ class SoftReferenceQueue implements Queue<Kryo> {
 		return getClass().getSimpleName() + super.toString();
 	}
 
-	public Iterator<Kryo> iterator () {
+	public Iterator<T> iterator () {
 		throw new UnsupportedOperationException();
 	}
 
-	public Kryo remove () {
+	public T remove () {
 		throw new UnsupportedOperationException();
 	}
 
@@ -98,11 +96,11 @@ class SoftReferenceQueue implements Queue<Kryo> {
 		throw new UnsupportedOperationException();
 	}
 
-	public Kryo element () {
+	public T element () {
 		throw new UnsupportedOperationException();
 	}
 
-	public Kryo peek () {
+	public T peek () {
 		throw new UnsupportedOperationException();
 	}
 
@@ -118,7 +116,7 @@ class SoftReferenceQueue implements Queue<Kryo> {
 		throw new UnsupportedOperationException();
 	}
 
-	public boolean addAll (Collection<? extends Kryo> c) {
+	public boolean addAll (Collection<? extends T> c) {
 		throw new UnsupportedOperationException();
 	}
 

--- a/test/com/esotericsoftware/kryo/pool/KryoInputPoolTest.java
+++ b/test/com/esotericsoftware/kryo/pool/KryoInputPoolTest.java
@@ -1,0 +1,89 @@
+/* Copyright (c) 2008, Nathan Sweet
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following
+ * conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the distribution.
+ * - Neither the name of Esoteric Software nor the names of its contributors may be used to endorse or promote products derived
+ * from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
+ * BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. */
+
+package com.esotericsoftware.kryo.pool;
+
+import com.esotericsoftware.kryo.io.Input;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/** @author Johno Crawford (johno.crawford@gmail.com) */
+@RunWith(Parameterized.class)
+public class KryoInputPoolTest {
+
+    @Parameterized.Parameters
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][] {{new KryoInputPool.Builder()}, {new KryoInputPool.Builder().softReferences()}});
+    }
+
+    private KryoInputPool pool;
+
+    public KryoInputPoolTest(KryoInputPool.Builder builder) {
+        pool = builder.build();
+    }
+
+    @Test
+    public void getShouldReturnAvailableInstance() {
+        final Input[] result = new Input[2];
+        pool.run(new KryoIOCallback<Input, Object>() {
+            public Object apply(Input input) {
+                assertEquals(0, input.position());
+                byte[] payload = new byte[] {1,2,3,4};
+                input.setBuffer(payload);
+                assertArrayEquals(payload, input.readBytes(4));
+                result[0] = input;
+                return null;
+            }
+        }, 0);
+        assertEquals(0, result[0].position());
+        pool.run(new KryoIOCallback<Input, Object>() {
+            public Object apply(Input input) {
+                result[1] = input;
+                return null;
+            }
+        }, 0);
+        assertTrue(result[0] == result[1]);
+    }
+
+    @Test
+    public void largeObjectNotRecycled() {
+        final Input[] result = new Input[2];
+        pool.run(new KryoIOCallback<Input, Object>() {
+            public Object apply(Input input) {
+                result[0] = input;
+                return null;
+            }
+        }, KryoInputPool.DEFAULT_MAX_POOLED_BUFFER_SIZE + 1);
+        pool.run(new KryoIOCallback<Input, Object>() {
+            public Object apply(Input input) {
+                result[1] = input;
+                return null;
+            }
+        }, 0);
+        assertTrue(result[0] != result[1]);
+    }
+}

--- a/test/com/esotericsoftware/kryo/pool/KryoOutputPoolTest.java
+++ b/test/com/esotericsoftware/kryo/pool/KryoOutputPoolTest.java
@@ -1,0 +1,87 @@
+/* Copyright (c) 2008, Nathan Sweet
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following
+ * conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the distribution.
+ * - Neither the name of Esoteric Software nor the names of its contributors may be used to endorse or promote products derived
+ * from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
+ * BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. */
+
+package com.esotericsoftware.kryo.pool;
+
+import com.esotericsoftware.kryo.io.Output;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/** @author Johno Crawford (johno.crawford@gmail.com) */
+@RunWith(Parameterized.class)
+public class KryoOutputPoolTest {
+
+    @Parameterized.Parameters
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][] {{new KryoOutputPool.Builder()}, {new KryoOutputPool.Builder().softReferences()}});
+    }
+
+    private KryoOutputPool pool;
+
+    public KryoOutputPoolTest(KryoOutputPool.Builder builder) {
+        pool = builder.build();
+    }
+
+    @Test
+    public void getShouldReturnAvailableInstance() {
+        final Output[] result = new Output[2];
+        pool.run(new KryoIOCallback<Output, Object>() {
+            public Object apply(Output output) {
+                output.writeInt(1);
+                assertEquals(4 /* size of int */, output.position());
+                result[0] = output;
+                return null;
+            }
+        }, 0);
+        assertEquals(0, result[0].position());
+        pool.run(new KryoIOCallback<Output, Object>() {
+            public Object apply(Output output) {
+                assertEquals(0, output.position());
+                result[1] = output;
+                return null;
+            }
+        }, 0);
+        assertTrue(result[0] == result[1]);
+    }
+
+    @Test
+    public void largeObjectNotRecycled() {
+        final Output[] result = new Output[2];
+        pool.run(new KryoIOCallback<Output, Object>() {
+            public Object apply(Output output) {
+                result[0] = output;
+                return null;
+            }
+        }, KryoOutputPool.DEFAULT_MAX_POOLED_BUFFER_SIZE + 1);
+        pool.run(new KryoIOCallback<Output, Object>() {
+            public Object apply(Output output) {
+                result[1] = output;
+                return null;
+            }
+        }, 0);
+        assertTrue(result[0] != result[1]);
+    }
+}


### PR DESCRIPTION
180% increase in throughput using pooled Output objects with default buffer size of 4096.

```
Benchmark                       (bufferSize)   Mode  Cnt        Score        Error  Units
KryoIOPoolTest.testOutput                1024  thrpt   40  4175474.459 ± 143755.009  ops/s
KryoIOPoolTest.testOutput                4096  thrpt   40  2371639.643 ±  73842.631  ops/s
KryoIOPoolTest.testPooledOutput          1024  thrpt   40  6643300.248 ± 217470.355  ops/s
KryoIOPoolTest.testPooledOutput          4096  thrpt   40  6653441.255 ± 266002.330  ops/s
```

```
Benchmark                       (bufferSize)   Mode  Cnt        Score       Error  Units
KryoIOPoolTest.testInput                1024  thrpt   40  1087908.503 ± 20258.313  ops/s
KryoIOPoolTest.testInput                4096  thrpt   40   898640.372 ±  7628.268  ops/s
KryoIOPoolTest.testPooledInput          1024  thrpt   40  1194824.270 ± 14490.884  ops/s
KryoIOPoolTest.testPooledInput          4096  thrpt   40  1321546.126 ± 67599.732  ops/s
```