### PR TITLE
Add module for JMH benchmarks and sample benchmark

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,15 @@
+# Kryo JMH Benchmarks
+
+This module contains JMH benchmarks for Kryo.
+
+## Usage
+
+To run benchmarks execute
+```
+mvn -f benchmarks/pom.xml compile exec:java
+```
+
+JMH options can be set via `-Dexec.args`, e.g.
+```
+mvn -f benchmarks/pom.xml compile exec:java -Dexec.args="-incl FieldSerializersBenchmark -f 2 -t 2 -wi 10 -i 10"
+```

--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -1,0 +1,147 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.esotericsoftware</groupId>
+        <artifactId>kryo-parent</artifactId>
+        <version>4.0.3-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>kryo-benchmarks</artifactId>
+    <packaging>jar</packaging>
+    <name>Kryo JMH Benchmarks</name>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <jmh.version>1.20</jmh.version>
+        <javac.target>1.8</javac.target>
+        <uberjar.name>benchmarks</uberjar.name>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.esotericsoftware</groupId>
+            <artifactId>kryo</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>commons-cli</groupId>
+            <artifactId>commons-cli</artifactId>
+            <version>1.3.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-core</artifactId>
+            <version>${jmh.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-generator-annprocess</artifactId>
+            <version>${jmh.version}</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+
+        <sourceDirectory>src/main/java</sourceDirectory>
+
+
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.1</version>
+                <configuration>
+                    <compilerVersion>${javac.target}</compilerVersion>
+                    <source>${javac.target}</source>
+                    <target>${javac.target}</target>
+                </configuration>
+            </plugin>
+
+
+            <plugin>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>build-classpath</id>
+                        <goals>
+                            <goal>build-classpath</goal>
+                        </goals>
+                        <configuration>
+                            <includeScope>runtime</includeScope>
+                            <outputProperty>depClasspath</outputProperty>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>1.4.0</version>
+                <executions>
+                    <execution>
+                        <id>run-tests</id>
+                        <goals>
+                            <goal>java</goal>
+                        </goals>
+                    </execution>
+
+                </executions>
+                <configuration>
+                    <mainClass>com.esotericsoftware.kryo.KryoBenchmarks</mainClass>
+                    <systemProperties>
+                        <systemProperty>
+                            <key>java.class.path</key>
+                            <value>${project.build.outputDirectory}${path.separator}${depClasspath}</value>
+                        </systemProperty>
+                    </systemProperties>
+                </configuration>
+            </plugin>
+
+        </plugins>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <artifactId>maven-clean-plugin</artifactId>
+                    <version>2.5</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-deploy-plugin</artifactId>
+                    <version>2.8.1</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-install-plugin</artifactId>
+                    <version>2.5.1</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-jar-plugin</artifactId>
+                    <version>2.4</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-javadoc-plugin</artifactId>
+                    <version>2.9.1</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-resources-plugin</artifactId>
+                    <version>2.6</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-site-plugin</artifactId>
+                    <version>3.3</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-source-plugin</artifactId>
+                    <version>2.2.1</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>2.17</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
+
+</project>

--- a/benchmarks/src/main/java/com/esotericsoftware/kryo/KryoBenchmarks.java
+++ b/benchmarks/src/main/java/com/esotericsoftware/kryo/KryoBenchmarks.java
@@ -1,0 +1,78 @@
+/* Copyright (c) 2018, Nathan Sweet
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following
+ * conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the distribution.
+ * - Neither the name of Esoteric Software nor the names of its contributors may be used to endorse or promote products derived
+ * from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
+ * BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.esotericsoftware.kryo;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.CommandLineParser;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.Option;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+public class KryoBenchmarks {
+
+	/*
+	 * To run, in command-line: $ mvn clean install exec:java -Dexec.args="-wi 10 -i 10"
+	 */
+    public static void main(String[] args) throws Exception {
+
+		org.apache.commons.cli.Options cliOptions = new org.apache.commons.cli.Options();
+
+		Option includeOption   = Option.builder( "incl" ).argName("include").hasArg().build();
+		Option forksOption   = Option.builder( "f" ).argName("forks").hasArg().build();
+		Option warmupIterationsOption   = Option.builder( "wi" ).argName("warmupIterations").hasArg().build();
+		Option iterationsOption   = Option.builder( "i" ).argName("iterations").hasArg().build();
+		Option threadsOption   = Option.builder( "t" ).argName("threads").hasArg().build();
+
+		cliOptions.addOption(includeOption);
+		cliOptions.addOption(forksOption);
+		cliOptions.addOption(warmupIterationsOption);
+		cliOptions.addOption(iterationsOption);
+		cliOptions.addOption(threadsOption);
+
+		CommandLineParser parser = new DefaultParser();
+		CommandLine cl = parser.parse(cliOptions, args);
+
+		String include = cl.getOptionValue(includeOption.getOpt(), "Benchmark");
+		int forks = intValue(cl, forksOption, "1");
+		int warmupIterations = intValue(cl, warmupIterationsOption, "10");
+		int iterations = intValue(cl, iterationsOption, "5");
+		int threads = intValue(cl, threadsOption, "1");
+
+        Options options = new OptionsBuilder()
+                .include(include)
+				.forks(forks)
+				// .mode(Mode.SampleTime)
+				// .timeUnit(TimeUnit.NANOSECONDS)
+				.warmupIterations(warmupIterations)
+				.measurementIterations(iterations)
+				.threads(threads)
+				.build();
+
+        new Runner(options).run();
+    }
+
+    private static int intValue(CommandLine cl, Option o, String defaultValue) {
+    	return Integer.parseInt(cl.getOptionValue(o.getOpt(), defaultValue));
+	}
+
+}

