### PR TITLE
Move to Junit4 Style test code (Part 2).

### DIFF
--- a/test/com/esotericsoftware/kryo/KryoAssert.java
+++ b/test/com/esotericsoftware/kryo/KryoAssert.java
@@ -1,0 +1,21 @@
+package com.esotericsoftware.kryo;
+
+import static org.junit.Assert.*;
+
+/**
+ * Junit Assert wrapper methods class
+ */
+public class KryoAssert {
+
+    private KryoAssert() {
+
+    }
+
+    public static void assertDoubleEquals(double expected, double actual) {
+        assertEquals(expected, actual, 0.0);
+    }
+
+    public static void assertFloatEquals(float expected, double actual) {
+        assertEquals(expected, actual, 0.0);
+    }
+}

--- a/test/com/esotericsoftware/kryo/io/ByteBufferInputOutputTest.java
+++ b/test/com/esotericsoftware/kryo/io/ByteBufferInputOutputTest.java
@@ -24,7 +24,10 @@ import com.esotericsoftware.kryo.KryoTestCase;
 import java.io.ByteArrayInputStream;
 import java.nio.ByteBuffer;
 
+import org.junit.Test;
+
 public class ByteBufferInputOutputTest extends KryoTestCase {
+	@Test
 	public void testByteBufferInputEnd () {
 		ByteBufferInput in = new ByteBufferInput(new ByteArrayInputStream(new byte[] {123, 0, 0, 0}));
 		assertEquals(false, in.end());
@@ -32,6 +35,7 @@ public class ByteBufferInputOutputTest extends KryoTestCase {
 		assertEquals(true, in.end());
 	}
 
+	@Test
 	public void testByteBufferInputPosition () {
 		ByteBuffer byteBuffer = ByteBuffer.allocateDirect(4096);
 		ByteBufferInput inputBuffer = new ByteBufferInput(byteBuffer);
@@ -42,6 +46,7 @@ public class ByteBufferInputOutputTest extends KryoTestCase {
 		assertEquals(5, inputBuffer.getByteBuffer().position());
 	}
 
+	@Test
 	public void testByteBufferInputLimit () {
 		ByteBuffer byteBuffer = ByteBuffer.allocateDirect(4096);
 		ByteBufferInput inputBuffer = new ByteBufferInput(byteBuffer);
@@ -52,6 +57,7 @@ public class ByteBufferInputOutputTest extends KryoTestCase {
 		assertEquals(1000, inputBuffer.getByteBuffer().limit());
 	}
 
+	@Test
 	public void testByteBufferInputSkip () {
 		ByteBuffer buffer = ByteBuffer.allocateDirect(4096);
 		ByteBufferInput inputBuffer = new ByteBufferInput(buffer);
@@ -60,6 +66,7 @@ public class ByteBufferInputOutputTest extends KryoTestCase {
 		assertEquals(5, inputBuffer.getByteBuffer().position());
 	}
 
+	@Test
 	public void testByteBufferOutputPosition () {
 		ByteBufferOutput outputBuffer = new ByteBufferOutput(4096);
 		assertEquals(0, outputBuffer.position());

--- a/test/com/esotericsoftware/kryo/io/ChunkedTest.java
+++ b/test/com/esotericsoftware/kryo/io/ChunkedTest.java
@@ -19,10 +19,13 @@
 
 package com.esotericsoftware.kryo.io;
 
-import com.esotericsoftware.kryo.KryoTestCase;
+import static org.junit.Assert.*;
+
+import org.junit.Test;
 
 /** @author Nathan Sweet */
-public class ChunkedTest extends KryoTestCase {
+public class ChunkedTest {
+	@Test
 	public void testChunks () {
 		Output output = new Output(512);
 		output.writeInt(1234);

--- a/test/com/esotericsoftware/kryo/io/InputOutputTest.java
+++ b/test/com/esotericsoftware/kryo/io/InputOutputTest.java
@@ -37,6 +37,7 @@ import org.junit.Test;
 
 /** @author Nathan Sweet */
 public class InputOutputTest extends KryoTestCase {
+	@Test
 	public void testByteBufferInputEnd () {
 		Input in = new Input(new ByteArrayInputStream(new byte[] {123, 0, 0, 0}));
 		assertEquals(false, in.end());
@@ -44,6 +45,7 @@ public class InputOutputTest extends KryoTestCase {
 		assertEquals(true, in.end());
 	}
 
+	@Test
 	public void testOutputStream () throws IOException {
 		ByteArrayOutputStream buffer = new ByteArrayOutputStream();
 		Output output = new Output(buffer, 2);
@@ -60,6 +62,7 @@ public class InputOutputTest extends KryoTestCase {
 			61, 62, 63, 64, 65}, buffer.toByteArray());
 	}
 
+	@Test
 	public void testInputStream () throws IOException {
 		byte[] bytes = new byte[] { //
 			11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, //
@@ -83,6 +86,7 @@ public class InputOutputTest extends KryoTestCase {
 		assertArrayEquals(bytes, temp2);
 	}
 
+	@Test
 	public void testWriteBytes () throws IOException {
 		Output buffer = new Output(512);
 		buffer.writeBytes(new byte[] {11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26});
@@ -103,6 +107,7 @@ public class InputOutputTest extends KryoTestCase {
 			61, 62, 63, 64, 65}, buffer.toBytes());
 	}
 
+	@Test
 	public void testStrings () throws IOException {
 		runStringTest(new Output(4096));
 		runStringTest(new Output(897));
@@ -141,7 +146,7 @@ public class InputOutputTest extends KryoTestCase {
 		assertEquals("node/read", new Input(output.getBuffer(), 0, output.position).readString());
 	}
 
-	public void runStringTest (int length) throws IOException {
+	private void runStringTest (int length) throws IOException {
 		Output write = new Output(1024, -1);
 		StringBuilder buffer = new StringBuilder();
 		for (int i = 0; i < length; i++)
@@ -171,7 +176,7 @@ public class InputOutputTest extends KryoTestCase {
 		}
 	}
 
-	public void runStringTest (Output write) throws IOException {
+	private void runStringTest (Output write) throws IOException {
 		String value1 = "ABCDEFGHIJKLMNOPQRSTUVWXYZ\rabcdefghijklmnopqrstuvwxyz\n1234567890\t\"!`?'.,;:()[]{}<>|/@\\^$-%+=#_&~*";
 		String value2 = "abcdef\u00E1\u00E9\u00ED\u00F3\u00FA\u1234";
 
@@ -220,6 +225,7 @@ public class InputOutputTest extends KryoTestCase {
 			assertEquals(String.valueOf((char)i) + "abc", read.readStringBuilder().toString());
 	}
 
+	@Test
 	public void testCanReadInt () throws IOException {
 		Output write = new Output(new ByteArrayOutputStream());
 
@@ -234,19 +240,21 @@ public class InputOutputTest extends KryoTestCase {
 		assertEquals(false, read.canReadVarInt());
 	}
 
+	@Test
 	public void testVarIntFlagOutput () throws IOException {
 		Output output = new Output(4096);
 		Input input = new Input(output.getBuffer());
 		runVarIntFlagsTest(output, input);
 	}
 
+	@Test
 	public void testVarIntFlagByteBufferOutput () throws IOException {
 		ByteBufferOutput output = new ByteBufferOutput(4096);
 		ByteBufferInput input = new ByteBufferInput(output.getByteBuffer());
 		runVarIntFlagsTest(output, input);
 	}
 
-	public void runVarIntFlagsTest (Output output, Input input) throws IOException {
+	private void runVarIntFlagsTest (Output output, Input input) throws IOException {
 		assertEquals(1, output.writeVarIntFlag(true, 63, true));
 		assertEquals(2, output.writeVarIntFlag(true, 64, true));
 
@@ -282,6 +290,7 @@ public class InputOutputTest extends KryoTestCase {
 		assertEquals(32, input.readVarIntFlag(false));
 	}
 
+	@Test
 	public void testInts () throws IOException {
 		runIntTest(new Output(4096));
 		runIntTest(new Output(new ByteArrayOutputStream()));
@@ -814,6 +823,7 @@ public class InputOutputTest extends KryoTestCase {
 		assertEquals(1.23456d, read.readDouble());
 	}
 
+	@Test
 	public void testBooleans () throws IOException {
 		runBooleanTest(new Output(4096));
 		runBooleanTest(new Output(new ByteArrayOutputStream()));
@@ -832,6 +842,7 @@ public class InputOutputTest extends KryoTestCase {
 		}
 	}
 
+	@Test
 	public void testChars () throws IOException {
 		runCharTest(new Output(4096));
 		runCharTest(new Output(new ByteArrayOutputStream()));
@@ -860,12 +871,14 @@ public class InputOutputTest extends KryoTestCase {
 		assertEquals(65535, read.readChar());
 	}
 
+	@Test
 	public void testInputWithOffset () throws Exception {
 		final byte[] buf = new byte[30];
 		final Input in = new Input(buf, 10, 10);
 		assertEquals(10, in.available());
 	}
 
+	@Test
 	public void testSmallBuffers () throws Exception {
 		ByteBuffer buf = ByteBuffer.allocate(1024);
 		ByteBufferOutputStream byteBufferOutputStream = new ByteBufferOutputStream(buf);
@@ -884,6 +897,7 @@ public class InputOutputTest extends KryoTestCase {
 		input.readBytes(toRead);
 	}
 
+	@Test
 	public void testVerySmallBuffers () throws Exception {
 		Output out1 = new Output(4, -1);
 		Output out2 = new ByteBufferOutput(4, -1);
@@ -899,6 +913,7 @@ public class InputOutputTest extends KryoTestCase {
 		assertArrayEquals(out1.toBytes(), out2.toBytes());
 	}
 
+	@Test
 	public void testZeroLengthOutputs () throws Exception {
 		Output output = new Output(0, 10000);
 		kryo.writeClassAndObject(output, "Test string");
@@ -907,6 +922,7 @@ public class InputOutputTest extends KryoTestCase {
 		kryo.writeClassAndObject(byteBufferOutput, "Test string");
 	}
 
+	@Test
 	public void testFlushRoundTrip () throws Exception {
 
 		Kryo kryo = new Kryo();
@@ -936,6 +952,7 @@ public class InputOutputTest extends KryoTestCase {
 
 	}
 
+	@Test
 	public void testNewOutputMaxBufferSizeLessThanBufferSize () {
 		int bufferSize = 2;
 		int maxBufferSize = 1;
@@ -947,6 +964,7 @@ public class InputOutputTest extends KryoTestCase {
 		}
 	}
 
+	@Test
 	public void testSetOutputMaxBufferSizeLessThanBufferSize () {
 		int bufferSize = 2;
 		int maxBufferSize = 1;
@@ -962,6 +980,7 @@ public class InputOutputTest extends KryoTestCase {
 
 	}
 
+	@Test
 	public void testNewOutputMaxBufferSizeIsMinusOne () {
 		int bufferSize = 2;
 		int maxBufferSize = -1;
@@ -971,6 +990,7 @@ public class InputOutputTest extends KryoTestCase {
 		// This test should pass as long as no exception thrown
 	}
 
+	@Test
 	public void testSetOutputMaxBufferSizeIsMinusOne () {
 		int bufferSize = 2;
 		int maxBufferSize = -1;

--- a/test/com/esotericsoftware/kryo/io/UnsafeByteBufferInputOutputTest.java
+++ b/test/com/esotericsoftware/kryo/io/UnsafeByteBufferInputOutputTest.java
@@ -19,9 +19,9 @@
 
 package com.esotericsoftware.kryo.io;
 
+import static com.esotericsoftware.kryo.KryoAssert.*;
 import static org.junit.Assert.*;
 
-import com.esotericsoftware.kryo.KryoTestCase;
 import com.esotericsoftware.kryo.unsafe.UnsafeByteBufferInput;
 import com.esotericsoftware.kryo.unsafe.UnsafeByteBufferOutput;
 import com.esotericsoftware.kryo.unsafe.UnsafeUtil;
@@ -31,9 +31,12 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.Random;
 
-/** @author Roman Levenstein <romixlev@gmail.com> */
-public class UnsafeByteBufferInputOutputTest extends KryoTestCase {
+import org.junit.Test;
 
+/** @author Roman Levenstein <romixlev@gmail.com> */
+public class UnsafeByteBufferInputOutputTest {
+
+	@Test
 	public void testByteBufferOutputWithPreallocatedMemory () {
 		long bufAddress = UnsafeUtil.unsafe.allocateMemory(4096);
 		try {
@@ -62,6 +65,7 @@ public class UnsafeByteBufferInputOutputTest extends KryoTestCase {
 		}
 	}
 
+	@Test
 	public void testOutputStream () throws IOException {
 		ByteArrayOutputStream buffer = new ByteArrayOutputStream();
 		UnsafeByteBufferOutput output = new UnsafeByteBufferOutput(buffer, 2);
@@ -78,6 +82,7 @@ public class UnsafeByteBufferInputOutputTest extends KryoTestCase {
 			61, 62, 63, 64, 65}, buffer.toByteArray());
 	}
 
+	@Test
 	public void testInputStream () throws IOException {
 		byte[] bytes = new byte[] { //
 			11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, //
@@ -101,6 +106,7 @@ public class UnsafeByteBufferInputOutputTest extends KryoTestCase {
 		assertArrayEquals(bytes, temp2);
 	}
 
+	@Test
 	public void testWriteBytes () throws IOException {
 		UnsafeByteBufferOutput buffer = new UnsafeByteBufferOutput(512);
 		buffer.writeBytes(new byte[] {11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26});
@@ -121,6 +127,7 @@ public class UnsafeByteBufferInputOutputTest extends KryoTestCase {
 			61, 62, 63, 64, 65}, buffer.toBytes());
 	}
 
+	@Test
 	public void testStrings () throws IOException {
 		runStringTest(new UnsafeByteBufferOutput(4096));
 		runStringTest(new UnsafeByteBufferOutput(897));
@@ -141,7 +148,7 @@ public class UnsafeByteBufferInputOutputTest extends KryoTestCase {
 		runStringTest(1024 * 1024 * 2);
 	}
 
-	public void runStringTest (int length) throws IOException {
+	private void runStringTest (int length) throws IOException {
 		UnsafeByteBufferOutput write = new UnsafeByteBufferOutput(1024, -1);
 		StringBuilder buffer = new StringBuilder();
 		for (int i = 0; i < length; i++)
@@ -171,7 +178,7 @@ public class UnsafeByteBufferInputOutputTest extends KryoTestCase {
 		}
 	}
 
-	public void runStringTest (UnsafeByteBufferOutput write) throws IOException {
+	private void runStringTest (UnsafeByteBufferOutput write) throws IOException {
 		String value1 = "ABCDEFGHIJKLMNOPQRSTUVWXYZ\rabcdefghijklmnopqrstuvwxyz\n1234567890\t\"!`?'.,;:()[]{}<>|/@\\^$-%+=#_&~*";
 		String value2 = "abcdef\u00E1\u00E9\u00ED\u00F3\u00FA\u1234";
 
@@ -220,6 +227,7 @@ public class UnsafeByteBufferInputOutputTest extends KryoTestCase {
 			assertEquals(String.valueOf((char)i) + "abc", read.readStringBuilder().toString());
 	}
 
+	@Test
 	public void testCanReadInt () throws IOException {
 		UnsafeByteBufferOutput write = new UnsafeByteBufferOutput(new ByteArrayOutputStream());
 
@@ -234,6 +242,7 @@ public class UnsafeByteBufferInputOutputTest extends KryoTestCase {
 		assertEquals(false, read.canReadVarInt());
 	}
 
+	@Test
 	public void testInts () throws IOException {
 		runIntTest(new UnsafeByteBufferOutput(4096));
 		runIntTest(new UnsafeByteBufferOutput(new ByteArrayOutputStream()));
@@ -399,6 +408,7 @@ public class UnsafeByteBufferInputOutputTest extends KryoTestCase {
 		}
 	}
 
+	@Test
 	public void testLongs () throws IOException {
 		runLongTest(new UnsafeByteBufferOutput(4096));
 		runLongTest(new UnsafeByteBufferOutput(new ByteArrayOutputStream()));
@@ -548,6 +558,7 @@ public class UnsafeByteBufferInputOutputTest extends KryoTestCase {
 		}
 	}
 
+	@Test
 	public void testShorts () throws IOException {
 		runShortTest(new UnsafeByteBufferOutput(4096));
 		runShortTest(new UnsafeByteBufferOutput(new ByteArrayOutputStream()));
@@ -588,6 +599,7 @@ public class UnsafeByteBufferInputOutputTest extends KryoTestCase {
 		assertEquals(-32768, read.readShort());
 	}
 
+	@Test
 	public void testFloats () throws IOException {
 		runFloatTest(new UnsafeByteBufferOutput(4096));
 		runFloatTest(new UnsafeByteBufferOutput(new ByteArrayOutputStream()));
@@ -638,49 +650,50 @@ public class UnsafeByteBufferInputOutputTest extends KryoTestCase {
 		assertEquals(5, write.writeVarFloat(-8192, 1000, true));
 
 		Input read = new UnsafeByteBufferInput(write.toBytes());
-		assertEquals(read.readFloat(), 0f);
-		assertEquals(read.readFloat(), 63f);
-		assertEquals(read.readFloat(), 64f);
-		assertEquals(read.readFloat(), 127f);
-		assertEquals(read.readFloat(), 128f);
-		assertEquals(read.readFloat(), 8192f);
-		assertEquals(read.readFloat(), 16384f);
-		assertEquals(read.readFloat(), 32767f);
-		assertEquals(read.readFloat(), -63f);
-		assertEquals(read.readFloat(), -64f);
-		assertEquals(read.readFloat(), -127f);
-		assertEquals(read.readFloat(), -128f);
-		assertEquals(read.readFloat(), -8192f);
-		assertEquals(read.readFloat(), -16384f);
-		assertEquals(read.readFloat(), -32768f);
-		assertEquals(read.readVarFloat(1000, true), 0f);
-		assertEquals(read.readVarFloat(1000, false), 0f);
-		assertEquals(read.readVarFloat(1000, true), 63f);
-		assertEquals(read.readVarFloat(1000, false), 63f);
-		assertEquals(read.readVarFloat(1000, true), 64f);
-		assertEquals(read.readVarFloat(1000, false), 64f);
-		assertEquals(read.readVarFloat(1000, true), 127f);
-		assertEquals(read.readVarFloat(1000, false), 127f);
-		assertEquals(read.readVarFloat(1000, true), 128f);
-		assertEquals(read.readVarFloat(1000, false), 128f);
-		assertEquals(read.readVarFloat(1000, true), 8191f);
-		assertEquals(read.readVarFloat(1000, false), 8191f);
-		assertEquals(read.readVarFloat(1000, true), 8192f);
-		assertEquals(read.readVarFloat(1000, false), 8192f);
-		assertEquals(read.readVarFloat(1000, true), 16383f);
-		assertEquals(read.readVarFloat(1000, false), 16383f);
-		assertEquals(read.readVarFloat(1000, true), 16384f);
-		assertEquals(read.readVarFloat(1000, false), 16384f);
-		assertEquals(read.readVarFloat(1000, true), 32767f);
-		assertEquals(read.readVarFloat(1000, false), 32767f);
-		assertEquals(read.readVarFloat(1000, false), -64f);
-		assertEquals(read.readVarFloat(1000, true), -64f);
-		assertEquals(read.readVarFloat(1000, false), -65f);
-		assertEquals(read.readVarFloat(1000, true), -65f);
-		assertEquals(read.readVarFloat(1000, false), -8192f);
-		assertEquals(read.readVarFloat(1000, true), -8192f);
+		assertFloatEquals(read.readFloat(), 0f);
+		assertFloatEquals(read.readFloat(), 63f);
+		assertFloatEquals(read.readFloat(), 64f);
+		assertFloatEquals(read.readFloat(), 127f);
+		assertFloatEquals(read.readFloat(), 128f);
+		assertFloatEquals(read.readFloat(), 8192f);
+		assertFloatEquals(read.readFloat(), 16384f);
+		assertFloatEquals(read.readFloat(), 32767f);
+		assertFloatEquals(read.readFloat(), -63f);
+		assertFloatEquals(read.readFloat(), -64f);
+		assertFloatEquals(read.readFloat(), -127f);
+		assertFloatEquals(read.readFloat(), -128f);
+		assertFloatEquals(read.readFloat(), -8192f);
+		assertFloatEquals(read.readFloat(), -16384f);
+		assertFloatEquals(read.readFloat(), -32768f);
+		assertFloatEquals(read.readVarFloat(1000, true), 0f);
+		assertFloatEquals(read.readVarFloat(1000, false), 0f);
+		assertFloatEquals(read.readVarFloat(1000, true), 63f);
+		assertFloatEquals(read.readVarFloat(1000, false), 63f);
+		assertFloatEquals(read.readVarFloat(1000, true), 64f);
+		assertFloatEquals(read.readVarFloat(1000, false), 64f);
+		assertFloatEquals(read.readVarFloat(1000, true), 127f);
+		assertFloatEquals(read.readVarFloat(1000, false), 127f);
+		assertFloatEquals(read.readVarFloat(1000, true), 128f);
+		assertFloatEquals(read.readVarFloat(1000, false), 128f);
+		assertFloatEquals(read.readVarFloat(1000, true), 8191f);
+		assertFloatEquals(read.readVarFloat(1000, false), 8191f);
+		assertFloatEquals(read.readVarFloat(1000, true), 8192f);
+		assertFloatEquals(read.readVarFloat(1000, false), 8192f);
+		assertFloatEquals(read.readVarFloat(1000, true), 16383f);
+		assertFloatEquals(read.readVarFloat(1000, false), 16383f);
+		assertFloatEquals(read.readVarFloat(1000, true), 16384f);
+		assertFloatEquals(read.readVarFloat(1000, false), 16384f);
+		assertFloatEquals(read.readVarFloat(1000, true), 32767f);
+		assertFloatEquals(read.readVarFloat(1000, false), 32767f);
+		assertFloatEquals(read.readVarFloat(1000, false), -64f);
+		assertFloatEquals(read.readVarFloat(1000, true), -64f);
+		assertFloatEquals(read.readVarFloat(1000, false), -65f);
+		assertFloatEquals(read.readVarFloat(1000, true), -65f);
+		assertFloatEquals(read.readVarFloat(1000, false), -8192f);
+		assertFloatEquals(read.readVarFloat(1000, true), -8192f);
 	}
 
+	@Test
 	public void testDoubles () throws IOException {
 		runDoubleTest(new UnsafeByteBufferOutput(4096));
 		runDoubleTest(new UnsafeByteBufferOutput(new ByteArrayOutputStream()));
@@ -732,51 +745,52 @@ public class UnsafeByteBufferInputOutputTest extends KryoTestCase {
 		write.writeDouble(1.23456d);
 
 		Input read = new UnsafeByteBufferInput(write.toBytes());
-		assertEquals(read.readDouble(), 0d);
-		assertEquals(read.readDouble(), 63d);
-		assertEquals(read.readDouble(), 64d);
-		assertEquals(read.readDouble(), 127d);
-		assertEquals(read.readDouble(), 128d);
-		assertEquals(read.readDouble(), 8192d);
-		assertEquals(read.readDouble(), 16384d);
-		assertEquals(read.readDouble(), 32767d);
-		assertEquals(read.readDouble(), -63d);
-		assertEquals(read.readDouble(), -64d);
-		assertEquals(read.readDouble(), -127d);
-		assertEquals(read.readDouble(), -128d);
-		assertEquals(read.readDouble(), -8192d);
-		assertEquals(read.readDouble(), -16384d);
-		assertEquals(read.readDouble(), -32768d);
+		assertDoubleEquals(read.readDouble(), 0d);
+		assertDoubleEquals(read.readDouble(), 63d);
+		assertDoubleEquals(read.readDouble(), 64d);
+		assertDoubleEquals(read.readDouble(), 127d);
+		assertDoubleEquals(read.readDouble(), 128d);
+		assertDoubleEquals(read.readDouble(), 8192d);
+		assertDoubleEquals(read.readDouble(), 16384d);
+		assertDoubleEquals(read.readDouble(), 32767d);
+		assertDoubleEquals(read.readDouble(), -63d);
+		assertDoubleEquals(read.readDouble(), -64d);
+		assertDoubleEquals(read.readDouble(), -127d);
+		assertDoubleEquals(read.readDouble(), -128d);
+		assertDoubleEquals(read.readDouble(), -8192d);
+		assertDoubleEquals(read.readDouble(), -16384d);
+		assertDoubleEquals(read.readDouble(), -32768d);
 
-		assertEquals(read.readVarDouble(1000, true), 0d);
-		assertEquals(read.readVarDouble(1000, false), 0d);
-		assertEquals(read.readVarDouble(1000, true), 63d);
-		assertEquals(read.readVarDouble(1000, false), 63d);
-		assertEquals(read.readVarDouble(1000, true), 64d);
-		assertEquals(read.readVarDouble(1000, false), 64d);
-		assertEquals(read.readVarDouble(1000, true), 127d);
-		assertEquals(read.readVarDouble(1000, false), 127d);
-		assertEquals(read.readVarDouble(1000, true), 128d);
-		assertEquals(read.readVarDouble(1000, false), 128d);
-		assertEquals(read.readVarDouble(1000, true), 8191d);
-		assertEquals(read.readVarDouble(1000, false), 8191d);
-		assertEquals(read.readVarDouble(1000, true), 8192d);
-		assertEquals(read.readVarDouble(1000, false), 8192d);
-		assertEquals(read.readVarDouble(1000, true), 16383d);
-		assertEquals(read.readVarDouble(1000, false), 16383d);
-		assertEquals(read.readVarDouble(1000, true), 16384d);
-		assertEquals(read.readVarDouble(1000, false), 16384d);
-		assertEquals(read.readVarDouble(1000, true), 32767d);
-		assertEquals(read.readVarDouble(1000, false), 32767d);
-		assertEquals(read.readVarDouble(1000, false), -64d);
-		assertEquals(read.readVarDouble(1000, true), -64d);
-		assertEquals(read.readVarDouble(1000, false), -65d);
-		assertEquals(read.readVarDouble(1000, true), -65d);
-		assertEquals(read.readVarDouble(1000, false), -8192d);
-		assertEquals(read.readVarDouble(1000, true), -8192d);
-		assertEquals(1.23456d, read.readDouble());
+		assertDoubleEquals(read.readVarDouble(1000, true), 0d);
+		assertDoubleEquals(read.readVarDouble(1000, false), 0d);
+		assertDoubleEquals(read.readVarDouble(1000, true), 63d);
+		assertDoubleEquals(read.readVarDouble(1000, false), 63d);
+		assertDoubleEquals(read.readVarDouble(1000, true), 64d);
+		assertDoubleEquals(read.readVarDouble(1000, false), 64d);
+		assertDoubleEquals(read.readVarDouble(1000, true), 127d);
+		assertDoubleEquals(read.readVarDouble(1000, false), 127d);
+		assertDoubleEquals(read.readVarDouble(1000, true), 128d);
+		assertDoubleEquals(read.readVarDouble(1000, false), 128d);
+		assertDoubleEquals(read.readVarDouble(1000, true), 8191d);
+		assertDoubleEquals(read.readVarDouble(1000, false), 8191d);
+		assertDoubleEquals(read.readVarDouble(1000, true), 8192d);
+		assertDoubleEquals(read.readVarDouble(1000, false), 8192d);
+		assertDoubleEquals(read.readVarDouble(1000, true), 16383d);
+		assertDoubleEquals(read.readVarDouble(1000, false), 16383d);
+		assertDoubleEquals(read.readVarDouble(1000, true), 16384d);
+		assertDoubleEquals(read.readVarDouble(1000, false), 16384d);
+		assertDoubleEquals(read.readVarDouble(1000, true), 32767d);
+		assertDoubleEquals(read.readVarDouble(1000, false), 32767d);
+		assertDoubleEquals(read.readVarDouble(1000, false), -64d);
+		assertDoubleEquals(read.readVarDouble(1000, true), -64d);
+		assertDoubleEquals(read.readVarDouble(1000, false), -65d);
+		assertDoubleEquals(read.readVarDouble(1000, true), -65d);
+		assertDoubleEquals(read.readVarDouble(1000, false), -8192d);
+		assertDoubleEquals(read.readVarDouble(1000, true), -8192d);
+		assertDoubleEquals(1.23456d, read.readDouble());
 	}
 
+	@Test
 	public void testBooleans () throws IOException {
 		runBooleanTest(new UnsafeByteBufferOutput(200));
 		runBooleanTest(new UnsafeByteBufferOutput(4096));
@@ -796,6 +810,7 @@ public class UnsafeByteBufferInputOutputTest extends KryoTestCase {
 		}
 	}
 
+	@Test
 	public void testChars () throws IOException {
 		runCharTest(new UnsafeByteBufferOutput(4096));
 		runCharTest(new UnsafeByteBufferOutput(new ByteArrayOutputStream()));

--- a/test/com/esotericsoftware/kryo/io/UnsafeInputOutputTest.java
+++ b/test/com/esotericsoftware/kryo/io/UnsafeInputOutputTest.java
@@ -19,9 +19,9 @@
 
 package com.esotericsoftware.kryo.io;
 
+import static com.esotericsoftware.kryo.KryoAssert.*;
 import static org.junit.Assert.*;
 
-import com.esotericsoftware.kryo.KryoTestCase;
 import com.esotericsoftware.kryo.unsafe.UnsafeInput;
 import com.esotericsoftware.kryo.unsafe.UnsafeOutput;
 
@@ -30,8 +30,11 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.Random;
 
+import org.junit.Test;
+
 /** @author Nathan Sweet <misc@n4te.com> */
-public class UnsafeInputOutputTest extends KryoTestCase {
+public class UnsafeInputOutputTest {
+	@Test
 	public void testOutputStream () throws IOException {
 		ByteArrayOutputStream buffer = new ByteArrayOutputStream();
 		UnsafeOutput output = new UnsafeOutput(buffer, 2);
@@ -48,6 +51,7 @@ public class UnsafeInputOutputTest extends KryoTestCase {
 			61, 62, 63, 64, 65}, buffer.toByteArray());
 	}
 
+	@Test
 	public void testInputStream () throws IOException {
 		byte[] bytes = new byte[] { //
 			11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, //
@@ -71,6 +75,7 @@ public class UnsafeInputOutputTest extends KryoTestCase {
 		assertArrayEquals(bytes, temp2);
 	}
 
+	@Test
 	public void testWriteBytes () throws IOException {
 		UnsafeOutput buffer = new UnsafeOutput(512);
 		buffer.writeBytes(new byte[] {11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26});
@@ -91,6 +96,7 @@ public class UnsafeInputOutputTest extends KryoTestCase {
 			61, 62, 63, 64, 65}, buffer.toBytes());
 	}
 
+	@Test
 	public void testStrings () throws IOException {
 		runStringTest(new UnsafeOutput(4096));
 		runStringTest(new UnsafeOutput(897));
@@ -111,7 +117,7 @@ public class UnsafeInputOutputTest extends KryoTestCase {
 		runStringTest(1024 * 1024 * 2);
 	}
 
-	public void runStringTest (int length) throws IOException {
+	private void runStringTest (int length) throws IOException {
 		UnsafeOutput write = new UnsafeOutput(1024, -1);
 		StringBuilder buffer = new StringBuilder();
 		for (int i = 0; i < length; i++)
@@ -141,7 +147,7 @@ public class UnsafeInputOutputTest extends KryoTestCase {
 		}
 	}
 
-	public void runStringTest (UnsafeOutput write) throws IOException {
+	private void runStringTest (UnsafeOutput write) throws IOException {
 		String value1 = "ABCDEFGHIJKLMNOPQRSTUVWXYZ\rabcdefghijklmnopqrstuvwxyz\n1234567890\t\"!`?'.,;:()[]{}<>|/@\\^$-%+=#_&~*";
 		String value2 = "abcdef\u00E1\u00E9\u00ED\u00F3\u00FA\u1234";
 
@@ -190,6 +196,7 @@ public class UnsafeInputOutputTest extends KryoTestCase {
 			assertEquals(String.valueOf((char)i) + "abc", read.readStringBuilder().toString());
 	}
 
+	@Test
 	public void testCanReadInt () throws IOException {
 		UnsafeOutput write = new UnsafeOutput(new ByteArrayOutputStream());
 
@@ -204,6 +211,7 @@ public class UnsafeInputOutputTest extends KryoTestCase {
 		assertEquals(false, read.canReadVarInt());
 	}
 
+	@Test
 	public void testInts () throws IOException {
 		runIntTest(new UnsafeOutput(4096));
 		runIntTest(new UnsafeOutput(new ByteArrayOutputStream()));
@@ -369,6 +377,7 @@ public class UnsafeInputOutputTest extends KryoTestCase {
 		}
 	}
 
+	@Test
 	public void testLongs () throws IOException {
 		runLongTest(new UnsafeOutput(4096));
 		runLongTest(new UnsafeOutput(new ByteArrayOutputStream()));
@@ -518,6 +527,7 @@ public class UnsafeInputOutputTest extends KryoTestCase {
 		}
 	}
 
+	@Test
 	public void testShorts () throws IOException {
 		runShortTest(new UnsafeOutput(4096));
 		runShortTest(new UnsafeOutput(new ByteArrayOutputStream()));
@@ -558,6 +568,7 @@ public class UnsafeInputOutputTest extends KryoTestCase {
 		assertEquals(-32768, read.readShort());
 	}
 
+	@Test
 	public void testFloats () throws IOException {
 		runFloatTest(new UnsafeOutput(4096));
 		runFloatTest(new UnsafeOutput(new ByteArrayOutputStream()));
@@ -608,49 +619,50 @@ public class UnsafeInputOutputTest extends KryoTestCase {
 		assertEquals(5, write.writeVarFloat(-8192, 1000, true));
 
 		Input read = new UnsafeInput(write.toBytes());
-		assertEquals(read.readFloat(), 0f);
-		assertEquals(read.readFloat(), 63f);
-		assertEquals(read.readFloat(), 64f);
-		assertEquals(read.readFloat(), 127f);
-		assertEquals(read.readFloat(), 128f);
-		assertEquals(read.readFloat(), 8192f);
-		assertEquals(read.readFloat(), 16384f);
-		assertEquals(read.readFloat(), 32767f);
-		assertEquals(read.readFloat(), -63f);
-		assertEquals(read.readFloat(), -64f);
-		assertEquals(read.readFloat(), -127f);
-		assertEquals(read.readFloat(), -128f);
-		assertEquals(read.readFloat(), -8192f);
-		assertEquals(read.readFloat(), -16384f);
-		assertEquals(read.readFloat(), -32768f);
-		assertEquals(read.readVarFloat(1000, true), 0f);
-		assertEquals(read.readVarFloat(1000, false), 0f);
-		assertEquals(read.readVarFloat(1000, true), 63f);
-		assertEquals(read.readVarFloat(1000, false), 63f);
-		assertEquals(read.readVarFloat(1000, true), 64f);
-		assertEquals(read.readVarFloat(1000, false), 64f);
-		assertEquals(read.readVarFloat(1000, true), 127f);
-		assertEquals(read.readVarFloat(1000, false), 127f);
-		assertEquals(read.readVarFloat(1000, true), 128f);
-		assertEquals(read.readVarFloat(1000, false), 128f);
-		assertEquals(read.readVarFloat(1000, true), 8191f);
-		assertEquals(read.readVarFloat(1000, false), 8191f);
-		assertEquals(read.readVarFloat(1000, true), 8192f);
-		assertEquals(read.readVarFloat(1000, false), 8192f);
-		assertEquals(read.readVarFloat(1000, true), 16383f);
-		assertEquals(read.readVarFloat(1000, false), 16383f);
-		assertEquals(read.readVarFloat(1000, true), 16384f);
-		assertEquals(read.readVarFloat(1000, false), 16384f);
-		assertEquals(read.readVarFloat(1000, true), 32767f);
-		assertEquals(read.readVarFloat(1000, false), 32767f);
-		assertEquals(read.readVarFloat(1000, false), -64f);
-		assertEquals(read.readVarFloat(1000, true), -64f);
-		assertEquals(read.readVarFloat(1000, false), -65f);
-		assertEquals(read.readVarFloat(1000, true), -65f);
-		assertEquals(read.readVarFloat(1000, false), -8192f);
-		assertEquals(read.readVarFloat(1000, true), -8192f);
+		assertFloatEquals(read.readFloat(), 0f);
+		assertFloatEquals(read.readFloat(), 63f);
+		assertFloatEquals(read.readFloat(), 64f);
+		assertFloatEquals(read.readFloat(), 127f);
+		assertFloatEquals(read.readFloat(), 128f);
+		assertFloatEquals(read.readFloat(), 8192f);
+		assertFloatEquals(read.readFloat(), 16384f);
+		assertFloatEquals(read.readFloat(), 32767f);
+		assertFloatEquals(read.readFloat(), -63f);
+		assertFloatEquals(read.readFloat(), -64f);
+		assertFloatEquals(read.readFloat(), -127f);
+		assertFloatEquals(read.readFloat(), -128f);
+		assertFloatEquals(read.readFloat(), -8192f);
+		assertFloatEquals(read.readFloat(), -16384f);
+		assertFloatEquals(read.readFloat(), -32768f);
+		assertFloatEquals(read.readVarFloat(1000, true), 0f);
+		assertFloatEquals(read.readVarFloat(1000, false), 0f);
+		assertFloatEquals(read.readVarFloat(1000, true), 63f);
+		assertFloatEquals(read.readVarFloat(1000, false), 63f);
+		assertFloatEquals(read.readVarFloat(1000, true), 64f);
+		assertFloatEquals(read.readVarFloat(1000, false), 64f);
+		assertFloatEquals(read.readVarFloat(1000, true), 127f);
+		assertFloatEquals(read.readVarFloat(1000, false), 127f);
+		assertFloatEquals(read.readVarFloat(1000, true), 128f);
+		assertFloatEquals(read.readVarFloat(1000, false), 128f);
+		assertFloatEquals(read.readVarFloat(1000, true), 8191f);
+		assertFloatEquals(read.readVarFloat(1000, false), 8191f);
+		assertFloatEquals(read.readVarFloat(1000, true), 8192f);
+		assertFloatEquals(read.readVarFloat(1000, false), 8192f);
+		assertFloatEquals(read.readVarFloat(1000, true), 16383f);
+		assertFloatEquals(read.readVarFloat(1000, false), 16383f);
+		assertFloatEquals(read.readVarFloat(1000, true), 16384f);
+		assertFloatEquals(read.readVarFloat(1000, false), 16384f);
+		assertFloatEquals(read.readVarFloat(1000, true), 32767f);
+		assertFloatEquals(read.readVarFloat(1000, false), 32767f);
+		assertFloatEquals(read.readVarFloat(1000, false), -64f);
+		assertFloatEquals(read.readVarFloat(1000, true), -64f);
+		assertFloatEquals(read.readVarFloat(1000, false), -65f);
+		assertFloatEquals(read.readVarFloat(1000, true), -65f);
+		assertFloatEquals(read.readVarFloat(1000, false), -8192f);
+		assertFloatEquals(read.readVarFloat(1000, true), -8192f);
 	}
 
+	@Test
 	public void testDoubles () throws IOException {
 		runDoubleTest(new UnsafeOutput(4096));
 		runDoubleTest(new UnsafeOutput(new ByteArrayOutputStream()));
@@ -702,51 +714,52 @@ public class UnsafeInputOutputTest extends KryoTestCase {
 		write.writeDouble(1.23456d);
 
 		Input read = new UnsafeInput(write.toBytes());
-		assertEquals(read.readDouble(), 0d);
-		assertEquals(read.readDouble(), 63d);
-		assertEquals(read.readDouble(), 64d);
-		assertEquals(read.readDouble(), 127d);
-		assertEquals(read.readDouble(), 128d);
-		assertEquals(read.readDouble(), 8192d);
-		assertEquals(read.readDouble(), 16384d);
-		assertEquals(read.readDouble(), 32767d);
-		assertEquals(read.readDouble(), -63d);
-		assertEquals(read.readDouble(), -64d);
-		assertEquals(read.readDouble(), -127d);
-		assertEquals(read.readDouble(), -128d);
-		assertEquals(read.readDouble(), -8192d);
-		assertEquals(read.readDouble(), -16384d);
-		assertEquals(read.readDouble(), -32768d);
+		assertDoubleEquals(read.readDouble(), 0d);
+		assertDoubleEquals(read.readDouble(), 63d);
+		assertDoubleEquals(read.readDouble(), 64d);
+		assertDoubleEquals(read.readDouble(), 127d);
+		assertDoubleEquals(read.readDouble(), 128d);
+		assertDoubleEquals(read.readDouble(), 8192d);
+		assertDoubleEquals(read.readDouble(), 16384d);
+		assertDoubleEquals(read.readDouble(), 32767d);
+		assertDoubleEquals(read.readDouble(), -63d);
+		assertDoubleEquals(read.readDouble(), -64d);
+		assertDoubleEquals(read.readDouble(), -127d);
+		assertDoubleEquals(read.readDouble(), -128d);
+		assertDoubleEquals(read.readDouble(), -8192d);
+		assertDoubleEquals(read.readDouble(), -16384d);
+		assertDoubleEquals(read.readDouble(), -32768d);
 
-		assertEquals(read.readVarDouble(1000, true), 0d);
-		assertEquals(read.readVarDouble(1000, false), 0d);
-		assertEquals(read.readVarDouble(1000, true), 63d);
-		assertEquals(read.readVarDouble(1000, false), 63d);
-		assertEquals(read.readVarDouble(1000, true), 64d);
-		assertEquals(read.readVarDouble(1000, false), 64d);
-		assertEquals(read.readVarDouble(1000, true), 127d);
-		assertEquals(read.readVarDouble(1000, false), 127d);
-		assertEquals(read.readVarDouble(1000, true), 128d);
-		assertEquals(read.readVarDouble(1000, false), 128d);
-		assertEquals(read.readVarDouble(1000, true), 8191d);
-		assertEquals(read.readVarDouble(1000, false), 8191d);
-		assertEquals(read.readVarDouble(1000, true), 8192d);
-		assertEquals(read.readVarDouble(1000, false), 8192d);
-		assertEquals(read.readVarDouble(1000, true), 16383d);
-		assertEquals(read.readVarDouble(1000, false), 16383d);
-		assertEquals(read.readVarDouble(1000, true), 16384d);
-		assertEquals(read.readVarDouble(1000, false), 16384d);
-		assertEquals(read.readVarDouble(1000, true), 32767d);
-		assertEquals(read.readVarDouble(1000, false), 32767d);
-		assertEquals(read.readVarDouble(1000, false), -64d);
-		assertEquals(read.readVarDouble(1000, true), -64d);
-		assertEquals(read.readVarDouble(1000, false), -65d);
-		assertEquals(read.readVarDouble(1000, true), -65d);
-		assertEquals(read.readVarDouble(1000, false), -8192d);
-		assertEquals(read.readVarDouble(1000, true), -8192d);
-		assertEquals(1.23456d, read.readDouble());
+		assertDoubleEquals(read.readVarDouble(1000, true), 0d);
+		assertDoubleEquals(read.readVarDouble(1000, false), 0d);
+		assertDoubleEquals(read.readVarDouble(1000, true), 63d);
+		assertDoubleEquals(read.readVarDouble(1000, false), 63d);
+		assertDoubleEquals(read.readVarDouble(1000, true), 64d);
+		assertDoubleEquals(read.readVarDouble(1000, false), 64d);
+		assertDoubleEquals(read.readVarDouble(1000, true), 127d);
+		assertDoubleEquals(read.readVarDouble(1000, false), 127d);
+		assertDoubleEquals(read.readVarDouble(1000, true), 128d);
+		assertDoubleEquals(read.readVarDouble(1000, false), 128d);
+		assertDoubleEquals(read.readVarDouble(1000, true), 8191d);
+		assertDoubleEquals(read.readVarDouble(1000, false), 8191d);
+		assertDoubleEquals(read.readVarDouble(1000, true), 8192d);
+		assertDoubleEquals(read.readVarDouble(1000, false), 8192d);
+		assertDoubleEquals(read.readVarDouble(1000, true), 16383d);
+		assertDoubleEquals(read.readVarDouble(1000, false), 16383d);
+		assertDoubleEquals(read.readVarDouble(1000, true), 16384d);
+		assertDoubleEquals(read.readVarDouble(1000, false), 16384d);
+		assertDoubleEquals(read.readVarDouble(1000, true), 32767d);
+		assertDoubleEquals(read.readVarDouble(1000, false), 32767d);
+		assertDoubleEquals(read.readVarDouble(1000, false), -64d);
+		assertDoubleEquals(read.readVarDouble(1000, true), -64d);
+		assertDoubleEquals(read.readVarDouble(1000, false), -65d);
+		assertDoubleEquals(read.readVarDouble(1000, true), -65d);
+		assertDoubleEquals(read.readVarDouble(1000, false), -8192d);
+		assertDoubleEquals(read.readVarDouble(1000, true), -8192d);
+		assertDoubleEquals(1.23456d, read.readDouble());
 	}
 
+	@Test
 	public void testBooleans () throws IOException {
 		runBooleanTest(new UnsafeOutput(4096));
 		runBooleanTest(new UnsafeOutput(new ByteArrayOutputStream()));
@@ -765,6 +778,7 @@ public class UnsafeInputOutputTest extends KryoTestCase {
 		}
 	}
 
+	@Test
 	public void testChars () throws IOException {
 		runCharTest(new UnsafeOutput(4096));
 		runCharTest(new UnsafeOutput(new ByteArrayOutputStream()));
@@ -794,6 +808,7 @@ public class UnsafeInputOutputTest extends KryoTestCase {
 	}
 
 	// Check if writing varInts may produce more bytes than expected
+	@Test
 	public void testWriteTooManyBytes () throws IOException {
 		ByteArrayOutputStream os = new ByteArrayOutputStream(1);
 		runIntTest(new UnsafeOutput(os, 4), os);

--- a/test/com/esotericsoftware/kryo/serializers/ArraySerializerTest.java
+++ b/test/com/esotericsoftware/kryo/serializers/ArraySerializerTest.java
@@ -22,12 +22,15 @@ package com.esotericsoftware.kryo.serializers;
 import com.esotericsoftware.kryo.KryoTestCase;
 import com.esotericsoftware.kryo.serializers.DefaultArraySerializers.ObjectArraySerializer;
 
+import org.junit.Test;
+
 /** @author Nathan Sweet */
 public class ArraySerializerTest extends KryoTestCase {
 	{
 		supportsCopy = true;
 	}
 
+	@Test
 	public void testArrays () {
 		kryo.register(int[].class);
 		kryo.register(int[][].class);

--- a/test/com/esotericsoftware/kryo/serializers/BeanSerializerTest.java
+++ b/test/com/esotericsoftware/kryo/serializers/BeanSerializerTest.java
@@ -21,12 +21,15 @@ package com.esotericsoftware.kryo.serializers;
 
 import com.esotericsoftware.kryo.KryoTestCase;
 
+import org.junit.Test;
+
 /** @author Nathan Sweet */
 public class BeanSerializerTest extends KryoTestCase {
 	{
 		supportsCopy = true;
 	}
 
+	@Test
 	public void testBeanSerializer () {
 		kryo.register(TestClass.class, new BeanSerializer(kryo, TestClass.class));
 

--- a/test/com/esotericsoftware/kryo/serializers/BlowfishSerializerTest.java
+++ b/test/com/esotericsoftware/kryo/serializers/BlowfishSerializerTest.java
@@ -24,8 +24,11 @@ import com.esotericsoftware.kryo.serializers.DefaultSerializers.StringSerializer
 
 import javax.crypto.KeyGenerator;
 
+import org.junit.Test;
+
 /** @author Nathan Sweet */
 public class BlowfishSerializerTest extends KryoTestCase {
+	@Test
 	public void testZip () throws Exception {
 		byte[] key = KeyGenerator.getInstance("Blowfish").generateKey().getEncoded();
 		kryo.register(String.class, new BlowfishSerializer(new StringSerializer(), key));

--- a/test/com/esotericsoftware/kryo/serializers/CollectionSerializerTest.java
+++ b/test/com/esotericsoftware/kryo/serializers/CollectionSerializerTest.java
@@ -33,12 +33,15 @@ import java.util.List;
 import java.util.TreeSet;
 import java.util.concurrent.CopyOnWriteArrayList;
 
+import org.junit.Test;
+
 /** @author Nathan Sweet */
 public class CollectionSerializerTest extends KryoTestCase {
 	{
 		supportsCopy = true;
 	}
 
+	@Test
 	public void testCollections () {
 		kryo.register(ArrayList.class);
 		kryo.register(LinkedList.class);

--- a/test/com/esotericsoftware/kryo/serializers/CompatibleFieldSerializerTest.java
+++ b/test/com/esotericsoftware/kryo/serializers/CompatibleFieldSerializerTest.java
@@ -40,8 +40,7 @@ public class CompatibleFieldSerializerTest extends KryoTestCase {
 		testCompatibleFieldSerializer(86, true, true);
 	}
 
-	@Test
-	public void testCompatibleFieldSerializer (int length, boolean references, final boolean chunked) {
+	private void testCompatibleFieldSerializer (int length, boolean references, final boolean chunked) {
 		kryo.setReferences(references);
 
 		CompatibleFieldSerializer serializer = new CompatibleFieldSerializer(kryo, ClassWithManyFields.class);
@@ -298,8 +297,7 @@ public class CompatibleFieldSerializerTest extends KryoTestCase {
 		testRemovedMultipleFieldsFromClassWithManyFields(247, true, true, false);
 	}
 
-	@Test
-	public void testRemovedMultipleFieldsFromClassWithManyFields (int length, boolean references, boolean chunked,
+	private void testRemovedMultipleFieldsFromClassWithManyFields (int length, boolean references, boolean chunked,
 		boolean readUnknownTagData) {
 		kryo.setReferences(references);
 
@@ -363,8 +361,7 @@ public class CompatibleFieldSerializerTest extends KryoTestCase {
 		testExtendedClass(297, true, true);
 	}
 
-	@Test
-	public void testExtendedClass (int length, boolean references, boolean chunked) {
+	private void testExtendedClass (int length, boolean references, boolean chunked) {
 		kryo.setReferences(references);
 
 		CompatibleFieldSerializer serializer = new CompatibleFieldSerializer(kryo, ExtendedTestClass.class);

--- a/test/com/esotericsoftware/kryo/serializers/CompatibleFieldSerializerTest.java
+++ b/test/com/esotericsoftware/kryo/serializers/CompatibleFieldSerializerTest.java
@@ -24,6 +24,7 @@ import com.esotericsoftware.kryo.KryoTestCase;
 import com.esotericsoftware.kryo.SerializerFactory.CompatibleFieldSerializerFactory;
 
 import org.apache.commons.lang.builder.EqualsBuilder;
+import org.junit.Test;
 
 /** @author Nathan Sweet */
 public class CompatibleFieldSerializerTest extends KryoTestCase {
@@ -31,6 +32,7 @@ public class CompatibleFieldSerializerTest extends KryoTestCase {
 		supportsCopy = true;
 	}
 
+	@Test
 	public void testCompatibleFieldSerializer () {
 		testCompatibleFieldSerializer(83, false, false);
 		testCompatibleFieldSerializer(83, false, true);
@@ -38,6 +40,7 @@ public class CompatibleFieldSerializerTest extends KryoTestCase {
 		testCompatibleFieldSerializer(86, true, true);
 	}
 
+	@Test
 	public void testCompatibleFieldSerializer (int length, boolean references, final boolean chunked) {
 		kryo.setReferences(references);
 
@@ -60,6 +63,7 @@ public class CompatibleFieldSerializerTest extends KryoTestCase {
 		roundTrip(length, object1);
 	}
 
+	@Test
 	public void testAddedField () {
 		testAddedField(59, false, false);
 		testAddedField(87, false, true);
@@ -67,7 +71,7 @@ public class CompatibleFieldSerializerTest extends KryoTestCase {
 		testAddedField(91, true, true);
 	}
 
-	public void testAddedField (int length, boolean references, boolean chunked) {
+	private void testAddedField (int length, boolean references, boolean chunked) {
 		kryo.setReferences(references);
 
 		CompatibleFieldSerializer serializer = new CompatibleFieldSerializer(kryo, AnotherClass.class);
@@ -91,6 +95,7 @@ public class CompatibleFieldSerializerTest extends KryoTestCase {
 		assertEquals(object1, object2);
 	}
 
+	@Test
 	public void testAddedFieldToClassWithManyFields () {
 		testAddedFieldToClassWithManyFields(189, false, false, true);
 		testAddedFieldToClassWithManyFields(152, false, false, false);
@@ -105,7 +110,8 @@ public class CompatibleFieldSerializerTest extends KryoTestCase {
 		testAddedFieldToClassWithManyFields(264, true, true, false);
 	}
 
-	public void testAddedFieldToClassWithManyFields (int length, boolean references, boolean chunked, boolean readUnknownTagData) {
+	private void testAddedFieldToClassWithManyFields (int length, boolean references, boolean chunked,
+		boolean readUnknownTagData) {
 		kryo.setReferences(references);
 
 		CompatibleFieldSerializer serializer = new CompatibleFieldSerializer(kryo, ClassWithManyFields.class);
@@ -162,6 +168,7 @@ public class CompatibleFieldSerializerTest extends KryoTestCase {
 		assertEquals(object1, object2);
 	}
 
+	@Test
 	public void testRemovedField () {
 		testRemovedField(92, false, false);
 		testRemovedField(125, false, true);
@@ -199,6 +206,7 @@ public class CompatibleFieldSerializerTest extends KryoTestCase {
 		assertEquals(object1, object2);
 	}
 
+	@Test
 	public void testRemovedFieldFromClassWithManyFields () {
 		testRemovedFieldFromClassWithManyFields(198, false, false, true);
 		// testRemovedFieldFromClassWithManyFields(0, false, false, false); // Doesn't support remove.
@@ -213,7 +221,7 @@ public class CompatibleFieldSerializerTest extends KryoTestCase {
 		testRemovedFieldFromClassWithManyFields(275, true, true, false);
 	}
 
-	public void testRemovedFieldFromClassWithManyFields (int length, boolean references, boolean chunked,
+	private void testRemovedFieldFromClassWithManyFields (int length, boolean references, boolean chunked,
 		boolean readUnknownTagData) {
 		kryo.setReferences(references);
 
@@ -275,6 +283,7 @@ public class CompatibleFieldSerializerTest extends KryoTestCase {
 		assertEquals(object1, object2);
 	}
 
+	@Test
 	public void testRemovedMultipleFieldsFromClassWithManyFields () {
 		testRemovedMultipleFieldsFromClassWithManyFields(170, false, false, true);
 		// testRemovedMultipleFieldsFromClassWithManyFields(0, false, false, false); // Doesn't support remove.
@@ -289,6 +298,7 @@ public class CompatibleFieldSerializerTest extends KryoTestCase {
 		testRemovedMultipleFieldsFromClassWithManyFields(247, true, true, false);
 	}
 
+	@Test
 	public void testRemovedMultipleFieldsFromClassWithManyFields (int length, boolean references, boolean chunked,
 		boolean readUnknownTagData) {
 		kryo.setReferences(references);
@@ -345,6 +355,7 @@ public class CompatibleFieldSerializerTest extends KryoTestCase {
 		assertEquals(object1, object2);
 	}
 
+	@Test
 	public void testExtendedClass () {
 		testExtendedClass(270, false, false);
 		testExtendedClass(294, false, true);
@@ -352,6 +363,7 @@ public class CompatibleFieldSerializerTest extends KryoTestCase {
 		testExtendedClass(297, true, true);
 	}
 
+	@Test
 	public void testExtendedClass (int length, boolean references, boolean chunked) {
 		kryo.setReferences(references);
 

--- a/test/com/esotericsoftware/kryo/serializers/DefaultSerializersTest.java
+++ b/test/com/esotericsoftware/kryo/serializers/DefaultSerializersTest.java
@@ -43,6 +43,7 @@ import java.util.Locale;
 import java.util.PriorityQueue;
 import java.util.TimeZone;
 
+import org.junit.Test;
 import org.objenesis.strategy.StdInstantiatorStrategy;
 
 /** @author Nathan Sweet */
@@ -51,34 +52,40 @@ public class DefaultSerializersTest extends KryoTestCase {
 		supportsCopy = true;
 	}
 
+	@Test
 	public void testBoolean () {
 		roundTrip(2, true);
 		roundTrip(2, false);
 	}
 
+	@Test
 	public void testByte () {
 		roundTrip(2, (byte)1);
 		roundTrip(2, (byte)125);
 		roundTrip(2, (byte)-125);
 	}
 
+	@Test
 	public void testChar () {
 		roundTrip(3, 'a');
 		roundTrip(3, 'z');
 	}
 
+	@Test
 	public void testDouble () {
 		roundTrip(9, 0d);
 		roundTrip(9, 1234d);
 		roundTrip(9, 1234.5678d);
 	}
 
+	@Test
 	public void testFloat () {
 		roundTrip(5, 0f);
 		roundTrip(5, 123f);
 		roundTrip(5, 123.456f);
 	}
 
+	@Test
 	public void testInt () {
 		roundTrip(2, 0);
 		roundTrip(2, 63);
@@ -103,6 +110,7 @@ public class DefaultSerializersTest extends KryoTestCase {
 		roundTrip(6, -134217729);
 	}
 
+	@Test
 	public void testLong () {
 		roundTrip(2, 0l);
 		roundTrip(2, 63l);
@@ -129,6 +137,7 @@ public class DefaultSerializersTest extends KryoTestCase {
 		roundTrip(10, -2368365495612416452l);
 	}
 
+	@Test
 	public void testShort () {
 		roundTrip(3, (short)0);
 		roundTrip(3, (short)123);
@@ -139,6 +148,7 @@ public class DefaultSerializersTest extends KryoTestCase {
 		roundTrip(3, (short)400);
 	}
 
+	@Test
 	public void testString () {
 		kryo = new Kryo();
 		roundTrip(6, "meow");
@@ -155,10 +165,12 @@ public class DefaultSerializersTest extends KryoTestCase {
 		roundTrip(21, "abcdef\u00E1\u00E9\u00ED\u00F3\u00FA\u7C9F");
 	}
 
+	@Test
 	public void testVoid () throws InstantiationException, IllegalAccessException {
 		roundTrip(1, (Void)null);
 	}
 
+	@Test
 	public void testNull () {
 		kryo = new Kryo();
 		kryo.register(ArrayList.class);
@@ -208,6 +220,7 @@ public class DefaultSerializersTest extends KryoTestCase {
 		roundTrip(10, new java.sql.Timestamp(-1234567));
 	}
 
+	@Test
 	public void testBigDecimalSerializer () {
 		kryo.register(BigDecimal.class);
 		kryo.register(BigDecimalSubclass.class);
@@ -220,6 +233,7 @@ public class DefaultSerializersTest extends KryoTestCase {
 		roundTrip(7, new BigDecimalSubclass("12345.12345"));
 	}
 
+	@Test
 	public void testBigIntegerSerializer () {
 		kryo.register(BigInteger.class);
 		kryo.register(BigIntegerSubclass.class);
@@ -230,6 +244,7 @@ public class DefaultSerializersTest extends KryoTestCase {
 		roundTrip(8, new BigIntegerSubclass("1270507903945"));
 	}
 
+	@Test
 	public void testEnumSerializer () {
 		kryo.register(TestEnum.class);
 		roundTrip(2, TestEnum.a);
@@ -241,6 +256,7 @@ public class DefaultSerializersTest extends KryoTestCase {
 		roundTrip(72, TestEnum.c);
 	}
 
+	@Test
 	public void testEnumSetSerializer () {
 		kryo.register(EnumSet.class);
 		kryo.register(TestEnum.class);
@@ -256,6 +272,7 @@ public class DefaultSerializersTest extends KryoTestCase {
 		roundTrip(101, EnumSet.of(TestEnum.a, TestEnum.c));
 	}
 
+	@Test
 	public void testEnumSerializerWithMethods () {
 		kryo.register(TestEnumWithMethods.class);
 		roundTrip(2, TestEnumWithMethods.a);
@@ -267,6 +284,7 @@ public class DefaultSerializersTest extends KryoTestCase {
 		roundTrip(85, TestEnumWithMethods.c);
 	}
 
+	@Test
 	public void testCollectionsMethods () {
 		kryo.setRegistrationRequired(false);
 		ArrayList test = new ArrayList();
@@ -279,18 +297,21 @@ public class DefaultSerializersTest extends KryoTestCase {
 		roundTrip(249, test);
 	}
 
+	@Test
 	public void testArraysAsListUnregistered () {
 		kryo.setRegistrationRequired(false);
 		roundTrip(29, Arrays.asList());
 		roundTrip(37, Arrays.asList(new String[] {"A", "B", "C"}));
 	}
 
+	@Test
 	public void testArraysAsList () {
 		kryo.register(Arrays.asList().getClass());
 		roundTrip(2, Arrays.asList());
 		roundTrip(10, Arrays.asList(new String[] {"A", "B", "C"}));
 	}
 
+	@Test
 	public void testDeepCollectionCloning () {
 		kryo.setRegistrationRequired(false);
 		Object contents = new Object();
@@ -299,6 +320,7 @@ public class DefaultSerializersTest extends KryoTestCase {
 		assertNotEquals(kryo.copy(Collections.singletonMap(contents, contents)).values().iterator().next(), contents);
 	}
 
+	@Test
 	public void testPriorityQueueCopy () {
 		List<Integer> values = Arrays.asList(7, 0, 5, 123, 432);
 		PriorityQueue<Integer> queue = new PriorityQueue(3, new Comparator<Integer>() {
@@ -313,6 +335,7 @@ public class DefaultSerializersTest extends KryoTestCase {
 		assertEquals(queue.peek(), copy.peek());
 	}
 
+	@Test
 	public void testCalendar () {
 		kryo.setRegistrationRequired(false);
 		Calendar calendar = Calendar.getInstance();
@@ -321,6 +344,7 @@ public class DefaultSerializersTest extends KryoTestCase {
 		roundTrip(64, calendar);
 	}
 
+	@Test
 	public void testClassSerializer () {
 		kryo.register(Class.class);
 		kryo.register(ArrayList.class);
@@ -374,6 +398,7 @@ public class DefaultSerializersTest extends KryoTestCase {
 		assertEquals(Enum.class, kryo.readObject(in, Class.class));
 	}
 
+	@Test
 	public void testLocaleSerializer () {
 		kryo.register(Locale.class);
 
@@ -384,6 +409,7 @@ public class DefaultSerializersTest extends KryoTestCase {
 		roundTrip(16, new Locale("es", "ES", "\u00E1\u00E9\u00ED\u00F3\u00FA"));
 	}
 
+	@Test
 	public void testCharset () {
 		List<String> css = Arrays.asList("ISO-8859-1", "US-ASCII", "UTF-8", "UTF-16", "UTF-16BE", "UTF-16LE");
 
@@ -404,6 +430,7 @@ public class DefaultSerializersTest extends KryoTestCase {
 		}
 	}
 
+	@Test
 	public void testURLSerializer () throws Exception {
 		kryo.setInstantiatorStrategy(new DefaultInstantiatorStrategy(new StdInstantiatorStrategy()));
 		kryo.register(URL.class);

--- a/test/com/esotericsoftware/kryo/serializers/DeflateSerializerTest.java
+++ b/test/com/esotericsoftware/kryo/serializers/DeflateSerializerTest.java
@@ -22,13 +22,17 @@ package com.esotericsoftware.kryo.serializers;
 import com.esotericsoftware.kryo.KryoTestCase;
 import com.esotericsoftware.kryo.serializers.DefaultSerializers.StringSerializer;
 
+import org.junit.Test;
+
 /** @author Nathan Sweet */
 public class DeflateSerializerTest extends KryoTestCase {
+	@Test
 	public void testString () {
 		kryo.register(String.class, new DeflateSerializer(new StringSerializer()));
 		roundTrip(14, "abcdefabcdefabcdefabcdefabcdefabcdefabcdef");
 	}
 
+	@Test
 	public void testGraph () {
 		kryo.register(Message.class);
 		kryo.register(MessageType.class);

--- a/test/com/esotericsoftware/kryo/serializers/EnumNameSerializerTest.java
+++ b/test/com/esotericsoftware/kryo/serializers/EnumNameSerializerTest.java
@@ -26,8 +26,11 @@ import com.esotericsoftware.kryo.io.Output;
 
 import java.util.EnumSet;
 
+import org.junit.Test;
+
 /** @author KwonNam Son <kwon37xi@gmail.com> */
 public class EnumNameSerializerTest extends KryoTestCase {
+	@Test
 	public void testEnumNameSerializer () {
 		kryo.addDefaultSerializer(Enum.class, EnumNameSerializer.class);
 		kryo.register(TestNameEnum.class);
@@ -49,6 +52,7 @@ public class EnumNameSerializerTest extends KryoTestCase {
 		roundTrip(88, TestAnotherNameEnum.MONDAY);
 	}
 
+	@Test
 	public void testEnumSetSerializerWithEnumNameSerializer () throws Exception {
 		kryo.addDefaultSerializer(Enum.class, EnumNameSerializer.class);
 		kryo.register(EnumSet.class);
@@ -71,6 +75,7 @@ public class EnumNameSerializerTest extends KryoTestCase {
 		roundTrip(3, EnumSet.noneOf(TestNameEnum.class));
 	}
 
+	@Test
 	public void testEnumNameSerializerWithMethods () {
 		kryo.addDefaultSerializer(Enum.class, EnumNameSerializer.class);
 

--- a/test/com/esotericsoftware/kryo/serializers/ExternalizableSerializerTest.java
+++ b/test/com/esotericsoftware/kryo/serializers/ExternalizableSerializerTest.java
@@ -31,8 +31,11 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
+import org.junit.Test;
+
 /** @author Robert DiFalco <robert.difalco@gmail.com> */
 public class ExternalizableSerializerTest extends KryoTestCase {
+	@Test
 	public void testRegister () {
 		kryo.register(TestClass.class, new ExternalizableSerializer());
 		kryo.register(String.class, new DefaultSerializers.StringSerializer());
@@ -45,6 +48,7 @@ public class ExternalizableSerializerTest extends KryoTestCase {
 		roundTrip(11, test);
 	}
 
+	@Test
 	public void testDefault () {
 		kryo.setRegistrationRequired(false);
 		kryo.addDefaultSerializer(Externalizable.class, new ExternalizableSerializer());
@@ -56,6 +60,7 @@ public class ExternalizableSerializerTest extends KryoTestCase {
 		roundTrip(88, test);
 	}
 
+	@Test
 	public void testReadResolve () {
 		kryo.setRegistrationRequired(false);
 		kryo.addDefaultSerializer(Externalizable.class, ExternalizableSerializer.class);
@@ -74,6 +79,7 @@ public class ExternalizableSerializerTest extends KryoTestCase {
 		assertEquals(test.value, result);
 	}
 
+	@Test
 	public void testTwoClasses () {
 		kryo.setRegistrationRequired(false);
 		kryo.addDefaultSerializer(Externalizable.class, ExternalizableSerializer.class);

--- a/test/com/esotericsoftware/kryo/serializers/FieldSerializerInheritanceTest.java
+++ b/test/com/esotericsoftware/kryo/serializers/FieldSerializerInheritanceTest.java
@@ -22,8 +22,11 @@ package com.esotericsoftware.kryo.serializers;
 import com.esotericsoftware.kryo.KryoTestCase;
 import com.esotericsoftware.kryo.SerializerFactory.FieldSerializerFactory;
 
+import org.junit.Test;
+
 /** Created by phamrak on 8.6.2016. */
 public class FieldSerializerInheritanceTest extends KryoTestCase {
+	@Test
 	public void testDefaultStrategyForDefaultClass () {
 		TestDefault testDefault = new TestDefault();
 		testDefault.a = "someDefaultValue";
@@ -38,6 +41,7 @@ public class FieldSerializerInheritanceTest extends KryoTestCase {
 		assertFieldRemoved(serializer, "a");
 	}
 
+	@Test
 	public void testDefaultStrategyForExtendedClass () {
 		TestExtended testExtended = new TestExtended();
 		((TestDefault)testExtended).a = "someDefaultValue";
@@ -58,6 +62,7 @@ public class FieldSerializerInheritanceTest extends KryoTestCase {
 		assertFieldRemoved(serializer, "a");
 	}
 
+	@Test
 	public void testExtendedStrategyForExtendedClass () {
 		TestExtended testExtended = new TestExtended();
 		((TestDefault)testExtended).a = "someDefaultValue";
@@ -80,7 +85,7 @@ public class FieldSerializerInheritanceTest extends KryoTestCase {
 		assertFieldRemoved(serializer, "TestExtended.a");
 	}
 
-	protected void assertFieldRemoved (FieldSerializer serializer, String fieldName) {
+	private void assertFieldRemoved (FieldSerializer serializer, String fieldName) {
 		try {
 			assertNull(serializer.getField(fieldName));
 			fail("Expected IllegalArgumentException to be thrown for serializer.getField(" + fieldName + ")");

--- a/test/com/esotericsoftware/kryo/serializers/FieldSerializerTest.java
+++ b/test/com/esotericsoftware/kryo/serializers/FieldSerializerTest.java
@@ -47,6 +47,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
+import org.junit.Test;
 import org.objenesis.strategy.StdInstantiatorStrategy;
 
 /** @author Nathan Sweet */
@@ -56,6 +57,7 @@ public class FieldSerializerTest extends KryoTestCase {
 		supportsCopy = true;
 	}
 
+	@Test
 	public void testDefaultTypes () {
 		kryo.register(DefaultTypes.class);
 		kryo.register(byte[].class);
@@ -91,6 +93,7 @@ public class FieldSerializerTest extends KryoTestCase {
 		roundTrip(78, test);
 	}
 
+	@Test
 	public void testFieldRemoval () {
 		kryo.register(DefaultTypes.class);
 		kryo.register(byte[].class);
@@ -121,6 +124,7 @@ public class FieldSerializerTest extends KryoTestCase {
 		supportsCopy = true;
 	}
 
+	@Test
 	public void testFieldRemovalOnGenerics () {
 		kryo.register(IsGeneric.class);
 		kryo.register(DefaultTypes.class);
@@ -141,6 +145,7 @@ public class FieldSerializerTest extends KryoTestCase {
 		}
 	}
 
+	@Test
 	public void testOptionalRegistration () {
 		kryo.setRegistrationRequired(false);
 		DefaultTypes test = new DefaultTypes();
@@ -189,6 +194,7 @@ public class FieldSerializerTest extends KryoTestCase {
 		roundTrip(75, c);
 	}
 
+	@Test
 	public void testReferences () {
 		C c = new C();
 		c.a = new A();
@@ -223,6 +229,7 @@ public class FieldSerializerTest extends KryoTestCase {
 		assertTrue(c2.d == c2.d.e.f.d);
 	}
 
+	@Test
 	public void testRegistrationOrder () {
 		A a = new A();
 		a.value = 100;
@@ -242,6 +249,7 @@ public class FieldSerializerTest extends KryoTestCase {
 		roundTrip(10, a);
 	}
 
+	@Test
 	public void testExceptionTrace () {
 		C c = new C();
 		c.a = new A();
@@ -290,6 +298,7 @@ public class FieldSerializerTest extends KryoTestCase {
 		}
 	}
 
+	@Test
 	public void testNoDefaultConstructor () {
 		kryo.register(SimpleNoDefaultConstructor.class, new Serializer<SimpleNoDefaultConstructor>() {
 			public SimpleNoDefaultConstructor read (Kryo kryo, Input input, Class<? extends SimpleNoDefaultConstructor> type) {
@@ -329,6 +338,7 @@ public class FieldSerializerTest extends KryoTestCase {
 		roundTrip(35, object2);
 	}
 
+	@Test
 	public void testNonNull () {
 		kryo.register(HasNonNull.class);
 		HasNonNull nonNullValue = new HasNonNull();
@@ -336,12 +346,14 @@ public class FieldSerializerTest extends KryoTestCase {
 		roundTrip(4, nonNullValue);
 	}
 
+	@Test
 	public void testDefaultSerializerAnnotation () {
 		kryo = new Kryo();
 		kryo.setRegistrationRequired(false);
 		roundTrip(92, new HasDefaultSerializerAnnotation(123));
 	}
 
+	@Test
 	public void testOptionalAnnotation () {
 		kryo = new Kryo();
 		kryo.setRegistrationRequired(false);
@@ -352,6 +364,7 @@ public class FieldSerializerTest extends KryoTestCase {
 		roundTrip(83, new HasOptionalAnnotation());
 	}
 
+	@Test
 	public void testCyclicGrgaph () throws Exception {
 		kryo = new Kryo();
 		kryo.register(DefaultTypes.class);
@@ -361,6 +374,7 @@ public class FieldSerializerTest extends KryoTestCase {
 		roundTrip(35, test);
 	}
 
+	@Test
 	public void testInstantiatorStrategy () {
 		kryo.register(HasArgumentConstructor.class);
 		kryo.setInstantiatorStrategy(new StdInstantiatorStrategy());
@@ -373,6 +387,7 @@ public class FieldSerializerTest extends KryoTestCase {
 	}
 
 	/** This test uses StdInstantiatorStrategy and therefore requires a no-arg constructor. **/
+	@Test
 	public void testDefaultInstantiatorStrategy () {
 		kryo.register(HasArgumentConstructor.class);
 		HasArgumentConstructor test = new HasPrivateConstructor();
@@ -384,6 +399,7 @@ public class FieldSerializerTest extends KryoTestCase {
 	}
 
 	/** This test uses StdInstantiatorStrategy and should bypass invocation of no-arg constructor, even if it is provided. **/
+	@Test
 	public void testStdInstantiatorStrategy () {
 		kryo.register(HasArgumentConstructor.class);
 		kryo.setInstantiatorStrategy(new StdInstantiatorStrategy());
@@ -396,6 +412,7 @@ public class FieldSerializerTest extends KryoTestCase {
 			HasPrivateConstructor.invocations);
 	}
 
+	@Test
 	public void testGenericTypes () {
 		kryo.setReferences(true);
 		kryo.register(HasGenerics.class);
@@ -436,6 +453,7 @@ public class FieldSerializerTest extends KryoTestCase {
 		roundTrip(17, al);
 	}
 
+	@Test
 	public void testRegistration () {
 		int id = kryo.getNextRegistrationId();
 		kryo.register(DefaultTypes.class, id);
@@ -453,6 +471,7 @@ public class FieldSerializerTest extends KryoTestCase {
 		roundTrip(75, test);
 	}
 
+	@Test
 	public void testTransients () {
 		kryo.register(HasTransients.class);
 		HasTransients objectWithTransients1 = new HasTransients();
@@ -475,6 +494,7 @@ public class FieldSerializerTest extends KryoTestCase {
 		assertEquals("Objects should be equal if copy includes transient fields", objectWithTransients2, objectWithTransients1);
 	}
 
+	@Test
 	public void testTransientsUsingGlobalConfig () {
 		FieldSerializerFactory factory = new FieldSerializerFactory();
 		factory.getConfig().setCopyTransient(false);
@@ -497,6 +517,7 @@ public class FieldSerializerTest extends KryoTestCase {
 		assertEquals("Objects should be equal if copy includes transient fields", objectWithTransients2, objectWithTransients1);
 	}
 
+	@Test
 	public void testSerializeTransients () {
 		kryo.register(HasTransients.class);
 		HasTransients objectWithTransients1 = new HasTransients();
@@ -540,6 +561,7 @@ public class FieldSerializerTest extends KryoTestCase {
 			objectWithTransients2.equals(objectWithTransients1));
 	}
 
+	@Test
 	public void testSerializeTransientsUsingGlobalConfig () {
 		FieldSerializerFactory factory = new FieldSerializerFactory();
 		factory.getConfig().setSerializeTransient(false);
@@ -583,6 +605,7 @@ public class FieldSerializerTest extends KryoTestCase {
 			objectWithTransients2.equals(objectWithTransients1));
 	}
 
+	@Test
 	public void testCorrectlyAnnotatedFields () {
 		kryo.register(int[].class);
 		kryo.register(long[].class);
@@ -613,6 +636,7 @@ public class FieldSerializerTest extends KryoTestCase {
 		roundTrip(41, obj1);
 	}
 
+	@Test
 	public void testWronglyAnnotatedCollectionFields () {
 		try {
 			kryo.register(WronglyAnnotatedCollectionFields.class);
@@ -627,6 +651,7 @@ public class FieldSerializerTest extends KryoTestCase {
 		assertFalse("Exception was expected", true);
 	}
 
+	@Test
 	public void testWronglyAnnotatedMapFields () {
 		try {
 			kryo.register(WronglyAnnotatedMapFields.class);
@@ -641,6 +666,7 @@ public class FieldSerializerTest extends KryoTestCase {
 		assertFalse("Exception was expected", true);
 	}
 
+	@Test
 	public void testMultipleTimesAnnotatedMapFields () {
 		try {
 			kryo.register(MultipleTimesAnnotatedCollectionFields.class);
@@ -655,6 +681,7 @@ public class FieldSerializerTest extends KryoTestCase {
 		assertFalse("Exception was expected", true);
 	}
 
+	@Test
 	public void testDeep () {
 		kryo.register(Deep.class);
 		Deep root = new Deep();

--- a/test/com/esotericsoftware/kryo/serializers/Java8ClosureSerializerTest.java
+++ b/test/com/esotericsoftware/kryo/serializers/Java8ClosureSerializerTest.java
@@ -26,9 +26,13 @@ import com.esotericsoftware.kryo.io.Output;
 import java.lang.invoke.SerializedLambda;
 import java.util.concurrent.Callable;
 
+import org.junit.Before;
+import org.junit.Test;
+
 /** Test for java 8 closures. For JDK < 1.8 exclude from the surefire tests via the "until-java8" profile in pom.xml (which
  * excludes "Java8*Tests"). */
 public class Java8ClosureSerializerTest extends KryoTestCase {
+	@Before
 	public void setUp () throws Exception {
 		super.setUp();
 		// kryo.setInstantiatorStrategy(new DefaultInstantiatorStrategy(new StdInstantiatorStrategy()));
@@ -39,6 +43,7 @@ public class Java8ClosureSerializerTest extends KryoTestCase {
 		kryo.register(ClosureSerializer.Closure.class, new ClosureSerializer());
 	}
 
+	@Test
 	public void testSerializableClosure () throws Exception {
 		Callable<Integer> closure1 = (Callable<Integer> & java.io.Serializable)( () -> 72363);
 
@@ -54,6 +59,7 @@ public class Java8ClosureSerializerTest extends KryoTestCase {
 		doAssertEquals(closure1, closure2);
 	}
 
+	@Override
 	protected void doAssertEquals (Object object1, Object object2) {
 		try {
 			assertEquals(((Callable)object1).call(), ((Callable)object2).call());

--- a/test/com/esotericsoftware/kryo/serializers/JavaSerializerTest.java
+++ b/test/com/esotericsoftware/kryo/serializers/JavaSerializerTest.java
@@ -23,8 +23,11 @@ import com.esotericsoftware.kryo.KryoTestCase;
 
 import java.io.Serializable;
 
+import org.junit.Test;
+
 /** @author Nathan Sweet */
 public class JavaSerializerTest extends KryoTestCase {
+	@Test
 	public void testJavaSerializer () {
 		kryo.register(String.class, new JavaSerializer());
 		roundTrip(50, "abcdefabcdefabcdefabcdefabcdefabcdefabcdef");

--- a/test/com/esotericsoftware/kryo/serializers/MapSerializerTest.java
+++ b/test/com/esotericsoftware/kryo/serializers/MapSerializerTest.java
@@ -40,6 +40,7 @@ import java.util.TreeMap;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.commons.lang.builder.EqualsBuilder;
+import org.junit.Test;
 
 /** @author Nathan Sweet */
 @SuppressWarnings("synthetic-access")
@@ -48,6 +49,7 @@ public class MapSerializerTest extends KryoTestCase {
 		supportsCopy = true;
 	}
 
+	@Test
 	public void testMaps () {
 		kryo.register(HashMap.class);
 		kryo.register(LinkedHashMap.class);
@@ -69,6 +71,7 @@ public class MapSerializerTest extends KryoTestCase {
 		roundTrip(14, map);
 	}
 
+	@Test
 	public void testEnumMap () {
 		kryo.register(SomeEnum.class);
 		kryo.register(EnumMap.class, new EnumMapSerializer(SomeEnum.class));
@@ -80,22 +83,27 @@ public class MapSerializerTest extends KryoTestCase {
 		roundTrip(7, map);
 	}
 
+	@Test
 	public void testEmptyHashMap () {
 		execute(new HashMap(), 0);
 	}
 
+	@Test
 	public void testNotEmptyHashMap () {
 		execute(new HashMap(), 1000);
 	}
 
+	@Test
 	public void testEmptyConcurrentHashMap () {
 		execute(new ConcurrentHashMap(), 0);
 	}
 
+	@Test
 	public void testNotEmptyConcurrentHashMap () {
 		execute(new ConcurrentHashMap(), 1000);
 	}
 
+	@Test
 	public void testGenerics () {
 		kryo.register(HasGenerics.class);
 		kryo.register(Integer[].class);
@@ -133,6 +141,7 @@ public class MapSerializerTest extends KryoTestCase {
 		assertEquals(map, deserialized);
 	}
 
+	@Test
 	public void testTreeMap () {
 		kryo.register(TreeMap.class);
 		TreeMap map = new TreeMap();
@@ -160,6 +169,7 @@ public class MapSerializerTest extends KryoTestCase {
 		roundTrip(24, map);
 	}
 
+	@Test
 	public void testTreeMapWithReferences () {
 		kryo.setReferences(true);
 		kryo.register(TreeMap.class);
@@ -188,6 +198,7 @@ public class MapSerializerTest extends KryoTestCase {
 		roundTrip(29, map);
 	}
 
+	@Test
 	public void testSerializingMapAfterDeserializingMultipleReferencesToSameMap () throws Exception {
 		Kryo kryo = new Kryo();
 		kryo.setRegistrationRequired(false);
@@ -198,7 +209,7 @@ public class MapSerializerTest extends KryoTestCase {
 		output.reset();
 
 		Map<Integer, List<String>> mapOfLists = new HashMap();
-		mapOfLists.put(1, new java.util.ArrayList());
+		mapOfLists.put(1, new ArrayList());
 		kryo.writeClassAndObject(output, mapOfLists);
 
 		Map<Integer, List<String>> deserializedMap = (Map<Integer, List<String>>)kryo
@@ -206,6 +217,7 @@ public class MapSerializerTest extends KryoTestCase {
 		assertEquals(1, deserializedMap.size());
 	}
 
+	@Test
 	public void testArrayListKeys () {
 		CollectionSerializer collectionSerializer = new CollectionSerializer();
 		// Increase generics savings so difference is more easily seen.

--- a/test/com/esotericsoftware/kryo/serializers/TaggedFieldSerializerTest.java
+++ b/test/com/esotericsoftware/kryo/serializers/TaggedFieldSerializerTest.java
@@ -32,12 +32,15 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.FileNotFoundException;
 
+import org.junit.Test;
+
 @SuppressWarnings("synthetic-access")
 public class TaggedFieldSerializerTest extends KryoTestCase {
 	{
 		supportsCopy = true;
 	}
 
+	@Test
 	public void testTaggedFieldSerializer () throws FileNotFoundException {
 		TestClass object1 = new TestClass();
 		object1.moo = 2;
@@ -53,6 +56,7 @@ public class TaggedFieldSerializerTest extends KryoTestCase {
 		assertTrue(object2.ignored == 0);
 	}
 
+	@Test
 	public void testAddedField () throws FileNotFoundException {
 		TestClass object1 = new TestClass();
 		object1.child = new TestClass();
@@ -73,6 +77,7 @@ public class TaggedFieldSerializerTest extends KryoTestCase {
 	/** Serializes an array with a Class with two tagged fields. Then deserializes it using a serializer that has removed some
 	 * fields to simulate a past version of the compiled application. An array is used to ensure subsequent bytes in the stream are
 	 * unaffected. */
+	@Test
 	public void testForwardCompatibility () {
 		FutureClass futureObject = new FutureClass();
 		futureObject.value = 3;
@@ -134,6 +139,7 @@ public class TaggedFieldSerializerTest extends KryoTestCase {
 
 	/** Attempts to register a class with a field tagged with a value already used in its superclass. Should receive
 	 * IllegalArgumentException. */
+	@Test
 	public void testInvalidTagValue () {
 		Kryo newKryo = new Kryo();
 		newKryo.setReferences(true);

--- a/test/com/esotericsoftware/kryo/serializers/VersionedFieldSerializerTest.java
+++ b/test/com/esotericsoftware/kryo/serializers/VersionedFieldSerializerTest.java
@@ -24,11 +24,14 @@ import com.esotericsoftware.kryo.serializers.VersionFieldSerializer.Since;
 
 import java.io.FileNotFoundException;
 
+import org.junit.Test;
+
 public class VersionedFieldSerializerTest extends KryoTestCase {
 	{
 		supportsCopy = true;
 	}
 
+	@Test
 	public void testVersionFieldSerializer () throws FileNotFoundException {
 		TestClass object1 = new TestClass();
 		object1.moo = 2;


### PR DESCRIPTION
- Add Junit4 style annotation @Before,@Test.
- Change public method to private if it is possible.
- Stop extending TestCase class, If it is possible.
- Because There are deprecated methods in junit4,
  I add static assertion class which is simple wrapper class.

I will Making KryoTestCase stop extending TestCase class at Part 3.