### PR TITLE
Declare IntArray being INTERNAL API

### DIFF
--- a/pom-main.xml
+++ b/pom-main.xml
@@ -80,9 +80,13 @@
 					<skip>false</skip>
 					<logResults>true</logResults>
 					<minSeverity>warning</minSeverity>
+					<excludes>
+						<!-- Internal APIs -->
+						<exclude>com/esotericsoftware/kryo/util/IntArray</exclude>
+					</excludes>
 					<!-- Configure ignored differences: http://mojo.codehaus.org/clirr-maven-plugin/examples/ignored-differences.html -->
 					<ignored>
-						<!-- Internal APIs -->
+						<!-- Specific internal APIs -->
 						<difference>
 							<className>com/esotericsoftware/kryo/Kryo</className>
 							<method>*GenericsScope*</method>

--- a/src/com/esotericsoftware/kryo/util/IntArray.java
+++ b/src/com/esotericsoftware/kryo/util/IntArray.java
@@ -21,7 +21,9 @@ package com.esotericsoftware.kryo.util;
 
 import java.util.Arrays;
 
-/** A resizable, ordered or unordered int array. Avoids the boxing that occurs with ArrayList<Integer>. If unordered, this class
+/** INTERNAL API
+ *
+ * A resizable, ordered or unordered int array. Avoids the boxing that occurs with ArrayList<Integer>. If unordered, this class
  * avoids a memory copy when removing elements (the last element is moved to the removed element's position).
  * @author Nathan Sweet */
 public class IntArray {


### PR DESCRIPTION
and in consequence exclude it from clirr compatibility checks in order to fix the build broken by commit eb69e09c.