--- a/benchmarks/src/main/java/com/esotericsoftware/kryo/KryoFieldSerializersBenchmark.java
+++ b/benchmarks/src/main/java/com/esotericsoftware/kryo/KryoFieldSerializersBenchmark.java
@@ -1,0 +1,159 @@
+/* Copyright (c) 2018, Nathan Sweet
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following
+ * conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the distribution.
+ * - Neither the name of Esoteric Software nor the names of its contributors may be used to endorse or promote products derived
+ * from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
+ * BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.esotericsoftware.kryo;
+
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+import com.esotericsoftware.kryo.serializers.CompatibleFieldSerializer;
+import com.esotericsoftware.kryo.serializers.FieldSerializer;
+import com.esotericsoftware.kryo.serializers.TaggedFieldSerializer;
+import com.esotericsoftware.kryo.serializers.VersionFieldSerializer;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.infra.Blackhole;
+
+public class KryoFieldSerializersBenchmark {
+
+	private static class BenchmarkState {
+
+		Kryo kryo;
+		byte[] out;
+		Output output;
+		SampleObject1 obj;
+
+		void setup(Class<? extends Serializer> defaultSerializer) {
+			kryo = new Kryo();
+			kryo.setDefaultSerializer(defaultSerializer);
+			kryo.setRegistrationRequired(true);
+			kryo.register(double[].class);
+			kryo.register(long[].class);
+			kryo.register(SampleObject1.class);
+
+			out = new byte[1024];
+			output = new Output(out);
+
+			obj = SampleObject1.createSample();
+		}
+	}
+
+	@State(Scope.Thread)
+	public static class FieldSerializerState extends BenchmarkState {
+		@Setup(Level.Invocation)
+		public void setup() {
+			super.setup(FieldSerializer.class);
+		}
+	}
+
+	@State(Scope.Thread)
+	public static class CompatibleFieldSerializerState extends BenchmarkState {
+		@Setup(Level.Invocation)
+		public void setup() {
+			super.setup(CompatibleFieldSerializer.class);
+		}
+	}
+
+	@State(Scope.Thread)
+	public static class TaggedFieldSerializerState extends BenchmarkState {
+		@Setup(Level.Invocation)
+		public void setup() {
+			super.setup(TaggedFieldSerializer.class);
+		}
+	}
+
+	@State(Scope.Thread)
+	public static class VersionFieldSerializerState extends BenchmarkState {
+		@Setup(Level.Invocation)
+		public void setup() {
+			super.setup(VersionFieldSerializer.class);
+		}
+	}
+
+	@State(Scope.Thread)
+	public static class CustomSerializerState extends BenchmarkState {
+		@Setup(Level.Invocation)
+		public void setup() {
+			super.setup(FieldSerializer.class);
+			kryo.register(SampleObject1.class, new Serializer<SampleObject1>() {
+
+				@Override
+				public void write(Kryo kryo, Output out, SampleObject1 obj) {
+					out.writeInt(obj.intVal);
+					out.writeFloat(obj.floatVal);
+					out.writeShort(obj.shortVal.intValue());
+					kryo.writeObject(out, obj.longArr); // could be referenced
+					kryo.writeObject(out, obj.dblArr); // could be referenced
+					out.writeString(obj.str);
+				}
+
+				@Override
+				public SampleObject1 read(Kryo kryo, Input in, Class<SampleObject1> type) {
+					return new SampleObject1(
+							in.readInt(),
+							in.readFloat(),
+							in.readShort(),
+							kryo.readObject(in, long[].class),
+							kryo.readObject(in, double[].class),
+							in.readString()
+					);
+				}
+			});
+		}
+	}
+
+	@Benchmark
+	public byte[] fieldSerializerSer(FieldSerializerState state, Blackhole blackhole) {
+		state.kryo.writeObject(state.output, state.obj);
+		state.output.close();
+		return state.out;
+	}
+
+	@Benchmark
+	public byte[] compatibleFieldSerializerSer(CompatibleFieldSerializerState state) {
+		state.kryo.writeObject(state.output, state.obj);
+		state.output.close();
+		return state.out;
+	}
+
+	@Benchmark
+	public byte[] taggedFieldSerializerSer(TaggedFieldSerializerState state) {
+		state.kryo.writeObject(state.output, state.obj);
+		state.output.close();
+		return state.out;
+	}
+
+	@Benchmark
+	public byte[] versionFieldSerializerSer(VersionFieldSerializerState state) {
+		state.kryo.writeObject(state.output, state.obj);
+		state.output.close();
+		return state.out;
+	}
+
+	@Benchmark
+	public byte[] customSerializerSer(CustomSerializerState state) {
+		state.kryo.writeObject(state.output, state.obj);
+		state.output.close();
+		return state.out;
+	}
+
+}

--- a/benchmarks/src/main/java/com/esotericsoftware/kryo/SampleObject1.java
+++ b/benchmarks/src/main/java/com/esotericsoftware/kryo/SampleObject1.java
@@ -1,0 +1,79 @@
+/* Copyright (c) 2018, Nathan Sweet
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following
+ * conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the distribution.
+ * - Neither the name of Esoteric Software nor the names of its contributors may be used to endorse or promote products derived
+ * from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
+ * BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.esotericsoftware.kryo;
+
+import com.esotericsoftware.kryo.serializers.TaggedFieldSerializer.Tag;
+
+import java.util.Arrays;
+
+public class SampleObject1 {
+
+	@Tag(1)
+	int intVal;
+	@Tag(2)
+	float floatVal;
+	@Tag(3)
+	Short shortVal;
+	@Tag(4)
+	long[] longArr;
+	@Tag(5)
+	double[] dblArr;
+	@Tag(6)
+	String str;
+
+	public SampleObject1 () {
+	}
+
+	SampleObject1 (int intVal, float floatVal, Short shortVal, long[] longArr, double[] dblArr, String str) {
+		this.intVal = intVal;
+		this.floatVal = floatVal;
+		this.shortVal = shortVal;
+		this.longArr = longArr;
+		this.dblArr = dblArr;
+		this.str = str;
+	}
+
+	static SampleObject1 createSample() {
+		long[] longArr = new long[10];
+		for (int i = 0; i < longArr.length; i++)
+			longArr[i] = i;
+
+		double[] dblArr = new double[10];
+		for (int i = 0; i < dblArr.length; i++)
+			dblArr[i] = 0.1 * i;
+
+		return new SampleObject1(123, 123.456f, (short)321, longArr, dblArr, "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789");
+	}
+
+	@Override
+	public boolean equals (Object other) {
+		if (this == other) return true;
+
+		if (other == null || getClass() != other.getClass()) return false;
+
+		SampleObject1 obj = (SampleObject1)other;
+
+		return intVal == obj.intVal && floatVal == obj.floatVal && shortVal.equals(obj.shortVal)
+				&& Arrays.equals(dblArr, obj.dblArr) && Arrays.equals(longArr, obj.longArr)
+				&& (str == null ? obj.str == null : str.equals(obj.str));
+	}
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,7 @@
 	<modules>
 		<module>pom-main.xml</module>
 		<module>pom-shaded.xml</module>
+		<module>benchmarks</module>
 	</modules>
 	
 	<dependencyManagement>


### PR DESCRIPTION
This adds a maven module for JMH benchmarks and a sample benchmark
comparing the serialization performance of the different reflection
based (field) serializers (deserialization left to do).

To run benchmarks execute
```
mvn -f benchmarks/pom.xml compile exec:java
```

JMH options can be set via `-Dexec.args`, e.g.
```
mvn -f benchmarks/pom.xml compile exec:java -Dexec.args="-incl FieldSerializersBenchmark -f 2 -t 2 -wi 10 -i 10"
```