### PR TITLE
 Move to Junit4 Style test code(Part3)

### DIFF
--- a/test/com/esotericsoftware/kryo/CopyTest.java
+++ b/test/com/esotericsoftware/kryo/CopyTest.java
@@ -19,6 +19,8 @@
 
 package com.esotericsoftware.kryo;
 
+import static org.junit.Assert.*;
+
 import java.util.ArrayList;
 
 import org.junit.Before;

--- a/test/com/esotericsoftware/kryo/CopyTest.java
+++ b/test/com/esotericsoftware/kryo/CopyTest.java
@@ -41,7 +41,7 @@ public class CopyTest extends KryoTestCase {
 		test.add("three");
 
 		ArrayList copy = kryo.copy(test);
-		assertTrue(test != copy);
+		assertNotSame(test, copy);
 		assertEquals(test, copy);
 	}
 
@@ -61,14 +61,14 @@ public class CopyTest extends KryoTestCase {
 		test.add(test2);
 
 		ArrayList copy = kryo.copy(test);
-		assertTrue(test != copy);
-		assertTrue(test.get(3) != copy.get(3));
+		assertNotSame(test, copy);
+		assertNotSame(test.get(3), copy.get(3));
 		assertEquals(test, copy);
 
 		kryo.setCopyReferences(false);
 		copy = kryo.copy(test);
-		assertTrue(test != copy);
-		assertTrue(test.get(3) != copy.get(3));
+		assertNotSame(test, copy);
+		assertNotSame(test.get(3), copy.get(3));
 		assertEquals(test, copy);
 	}
 
@@ -90,19 +90,19 @@ public class CopyTest extends KryoTestCase {
 		test.add(test2);
 
 		ArrayList copy = kryo.copy(test);
-		assertTrue(test != copy);
+		assertNotSame(test, copy);
 		assertEquals(test, copy);
-		assertTrue(test.get(3) != copy.get(4));
-		assertTrue(copy.get(3) == copy.get(4));
-		assertTrue(copy.get(3) == copy.get(5));
+		assertNotSame(test.get(3), copy.get(4));
+		assertSame(copy.get(3), copy.get(4));
+		assertSame(copy.get(3), copy.get(5));
 
 		kryo.setCopyReferences(false);
 		copy = kryo.copy(test);
-		assertTrue(test != copy);
+		assertNotSame(test, copy);
 		assertEquals(test, copy);
-		assertTrue(test.get(3) != copy.get(4));
-		assertTrue(copy.get(3) != copy.get(4));
-		assertTrue(copy.get(3) != copy.get(5));
+		assertNotSame(test.get(3), copy.get(4));
+		assertNotSame(copy.get(3), copy.get(4));
+		assertNotSame(copy.get(3), copy.get(5));
 	}
 
 	@Test
@@ -114,11 +114,11 @@ public class CopyTest extends KryoTestCase {
 		test.add(test);
 
 		ArrayList copy = kryo.copy(test);
-		assertTrue(test != copy);
+		assertNotSame(test, copy);
 		assertEquals(copy.get(0), "one");
 		assertEquals(copy.get(1), "two");
 		assertEquals(copy.get(2), "three");
-		assertTrue(copy.get(3) == copy);
+		assertSame(copy.get(3), copy);
 
 		Moo root = new Moo();
 		Moo moo1 = new Moo();
@@ -129,13 +129,13 @@ public class CopyTest extends KryoTestCase {
 		moo2.moo = moo3;
 		moo3.moo = root;
 		Moo root2 = kryo.copy(root);
-		assertTrue(root != root2);
-		assertTrue(root.moo != root2.moo);
-		assertTrue(root.moo.moo != root2.moo.moo);
-		assertTrue(root.moo.moo.moo != root2.moo.moo.moo);
-		assertTrue(root.moo.moo.moo.moo != root2.moo.moo.moo.moo);
-		assertTrue(root.moo.moo.moo.moo == root);
-		assertTrue(root2.moo.moo.moo.moo == root2);
+		assertNotSame(root, root2);
+		assertNotSame(root.moo, root2.moo);
+		assertNotSame(root.moo.moo, root2.moo.moo);
+		assertNotSame(root.moo.moo.moo, root2.moo.moo.moo);
+		assertNotSame(root.moo.moo.moo.moo, root2.moo.moo.moo.moo);
+		assertSame(root.moo.moo.moo.moo, root);
+		assertSame(root2.moo.moo.moo.moo, root2);
 	}
 
 	@Test
@@ -154,8 +154,8 @@ public class CopyTest extends KryoTestCase {
 		test.add(test2);
 
 		ArrayList copy = kryo.copyShallow(test);
-		assertTrue(test != copy);
-		assertTrue(test.get(3) == copy.get(3));
+		assertNotSame(test, copy);
+		assertSame(test.get(3), copy.get(3));
 		assertEquals(test, copy);
 	}
 

--- a/test/com/esotericsoftware/kryo/KryoTestCase.java
+++ b/test/com/esotericsoftware/kryo/KryoTestCase.java
@@ -20,6 +20,7 @@
 package com.esotericsoftware.kryo;
 
 import static com.esotericsoftware.minlog.Log.*;
+import static org.junit.Assert.assertEquals;
 
 import com.esotericsoftware.kryo.io.ByteBufferInput;
 import com.esotericsoftware.kryo.io.ByteBufferOutput;
@@ -43,7 +44,7 @@ import junit.framework.TestCase;
 
 /** Convenience methods for round tripping objects.
  * @author Nathan Sweet */
-abstract public class KryoTestCase extends TestCase {
+abstract public class KryoTestCase {
 	// When true, roundTrip will only do a single write/read to make debugging easier (breaks some tests).
 	static private final boolean debug = false;
 

--- a/test/com/esotericsoftware/kryo/KryoTestCase.java
+++ b/test/com/esotericsoftware/kryo/KryoTestCase.java
@@ -20,7 +20,7 @@
 package com.esotericsoftware.kryo;
 
 import static com.esotericsoftware.minlog.Log.*;
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
 
 import com.esotericsoftware.kryo.io.ByteBufferInput;
 import com.esotericsoftware.kryo.io.ByteBufferOutput;
@@ -39,8 +39,6 @@ import java.lang.reflect.Array;
 import java.util.ArrayList;
 
 import org.junit.Before;
-
-import junit.framework.TestCase;
 
 /** Convenience methods for round tripping objects.
  * @author Nathan Sweet */
@@ -98,7 +96,7 @@ abstract public class KryoTestCase {
 			}
 		});
 
-		if (debug) return (T)object2;
+		if (debug) return object2;
 
 		roundTripWithBufferFactory(length, object1, new BufferFactory() {
 			public Output createOutput (OutputStream os) {
@@ -217,10 +215,10 @@ abstract public class KryoTestCase {
 
 			// Test null from byte array with and without serializer.
 			input = sf.createInput(new ByteArrayInputStream(outStream.toByteArray()), 10);
-			assertEquals(null, kryo.readObjectOrNull(input, object1.getClass(), serializer));
+			assertNull(kryo.readObjectOrNull(input, object1.getClass(), serializer));
 
 			input = sf.createInput(new ByteArrayInputStream(outStream.toByteArray()), 10);
-			assertEquals(null, kryo.readObjectOrNull(input, object1.getClass()));
+			assertNull(kryo.readObjectOrNull(input, object1.getClass()));
 		}
 
 		// Test output to byte array.

--- a/test/com/esotericsoftware/kryo/ReferenceTest.java
+++ b/test/com/esotericsoftware/kryo/ReferenceTest.java
@@ -76,8 +76,8 @@ public class ReferenceTest extends KryoTestCase {
 		assertEquals(stuff.ordering.order, stuff2.ordering.order);
 		assertEquals(stuff.get("key"), stuff2.get("key"));
 		assertEquals(stuff.get("something"), stuff2.get("something"));
-		assertTrue(stuff.get("self") == stuff);
-		assertTrue(stuff2.get("self") == stuff2);
+		assertSame(stuff.get("self"), stuff);
+		assertSame(stuff2.get("self"), stuff2);
 	}
 
 	@Test

--- a/test/com/esotericsoftware/kryo/ReferenceTest.java
+++ b/test/com/esotericsoftware/kryo/ReferenceTest.java
@@ -19,6 +19,8 @@
 
 package com.esotericsoftware.kryo;
 
+import static org.junit.Assert.*;
+
 import com.esotericsoftware.kryo.io.Input;
 import com.esotericsoftware.kryo.io.Output;
 import com.esotericsoftware.kryo.serializers.MapSerializer;

--- a/test/com/esotericsoftware/kryo/SerializationBenchmarkTest.java
+++ b/test/com/esotericsoftware/kryo/SerializationBenchmarkTest.java
@@ -74,7 +74,6 @@ public class SerializationBenchmarkTest extends KryoTestCase {
 
 	@Test
 	public void testOutput () throws Exception {
-		byte[] out = new byte[OUTPUT_BUFFER_SIZE];
 		Output output = new Output(OUTPUT_BUFFER_SIZE);
 		Input input = new Input(output.getBuffer());
 		run("Output", 1, WARMUP_ITERATIONS, output, input, false);
@@ -83,7 +82,6 @@ public class SerializationBenchmarkTest extends KryoTestCase {
 
 	@Test
 	public void testOutputFixed () throws Exception {
-		byte[] out = new byte[OUTPUT_BUFFER_SIZE];
 		Output output = new Output(OUTPUT_BUFFER_SIZE);
 		Input input = new Input(output.getBuffer());
 		input.setVariableLengthEncoding(false);
@@ -94,7 +92,6 @@ public class SerializationBenchmarkTest extends KryoTestCase {
 
 	@Test
 	public void testByteBufferOutput () throws Exception {
-		byte[] out = new byte[OUTPUT_BUFFER_SIZE];
 		ByteBufferOutput output = new ByteBufferOutput(OUTPUT_BUFFER_SIZE);
 		ByteBufferInput input = new ByteBufferInput(output.getByteBuffer());
 		run("ByteBufferOutput", 1, WARMUP_ITERATIONS, output, input, false);
@@ -103,7 +100,6 @@ public class SerializationBenchmarkTest extends KryoTestCase {
 
 	@Test
 	public void testByteBufferOutputFixed () throws Exception {
-		byte[] out = new byte[OUTPUT_BUFFER_SIZE];
 		ByteBufferOutput output = new ByteBufferOutput(OUTPUT_BUFFER_SIZE);
 		ByteBufferInput input = new ByteBufferInput(output.getByteBuffer());
 		input.setVariableLengthEncoding(false);

--- a/test/com/esotericsoftware/kryo/SerializationCompatTest.java
+++ b/test/com/esotericsoftware/kryo/SerializationCompatTest.java
@@ -20,6 +20,7 @@
 package com.esotericsoftware.kryo;
 
 import static com.esotericsoftware.kryo.ReflectionAssert.*;
+import static org.junit.Assert.*;
 
 import com.esotericsoftware.kryo.SerializationCompatTestData.TestData;
 import com.esotericsoftware.kryo.SerializationCompatTestData.TestDataJava8;

--- a/test/com/esotericsoftware/kryo/io/ByteBufferInputOutputTest.java
+++ b/test/com/esotericsoftware/kryo/io/ByteBufferInputOutputTest.java
@@ -19,7 +19,7 @@
 
 package com.esotericsoftware.kryo.io;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
 
 import com.esotericsoftware.kryo.KryoTestCase;
 
@@ -32,9 +32,9 @@ public class ByteBufferInputOutputTest extends KryoTestCase {
 	@Test
 	public void testByteBufferInputEnd () {
 		ByteBufferInput in = new ByteBufferInput(new ByteArrayInputStream(new byte[] {123, 0, 0, 0}));
-		assertEquals(false, in.end());
+		assertFalse(in.end());
 		in.setPosition(4);
-		assertEquals(true, in.end());
+		assertTrue(in.end());
 	}
 
 	@Test

--- a/test/com/esotericsoftware/kryo/io/ByteBufferInputOutputTest.java
+++ b/test/com/esotericsoftware/kryo/io/ByteBufferInputOutputTest.java
@@ -19,6 +19,8 @@
 
 package com.esotericsoftware.kryo.io;
 
+import static org.junit.Assert.assertEquals;
+
 import com.esotericsoftware.kryo.KryoTestCase;
 
 import java.io.ByteArrayInputStream;

--- a/test/com/esotericsoftware/kryo/io/InputOutputTest.java
+++ b/test/com/esotericsoftware/kryo/io/InputOutputTest.java
@@ -958,19 +958,15 @@ public class InputOutputTest extends KryoTestCase {
 
 	}
 
-	@Test
+	@Test(expected = IllegalArgumentException.class)
 	public void testNewOutputMaxBufferSizeLessThanBufferSize () {
 		int bufferSize = 2;
 		int maxBufferSize = 1;
 
-		try {
-			new Output(bufferSize, maxBufferSize);
-			fail("Expecting IllegalArgumentException not thrown");
-		} catch (IllegalArgumentException expected) {
-		}
+		new Output(bufferSize, maxBufferSize);
 	}
 
-	@Test
+	@Test(expected = IllegalArgumentException.class)
 	public void testSetOutputMaxBufferSizeLessThanBufferSize () {
 		int bufferSize = 2;
 		int maxBufferSize = 1;
@@ -978,12 +974,7 @@ public class InputOutputTest extends KryoTestCase {
 		Output output = new Output(bufferSize, bufferSize);
 		assertNotNull(output);
 
-		try {
-			output.setBuffer(new byte[bufferSize], maxBufferSize);
-			fail("Expecting IllegalArgumentException not thrown");
-		} catch (IllegalArgumentException expected) {
-		}
-
+		output.setBuffer(new byte[bufferSize], maxBufferSize);
 	}
 
 	@Test

--- a/test/com/esotericsoftware/kryo/io/InputOutputTest.java
+++ b/test/com/esotericsoftware/kryo/io/InputOutputTest.java
@@ -37,13 +37,14 @@ import java.util.Random;
 import org.junit.Test;
 
 /** @author Nathan Sweet */
+@SuppressWarnings("ALL")
 public class InputOutputTest extends KryoTestCase {
 	@Test
 	public void testByteBufferInputEnd () {
 		Input in = new Input(new ByteArrayInputStream(new byte[] {123, 0, 0, 0}));
-		assertEquals(false, in.end());
+		assertFalse(in.end());
 		in.setPosition(4);
-		assertEquals(true, in.end());
+		assertTrue(in.end());
 	}
 
 	@Test
@@ -123,7 +124,7 @@ public class InputOutputTest extends KryoTestCase {
 		write.reset();
 		write.writeString(null);
 		read = new Input(write.toBytes());
-		assertEquals(null, read.readString());
+		assertNull(read.readString());
 
 		for (int i = 0; i <= 258; i++)
 			runStringTest(i);
@@ -202,7 +203,7 @@ public class InputOutputTest extends KryoTestCase {
 		assertEquals("uno", read.readString());
 		assertEquals("dos", read.readString());
 		assertEquals("tres", read.readString());
-		assertEquals(null, read.readString());
+		assertNull(read.readString());
 		assertEquals(value1, read.readString());
 		assertEquals(value2, read.readString());
 		for (int i = 0; i < 127; i++)
@@ -217,7 +218,7 @@ public class InputOutputTest extends KryoTestCase {
 		assertEquals("uno", read.readStringBuilder().toString());
 		assertEquals("dos", read.readStringBuilder().toString());
 		assertEquals("tres", read.readStringBuilder().toString());
-		assertEquals(null, read.readStringBuilder());
+		assertNull(read.readStringBuilder());
 		assertEquals(value1, read.readStringBuilder().toString());
 		assertEquals(value2, read.readStringBuilder().toString());
 		for (int i = 0; i < 127; i++)
@@ -231,14 +232,14 @@ public class InputOutputTest extends KryoTestCase {
 		Output write = new Output(new ByteArrayOutputStream());
 
 		Input read = new Input(write.toBytes());
-		assertEquals(false, read.canReadVarInt());
+		assertFalse(read.canReadVarInt());
 
 		write.writeVarInt(400, true);
 
 		read = new Input(write.toBytes());
-		assertEquals(true, read.canReadVarInt());
+		assertTrue(read.canReadVarInt());
 		read.setLimit(read.limit() - 1);
-		assertEquals(false, read.canReadVarInt());
+		assertFalse(read.canReadVarInt());
 	}
 
 	@Test
@@ -270,24 +271,24 @@ public class InputOutputTest extends KryoTestCase {
 
 		input.setPosition(0);
 		input.setLimit(output.position());
-		assertEquals(true, input.readVarIntFlag());
+		assertTrue(input.readVarIntFlag());
 		assertEquals(63, input.readVarIntFlag(true));
-		assertEquals(true, input.readVarIntFlag());
+		assertTrue(input.readVarIntFlag());
 		assertEquals(64, input.readVarIntFlag(true));
 
-		assertEquals(false, input.readVarIntFlag());
+		assertFalse(input.readVarIntFlag());
 		assertEquals(63, input.readVarIntFlag(true));
-		assertEquals(false, input.readVarIntFlag());
+		assertFalse(input.readVarIntFlag());
 		assertEquals(64, input.readVarIntFlag(true));
 
-		assertEquals(true, input.readVarIntFlag());
+		assertTrue(input.readVarIntFlag());
 		assertEquals(31, input.readVarIntFlag(false));
-		assertEquals(true, input.readVarIntFlag());
+		assertTrue(input.readVarIntFlag());
 		assertEquals(32, input.readVarIntFlag(false));
 
-		assertEquals(false, input.readVarIntFlag());
+		assertFalse(input.readVarIntFlag());
 		assertEquals(31, input.readVarIntFlag(false));
-		assertEquals(false, input.readVarIntFlag());
+		assertFalse(input.readVarIntFlag());
 		assertEquals(32, input.readVarIntFlag(false));
 	}
 
@@ -386,9 +387,9 @@ public class InputOutputTest extends KryoTestCase {
 		assertEquals(-268435455, read.readInt());
 		assertEquals(-134217728, read.readInt());
 		assertEquals(-268435456, read.readInt());
-		assertEquals(true, read.canReadVarInt());
-		assertEquals(true, read.canReadVarInt());
-		assertEquals(true, read.canReadVarInt());
+		assertTrue(read.canReadVarInt());
+		assertTrue(read.canReadVarInt());
+		assertTrue(read.canReadVarInt());
 		assertEquals(0, read.readVarInt(true));
 		assertEquals(0, read.readVarInt(false));
 		assertEquals(63, read.readVarInt(true));
@@ -437,7 +438,7 @@ public class InputOutputTest extends KryoTestCase {
 		assertEquals(Integer.MAX_VALUE - 1, read.readVarInt(true));
 		assertEquals(Integer.MAX_VALUE, read.readVarInt(false));
 		assertEquals(Integer.MAX_VALUE, read.readVarInt(true));
-		assertEquals(false, read.canReadVarInt());
+		assertFalse(read.canReadVarInt());
 
 		Random random = new Random();
 		for (int i = 0; i < 10000; i++) {
@@ -503,12 +504,12 @@ public class InputOutputTest extends KryoTestCase {
 		assertEquals(3, write.writeVarLong(1048575, false));
 		assertEquals(4, write.writeVarLong(134217727, true));
 		assertEquals(4, write.writeVarLong(134217727, false));
-		assertEquals(4, write.writeVarLong(268435455l, true));
-		assertEquals(5, write.writeVarLong(268435455l, false));
-		assertEquals(4, write.writeVarLong(134217728l, true));
-		assertEquals(5, write.writeVarLong(134217728l, false));
-		assertEquals(5, write.writeVarLong(268435456l, true));
-		assertEquals(5, write.writeVarLong(268435456l, false));
+		assertEquals(4, write.writeVarLong(268435455L, true));
+		assertEquals(5, write.writeVarLong(268435455L, false));
+		assertEquals(4, write.writeVarLong(134217728L, true));
+		assertEquals(5, write.writeVarLong(134217728L, false));
+		assertEquals(5, write.writeVarLong(268435456L, true));
+		assertEquals(5, write.writeVarLong(268435456L, false));
 		assertEquals(1, write.writeVarLong(-64, false));
 		assertEquals(9, write.writeVarLong(-64, true));
 		assertEquals(2, write.writeVarLong(-65, false));
@@ -842,8 +843,8 @@ public class InputOutputTest extends KryoTestCase {
 
 		Input read = new Input(write.toBytes());
 		for (int i = 0; i < 100; i++) {
-			assertEquals(true, read.readBoolean());
-			assertEquals(false, read.readBoolean());
+			assertTrue(read.readBoolean());
+			assertFalse(read.readBoolean());
 		}
 	}
 

--- a/test/com/esotericsoftware/kryo/io/InputOutputTest.java
+++ b/test/com/esotericsoftware/kryo/io/InputOutputTest.java
@@ -19,6 +19,7 @@
 
 package com.esotericsoftware.kryo.io;
 
+import static com.esotericsoftware.kryo.KryoAssert.*;
 import static org.junit.Assert.*;
 
 import com.esotericsoftware.kryo.Kryo;
@@ -452,6 +453,7 @@ public class InputOutputTest extends KryoTestCase {
 		}
 	}
 
+	@Test
 	public void testLongs () throws IOException {
 		runLongTest(new Output(4096));
 		runLongTest(new Output(new ByteArrayOutputStream()));
@@ -597,6 +599,7 @@ public class InputOutputTest extends KryoTestCase {
 		}
 	}
 
+	@Test
 	public void testShorts () throws IOException {
 		runShortTest(new Output(4096));
 		runShortTest(new Output(new ByteArrayOutputStream()));
@@ -637,6 +640,7 @@ public class InputOutputTest extends KryoTestCase {
 		assertEquals(-32768, read.readShort());
 	}
 
+	@Test
 	public void testFloats () throws IOException {
 		runFloatTest(new Output(4096));
 		runFloatTest(new Output(new ByteArrayOutputStream()));
@@ -686,49 +690,50 @@ public class InputOutputTest extends KryoTestCase {
 		assertEquals(5, write.writeVarFloat(-8192, 1000, true));
 
 		Input read = new Input(write.toBytes());
-		assertEquals(read.readFloat(), 0f);
-		assertEquals(read.readFloat(), 63f);
-		assertEquals(read.readFloat(), 64f);
-		assertEquals(read.readFloat(), 127f);
-		assertEquals(read.readFloat(), 128f);
-		assertEquals(read.readFloat(), 8192f);
-		assertEquals(read.readFloat(), 16384f);
-		assertEquals(read.readFloat(), 32767f);
-		assertEquals(read.readFloat(), -63f);
-		assertEquals(read.readFloat(), -64f);
-		assertEquals(read.readFloat(), -127f);
-		assertEquals(read.readFloat(), -128f);
-		assertEquals(read.readFloat(), -8192f);
-		assertEquals(read.readFloat(), -16384f);
-		assertEquals(read.readFloat(), -32768f);
-		assertEquals(read.readVarFloat(1000, true), 0f);
-		assertEquals(read.readVarFloat(1000, false), 0f);
-		assertEquals(read.readVarFloat(1000, true), 63f);
-		assertEquals(read.readVarFloat(1000, false), 63f);
-		assertEquals(read.readVarFloat(1000, true), 64f);
-		assertEquals(read.readVarFloat(1000, false), 64f);
-		assertEquals(read.readVarFloat(1000, true), 127f);
-		assertEquals(read.readVarFloat(1000, false), 127f);
-		assertEquals(read.readVarFloat(1000, true), 128f);
-		assertEquals(read.readVarFloat(1000, false), 128f);
-		assertEquals(read.readVarFloat(1000, true), 8191f);
-		assertEquals(read.readVarFloat(1000, false), 8191f);
-		assertEquals(read.readVarFloat(1000, true), 8192f);
-		assertEquals(read.readVarFloat(1000, false), 8192f);
-		assertEquals(read.readVarFloat(1000, true), 16383f);
-		assertEquals(read.readVarFloat(1000, false), 16383f);
-		assertEquals(read.readVarFloat(1000, true), 16384f);
-		assertEquals(read.readVarFloat(1000, false), 16384f);
-		assertEquals(read.readVarFloat(1000, true), 32767f);
-		assertEquals(read.readVarFloat(1000, false), 32767f);
-		assertEquals(read.readVarFloat(1000, false), -64f);
-		assertEquals(read.readVarFloat(1000, true), -64f);
-		assertEquals(read.readVarFloat(1000, false), -65f);
-		assertEquals(read.readVarFloat(1000, true), -65f);
-		assertEquals(read.readVarFloat(1000, false), -8192f);
-		assertEquals(read.readVarFloat(1000, true), -8192f);
+		assertFloatEquals(read.readFloat(), 0f);
+		assertFloatEquals(read.readFloat(), 63f);
+		assertFloatEquals(read.readFloat(), 64f);
+		assertFloatEquals(read.readFloat(), 127f);
+		assertFloatEquals(read.readFloat(), 128f);
+		assertFloatEquals(read.readFloat(), 8192f);
+		assertFloatEquals(read.readFloat(), 16384f);
+		assertFloatEquals(read.readFloat(), 32767f);
+		assertFloatEquals(read.readFloat(), -63f);
+		assertFloatEquals(read.readFloat(), -64f);
+		assertFloatEquals(read.readFloat(), -127f);
+		assertFloatEquals(read.readFloat(), -128f);
+		assertFloatEquals(read.readFloat(), -8192f);
+		assertFloatEquals(read.readFloat(), -16384f);
+		assertFloatEquals(read.readFloat(), -32768f);
+		assertFloatEquals(read.readVarFloat(1000, true), 0f);
+		assertFloatEquals(read.readVarFloat(1000, false), 0f);
+		assertFloatEquals(read.readVarFloat(1000, true), 63f);
+		assertFloatEquals(read.readVarFloat(1000, false), 63f);
+		assertFloatEquals(read.readVarFloat(1000, true), 64f);
+		assertFloatEquals(read.readVarFloat(1000, false), 64f);
+		assertFloatEquals(read.readVarFloat(1000, true), 127f);
+		assertFloatEquals(read.readVarFloat(1000, false), 127f);
+		assertFloatEquals(read.readVarFloat(1000, true), 128f);
+		assertFloatEquals(read.readVarFloat(1000, false), 128f);
+		assertFloatEquals(read.readVarFloat(1000, true), 8191f);
+		assertFloatEquals(read.readVarFloat(1000, false), 8191f);
+		assertFloatEquals(read.readVarFloat(1000, true), 8192f);
+		assertFloatEquals(read.readVarFloat(1000, false), 8192f);
+		assertFloatEquals(read.readVarFloat(1000, true), 16383f);
+		assertFloatEquals(read.readVarFloat(1000, false), 16383f);
+		assertFloatEquals(read.readVarFloat(1000, true), 16384f);
+		assertFloatEquals(read.readVarFloat(1000, false), 16384f);
+		assertFloatEquals(read.readVarFloat(1000, true), 32767f);
+		assertFloatEquals(read.readVarFloat(1000, false), 32767f);
+		assertFloatEquals(read.readVarFloat(1000, false), -64f);
+		assertFloatEquals(read.readVarFloat(1000, true), -64f);
+		assertFloatEquals(read.readVarFloat(1000, false), -65f);
+		assertFloatEquals(read.readVarFloat(1000, true), -65f);
+		assertFloatEquals(read.readVarFloat(1000, false), -8192f);
+		assertFloatEquals(read.readVarFloat(1000, true), -8192f);
 	}
 
+	@Test
 	public void testDoubles () throws IOException {
 		runDoubleTest(new Output(4096));
 		runDoubleTest(new Output(new ByteArrayOutputStream()));
@@ -779,48 +784,48 @@ public class InputOutputTest extends KryoTestCase {
 		write.writeDouble(1.23456d);
 
 		Input read = new Input(write.toBytes());
-		assertEquals(read.readDouble(), 0d);
-		assertEquals(read.readDouble(), 63d);
-		assertEquals(read.readDouble(), 64d);
-		assertEquals(read.readDouble(), 127d);
-		assertEquals(read.readDouble(), 128d);
-		assertEquals(read.readDouble(), 8192d);
-		assertEquals(read.readDouble(), 16384d);
-		assertEquals(read.readDouble(), 32767d);
-		assertEquals(read.readDouble(), -63d);
-		assertEquals(read.readDouble(), -64d);
-		assertEquals(read.readDouble(), -127d);
-		assertEquals(read.readDouble(), -128d);
-		assertEquals(read.readDouble(), -8192d);
-		assertEquals(read.readDouble(), -16384d);
-		assertEquals(read.readDouble(), -32768d);
-		assertEquals(read.readVarDouble(1000, true), 0d);
-		assertEquals(read.readVarDouble(1000, false), 0d);
-		assertEquals(read.readVarDouble(1000, true), 63d);
-		assertEquals(read.readVarDouble(1000, false), 63d);
-		assertEquals(read.readVarDouble(1000, true), 64d);
-		assertEquals(read.readVarDouble(1000, false), 64d);
-		assertEquals(read.readVarDouble(1000, true), 127d);
-		assertEquals(read.readVarDouble(1000, false), 127d);
-		assertEquals(read.readVarDouble(1000, true), 128d);
-		assertEquals(read.readVarDouble(1000, false), 128d);
-		assertEquals(read.readVarDouble(1000, true), 8191d);
-		assertEquals(read.readVarDouble(1000, false), 8191d);
-		assertEquals(read.readVarDouble(1000, true), 8192d);
-		assertEquals(read.readVarDouble(1000, false), 8192d);
-		assertEquals(read.readVarDouble(1000, true), 16383d);
-		assertEquals(read.readVarDouble(1000, false), 16383d);
-		assertEquals(read.readVarDouble(1000, true), 16384d);
-		assertEquals(read.readVarDouble(1000, false), 16384d);
-		assertEquals(read.readVarDouble(1000, true), 32767d);
-		assertEquals(read.readVarDouble(1000, false), 32767d);
-		assertEquals(read.readVarDouble(1000, false), -64d);
-		assertEquals(read.readVarDouble(1000, true), -64d);
-		assertEquals(read.readVarDouble(1000, false), -65d);
-		assertEquals(read.readVarDouble(1000, true), -65d);
-		assertEquals(read.readVarDouble(1000, false), -8192d);
-		assertEquals(read.readVarDouble(1000, true), -8192d);
-		assertEquals(1.23456d, read.readDouble());
+		assertDoubleEquals(read.readDouble(), 0d);
+		assertDoubleEquals(read.readDouble(), 63d);
+		assertDoubleEquals(read.readDouble(), 64d);
+		assertDoubleEquals(read.readDouble(), 127d);
+		assertDoubleEquals(read.readDouble(), 128d);
+		assertDoubleEquals(read.readDouble(), 8192d);
+		assertDoubleEquals(read.readDouble(), 16384d);
+		assertDoubleEquals(read.readDouble(), 32767d);
+		assertDoubleEquals(read.readDouble(), -63d);
+		assertDoubleEquals(read.readDouble(), -64d);
+		assertDoubleEquals(read.readDouble(), -127d);
+		assertDoubleEquals(read.readDouble(), -128d);
+		assertDoubleEquals(read.readDouble(), -8192d);
+		assertDoubleEquals(read.readDouble(), -16384d);
+		assertDoubleEquals(read.readDouble(), -32768d);
+		assertDoubleEquals(read.readVarDouble(1000, true), 0d);
+		assertDoubleEquals(read.readVarDouble(1000, false), 0d);
+		assertDoubleEquals(read.readVarDouble(1000, true), 63d);
+		assertDoubleEquals(read.readVarDouble(1000, false), 63d);
+		assertDoubleEquals(read.readVarDouble(1000, true), 64d);
+		assertDoubleEquals(read.readVarDouble(1000, false), 64d);
+		assertDoubleEquals(read.readVarDouble(1000, true), 127d);
+		assertDoubleEquals(read.readVarDouble(1000, false), 127d);
+		assertDoubleEquals(read.readVarDouble(1000, true), 128d);
+		assertDoubleEquals(read.readVarDouble(1000, false), 128d);
+		assertDoubleEquals(read.readVarDouble(1000, true), 8191d);
+		assertDoubleEquals(read.readVarDouble(1000, false), 8191d);
+		assertDoubleEquals(read.readVarDouble(1000, true), 8192d);
+		assertDoubleEquals(read.readVarDouble(1000, false), 8192d);
+		assertDoubleEquals(read.readVarDouble(1000, true), 16383d);
+		assertDoubleEquals(read.readVarDouble(1000, false), 16383d);
+		assertDoubleEquals(read.readVarDouble(1000, true), 16384d);
+		assertDoubleEquals(read.readVarDouble(1000, false), 16384d);
+		assertDoubleEquals(read.readVarDouble(1000, true), 32767d);
+		assertDoubleEquals(read.readVarDouble(1000, false), 32767d);
+		assertDoubleEquals(read.readVarDouble(1000, false), -64d);
+		assertDoubleEquals(read.readVarDouble(1000, true), -64d);
+		assertDoubleEquals(read.readVarDouble(1000, false), -65d);
+		assertDoubleEquals(read.readVarDouble(1000, true), -65d);
+		assertDoubleEquals(read.readVarDouble(1000, false), -8192d);
+		assertDoubleEquals(read.readVarDouble(1000, true), -8192d);
+		assertDoubleEquals(1.23456d, read.readDouble());
 	}
 
 	@Test

--- a/test/com/esotericsoftware/kryo/io/UnsafeByteBufferInputOutputTest.java
+++ b/test/com/esotericsoftware/kryo/io/UnsafeByteBufferInputOutputTest.java
@@ -28,7 +28,6 @@ import com.esotericsoftware.kryo.unsafe.UnsafeUtil;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.io.IOException;
 import java.util.Random;
 
 import org.junit.Test;
@@ -66,7 +65,7 @@ public class UnsafeByteBufferInputOutputTest {
 	}
 
 	@Test
-	public void testOutputStream () throws IOException {
+	public void testOutputStream () {
 		ByteArrayOutputStream buffer = new ByteArrayOutputStream();
 		UnsafeByteBufferOutput output = new UnsafeByteBufferOutput(buffer, 2);
 		output.writeBytes(new byte[] {11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26});
@@ -83,7 +82,7 @@ public class UnsafeByteBufferInputOutputTest {
 	}
 
 	@Test
-	public void testInputStream () throws IOException {
+	public void testInputStream () {
 		byte[] bytes = new byte[] { //
 			11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, //
 			31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, //
@@ -107,7 +106,7 @@ public class UnsafeByteBufferInputOutputTest {
 	}
 
 	@Test
-	public void testWriteBytes () throws IOException {
+	public void testWriteBytes () {
 		UnsafeByteBufferOutput buffer = new UnsafeByteBufferOutput(512);
 		buffer.writeBytes(new byte[] {11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26});
 		buffer.writeBytes(new byte[] {31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46});
@@ -128,7 +127,7 @@ public class UnsafeByteBufferInputOutputTest {
 	}
 
 	@Test
-	public void testStrings () throws IOException {
+	public void testStrings () {
 		runStringTest(new UnsafeByteBufferOutput(4096));
 		runStringTest(new UnsafeByteBufferOutput(897));
 		runStringTest(new UnsafeByteBufferOutput(new ByteArrayOutputStream()));
@@ -148,7 +147,7 @@ public class UnsafeByteBufferInputOutputTest {
 		runStringTest(1024 * 1024 * 2);
 	}
 
-	private void runStringTest (int length) throws IOException {
+	private void runStringTest (int length) {
 		UnsafeByteBufferOutput write = new UnsafeByteBufferOutput(1024, -1);
 		StringBuilder buffer = new StringBuilder();
 		for (int i = 0; i < length; i++)
@@ -178,7 +177,7 @@ public class UnsafeByteBufferInputOutputTest {
 		}
 	}
 
-	private void runStringTest (UnsafeByteBufferOutput write) throws IOException {
+	private void runStringTest (UnsafeByteBufferOutput write) {
 		String value1 = "ABCDEFGHIJKLMNOPQRSTUVWXYZ\rabcdefghijklmnopqrstuvwxyz\n1234567890\t\"!`?'.,;:()[]{}<>|/@\\^$-%+=#_&~*";
 		String value2 = "abcdef\u00E1\u00E9\u00ED\u00F3\u00FA\u1234";
 
@@ -203,7 +202,7 @@ public class UnsafeByteBufferInputOutputTest {
 		assertEquals("uno", read.readString());
 		assertEquals("dos", read.readString());
 		assertEquals("tres", read.readString());
-		assertEquals(null, read.readString());
+		assertNull(read.readString());
 		assertEquals(value1, read.readString());
 		assertEquals(value2, read.readString());
 		for (int i = 0; i < 127; i++)
@@ -218,7 +217,7 @@ public class UnsafeByteBufferInputOutputTest {
 		assertEquals("uno", read.readStringBuilder().toString());
 		assertEquals("dos", read.readStringBuilder().toString());
 		assertEquals("tres", read.readStringBuilder().toString());
-		assertEquals(null, read.readStringBuilder());
+		assertNull(read.readStringBuilder());
 		assertEquals(value1, read.readStringBuilder().toString());
 		assertEquals(value2, read.readStringBuilder().toString());
 		for (int i = 0; i < 127; i++)
@@ -228,27 +227,27 @@ public class UnsafeByteBufferInputOutputTest {
 	}
 
 	@Test
-	public void testCanReadInt () throws IOException {
+	public void testCanReadInt () {
 		UnsafeByteBufferOutput write = new UnsafeByteBufferOutput(new ByteArrayOutputStream());
 
 		Input read = new UnsafeByteBufferInput(write.toBytes());
-		assertEquals(false, read.canReadVarInt());
+		assertFalse(read.canReadVarInt());
 
 		write.writeVarInt(400, true);
 
 		read = new UnsafeByteBufferInput(write.toBytes());
-		assertEquals(true, read.canReadVarInt());
+		assertTrue(read.canReadVarInt());
 		read.setLimit(read.limit() - 1);
-		assertEquals(false, read.canReadVarInt());
+		assertFalse(read.canReadVarInt());
 	}
 
 	@Test
-	public void testInts () throws IOException {
+	public void testInts () {
 		runIntTest(new UnsafeByteBufferOutput(4096));
 		runIntTest(new UnsafeByteBufferOutput(new ByteArrayOutputStream()));
 	}
 
-	private void runIntTest (UnsafeByteBufferOutput write) throws IOException {
+	private void runIntTest (UnsafeByteBufferOutput write) {
 		write.writeInt(0);
 		write.writeInt(63);
 		write.writeInt(64);
@@ -339,9 +338,9 @@ public class UnsafeByteBufferInputOutputTest {
 		assertEquals(-268435455, read.readInt());
 		assertEquals(-134217728, read.readInt());
 		assertEquals(-268435456, read.readInt());
-		assertEquals(true, read.canReadInt());
-		assertEquals(true, read.canReadInt());
-		assertEquals(true, read.canReadInt());
+		assertTrue(read.canReadInt());
+		assertTrue(read.canReadInt());
+		assertTrue(read.canReadInt());
 
 		read.setVariableLengthEncoding(false);
 		assertEquals(0, read.readInt(true));
@@ -392,7 +391,7 @@ public class UnsafeByteBufferInputOutputTest {
 		assertEquals(Integer.MAX_VALUE - 1, read.readInt(true));
 		assertEquals(Integer.MAX_VALUE, read.readInt(false));
 		assertEquals(Integer.MAX_VALUE, read.readInt(true));
-		assertEquals(false, read.canReadInt());
+		assertFalse(read.canReadInt());
 
 		Random random = new Random();
 		for (int i = 0; i < 10000; i++) {
@@ -409,12 +408,12 @@ public class UnsafeByteBufferInputOutputTest {
 	}
 
 	@Test
-	public void testLongs () throws IOException {
+	public void testLongs () {
 		runLongTest(new UnsafeByteBufferOutput(4096));
 		runLongTest(new UnsafeByteBufferOutput(new ByteArrayOutputStream()));
 	}
 
-	private void runLongTest (UnsafeByteBufferOutput write) throws IOException {
+	private void runLongTest (UnsafeByteBufferOutput write) {
 		write.writeLong(0);
 		write.writeLong(63);
 		write.writeLong(64);
@@ -460,12 +459,12 @@ public class UnsafeByteBufferInputOutputTest {
 		assertEquals(8, write.writeLong(1048575, false));
 		assertEquals(8, write.writeLong(134217727, true));
 		assertEquals(8, write.writeLong(134217727, false));
-		assertEquals(8, write.writeLong(268435455l, true));
-		assertEquals(8, write.writeLong(268435455l, false));
-		assertEquals(8, write.writeLong(134217728l, true));
-		assertEquals(8, write.writeLong(134217728l, false));
-		assertEquals(8, write.writeLong(268435456l, true));
-		assertEquals(8, write.writeLong(268435456l, false));
+		assertEquals(8, write.writeLong(268435455L, true));
+		assertEquals(8, write.writeLong(268435455L, false));
+		assertEquals(8, write.writeLong(134217728L, true));
+		assertEquals(8, write.writeLong(134217728L, false));
+		assertEquals(8, write.writeLong(268435456L, true));
+		assertEquals(8, write.writeLong(268435456L, false));
 		assertEquals(8, write.writeLong(-64, false));
 		assertEquals(8, write.writeLong(-64, true));
 		assertEquals(8, write.writeLong(-65, false));
@@ -559,12 +558,12 @@ public class UnsafeByteBufferInputOutputTest {
 	}
 
 	@Test
-	public void testShorts () throws IOException {
+	public void testShorts () {
 		runShortTest(new UnsafeByteBufferOutput(4096));
 		runShortTest(new UnsafeByteBufferOutput(new ByteArrayOutputStream()));
 	}
 
-	private void runShortTest (UnsafeByteBufferOutput write) throws IOException {
+	private void runShortTest (UnsafeByteBufferOutput write) {
 		write.writeShort(0);
 		write.writeShort(63);
 		write.writeShort(64);
@@ -600,12 +599,12 @@ public class UnsafeByteBufferInputOutputTest {
 	}
 
 	@Test
-	public void testFloats () throws IOException {
+	public void testFloats () {
 		runFloatTest(new UnsafeByteBufferOutput(4096));
 		runFloatTest(new UnsafeByteBufferOutput(new ByteArrayOutputStream()));
 	}
 
-	private void runFloatTest (UnsafeByteBufferOutput write) throws IOException {
+	private void runFloatTest (UnsafeByteBufferOutput write) {
 		write.writeFloat(0);
 		write.writeFloat(63);
 		write.writeFloat(64);
@@ -694,12 +693,12 @@ public class UnsafeByteBufferInputOutputTest {
 	}
 
 	@Test
-	public void testDoubles () throws IOException {
+	public void testDoubles () {
 		runDoubleTest(new UnsafeByteBufferOutput(4096));
 		runDoubleTest(new UnsafeByteBufferOutput(new ByteArrayOutputStream()));
 	}
 
-	private void runDoubleTest (UnsafeByteBufferOutput write) throws IOException {
+	private void runDoubleTest (UnsafeByteBufferOutput write) {
 		write.writeDouble(0);
 		write.writeDouble(63);
 		write.writeDouble(64);
@@ -791,13 +790,13 @@ public class UnsafeByteBufferInputOutputTest {
 	}
 
 	@Test
-	public void testBooleans () throws IOException {
+	public void testBooleans () {
 		runBooleanTest(new UnsafeByteBufferOutput(200));
 		runBooleanTest(new UnsafeByteBufferOutput(4096));
 		runBooleanTest(new UnsafeByteBufferOutput(new ByteArrayOutputStream()));
 	}
 
-	private void runBooleanTest (UnsafeByteBufferOutput write) throws IOException {
+	private void runBooleanTest (UnsafeByteBufferOutput write) {
 		for (int i = 0; i < 100; i++) {
 			write.writeBoolean(true);
 			write.writeBoolean(false);
@@ -805,18 +804,18 @@ public class UnsafeByteBufferInputOutputTest {
 
 		Input read = new UnsafeByteBufferInput(write.toBytes());
 		for (int i = 0; i < 100; i++) {
-			assertEquals(true, read.readBoolean());
-			assertEquals(false, read.readBoolean());
+			assertTrue(read.readBoolean());
+			assertFalse(read.readBoolean());
 		}
 	}
 
 	@Test
-	public void testChars () throws IOException {
+	public void testChars () {
 		runCharTest(new UnsafeByteBufferOutput(4096));
 		runCharTest(new UnsafeByteBufferOutput(new ByteArrayOutputStream()));
 	}
 
-	private void runCharTest (UnsafeByteBufferOutput write) throws IOException {
+	private void runCharTest (UnsafeByteBufferOutput write) {
 		write.writeChar((char)0);
 		write.writeChar((char)63);
 		write.writeChar((char)64);

--- a/test/com/esotericsoftware/kryo/io/UnsafeInputOutputTest.java
+++ b/test/com/esotericsoftware/kryo/io/UnsafeInputOutputTest.java
@@ -27,7 +27,6 @@ import com.esotericsoftware.kryo.unsafe.UnsafeOutput;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.io.IOException;
 import java.util.Random;
 
 import org.junit.Test;
@@ -35,7 +34,7 @@ import org.junit.Test;
 /** @author Nathan Sweet <misc@n4te.com> */
 public class UnsafeInputOutputTest {
 	@Test
-	public void testOutputStream () throws IOException {
+	public void testOutputStream () {
 		ByteArrayOutputStream buffer = new ByteArrayOutputStream();
 		UnsafeOutput output = new UnsafeOutput(buffer, 2);
 		output.writeBytes(new byte[] {11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26});
@@ -52,7 +51,7 @@ public class UnsafeInputOutputTest {
 	}
 
 	@Test
-	public void testInputStream () throws IOException {
+	public void testInputStream () {
 		byte[] bytes = new byte[] { //
 			11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, //
 			31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, //
@@ -76,7 +75,7 @@ public class UnsafeInputOutputTest {
 	}
 
 	@Test
-	public void testWriteBytes () throws IOException {
+	public void testWriteBytes () {
 		UnsafeOutput buffer = new UnsafeOutput(512);
 		buffer.writeBytes(new byte[] {11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26});
 		buffer.writeBytes(new byte[] {31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46});
@@ -97,7 +96,7 @@ public class UnsafeInputOutputTest {
 	}
 
 	@Test
-	public void testStrings () throws IOException {
+	public void testStrings () {
 		runStringTest(new UnsafeOutput(4096));
 		runStringTest(new UnsafeOutput(897));
 		runStringTest(new UnsafeOutput(new ByteArrayOutputStream()));
@@ -117,7 +116,7 @@ public class UnsafeInputOutputTest {
 		runStringTest(1024 * 1024 * 2);
 	}
 
-	private void runStringTest (int length) throws IOException {
+	private void runStringTest (int length) {
 		UnsafeOutput write = new UnsafeOutput(1024, -1);
 		StringBuilder buffer = new StringBuilder();
 		for (int i = 0; i < length; i++)
@@ -147,7 +146,7 @@ public class UnsafeInputOutputTest {
 		}
 	}
 
-	private void runStringTest (UnsafeOutput write) throws IOException {
+	private void runStringTest (UnsafeOutput write) {
 		String value1 = "ABCDEFGHIJKLMNOPQRSTUVWXYZ\rabcdefghijklmnopqrstuvwxyz\n1234567890\t\"!`?'.,;:()[]{}<>|/@\\^$-%+=#_&~*";
 		String value2 = "abcdef\u00E1\u00E9\u00ED\u00F3\u00FA\u1234";
 
@@ -172,7 +171,7 @@ public class UnsafeInputOutputTest {
 		assertEquals("uno", read.readString());
 		assertEquals("dos", read.readString());
 		assertEquals("tres", read.readString());
-		assertEquals(null, read.readString());
+		assertNull(read.readString());
 		assertEquals(value1, read.readString());
 		assertEquals(value2, read.readString());
 		for (int i = 0; i < 127; i++)
@@ -187,7 +186,7 @@ public class UnsafeInputOutputTest {
 		assertEquals("uno", read.readStringBuilder().toString());
 		assertEquals("dos", read.readStringBuilder().toString());
 		assertEquals("tres", read.readStringBuilder().toString());
-		assertEquals(null, read.readStringBuilder());
+		assertNull(read.readStringBuilder());
 		assertEquals(value1, read.readStringBuilder().toString());
 		assertEquals(value2, read.readStringBuilder().toString());
 		for (int i = 0; i < 127; i++)
@@ -197,27 +196,27 @@ public class UnsafeInputOutputTest {
 	}
 
 	@Test
-	public void testCanReadInt () throws IOException {
+	public void testCanReadInt () {
 		UnsafeOutput write = new UnsafeOutput(new ByteArrayOutputStream());
 
 		Input read = new UnsafeInput(write.toBytes());
-		assertEquals(false, read.canReadVarInt());
+		assertFalse(read.canReadVarInt());
 
 		write.writeVarInt(400, true);
 
 		read = new UnsafeInput(write.toBytes());
-		assertEquals(true, read.canReadVarInt());
+		assertTrue(read.canReadVarInt());
 		read.setLimit(read.limit() - 1);
-		assertEquals(false, read.canReadVarInt());
+		assertFalse(read.canReadVarInt());
 	}
 
 	@Test
-	public void testInts () throws IOException {
+	public void testInts () {
 		runIntTest(new UnsafeOutput(4096));
 		runIntTest(new UnsafeOutput(new ByteArrayOutputStream()));
 	}
 
-	private void runIntTest (UnsafeOutput write) throws IOException {
+	private void runIntTest (UnsafeOutput write) {
 		write.writeInt(0);
 		write.writeInt(63);
 		write.writeInt(64);
@@ -308,9 +307,9 @@ public class UnsafeInputOutputTest {
 		assertEquals(-268435455, read.readInt());
 		assertEquals(-134217728, read.readInt());
 		assertEquals(-268435456, read.readInt());
-		assertEquals(true, read.canReadInt());
-		assertEquals(true, read.canReadInt());
-		assertEquals(true, read.canReadInt());
+		assertTrue(read.canReadInt());
+		assertTrue(read.canReadInt());
+		assertTrue(read.canReadInt());
 
 		read.setVariableLengthEncoding(false);
 		assertEquals(0, read.readInt(true));
@@ -361,7 +360,7 @@ public class UnsafeInputOutputTest {
 		assertEquals(Integer.MAX_VALUE - 1, read.readInt(true));
 		assertEquals(Integer.MAX_VALUE, read.readInt(false));
 		assertEquals(Integer.MAX_VALUE, read.readInt(true));
-		assertEquals(false, read.canReadInt());
+		assertFalse(read.canReadInt());
 
 		Random random = new Random();
 		for (int i = 0; i < 10000; i++) {
@@ -378,12 +377,12 @@ public class UnsafeInputOutputTest {
 	}
 
 	@Test
-	public void testLongs () throws IOException {
+	public void testLongs () {
 		runLongTest(new UnsafeOutput(4096));
 		runLongTest(new UnsafeOutput(new ByteArrayOutputStream()));
 	}
 
-	private void runLongTest (UnsafeOutput write) throws IOException {
+	private void runLongTest (UnsafeOutput write) {
 		write.writeLong(0);
 		write.writeLong(63);
 		write.writeLong(64);
@@ -429,12 +428,12 @@ public class UnsafeInputOutputTest {
 		assertEquals(8, write.writeLong(1048575, false));
 		assertEquals(8, write.writeLong(134217727, true));
 		assertEquals(8, write.writeLong(134217727, false));
-		assertEquals(8, write.writeLong(268435455l, true));
-		assertEquals(8, write.writeLong(268435455l, false));
-		assertEquals(8, write.writeLong(134217728l, true));
-		assertEquals(8, write.writeLong(134217728l, false));
-		assertEquals(8, write.writeLong(268435456l, true));
-		assertEquals(8, write.writeLong(268435456l, false));
+		assertEquals(8, write.writeLong(268435455L, true));
+		assertEquals(8, write.writeLong(268435455L, false));
+		assertEquals(8, write.writeLong(134217728L, true));
+		assertEquals(8, write.writeLong(134217728L, false));
+		assertEquals(8, write.writeLong(268435456L, true));
+		assertEquals(8, write.writeLong(268435456L, false));
 		assertEquals(8, write.writeLong(-64, false));
 		assertEquals(8, write.writeLong(-64, true));
 		assertEquals(8, write.writeLong(-65, false));
@@ -528,12 +527,12 @@ public class UnsafeInputOutputTest {
 	}
 
 	@Test
-	public void testShorts () throws IOException {
+	public void testShorts () {
 		runShortTest(new UnsafeOutput(4096));
 		runShortTest(new UnsafeOutput(new ByteArrayOutputStream()));
 	}
 
-	private void runShortTest (UnsafeOutput write) throws IOException {
+	private void runShortTest (UnsafeOutput write) {
 		write.writeShort(0);
 		write.writeShort(63);
 		write.writeShort(64);
@@ -569,12 +568,12 @@ public class UnsafeInputOutputTest {
 	}
 
 	@Test
-	public void testFloats () throws IOException {
+	public void testFloats () {
 		runFloatTest(new UnsafeOutput(4096));
 		runFloatTest(new UnsafeOutput(new ByteArrayOutputStream()));
 	}
 
-	private void runFloatTest (UnsafeOutput write) throws IOException {
+	private void runFloatTest (UnsafeOutput write) {
 		write.writeFloat(0);
 		write.writeFloat(63);
 		write.writeFloat(64);
@@ -663,12 +662,12 @@ public class UnsafeInputOutputTest {
 	}
 
 	@Test
-	public void testDoubles () throws IOException {
+	public void testDoubles () {
 		runDoubleTest(new UnsafeOutput(4096));
 		runDoubleTest(new UnsafeOutput(new ByteArrayOutputStream()));
 	}
 
-	private void runDoubleTest (UnsafeOutput write) throws IOException {
+	private void runDoubleTest (UnsafeOutput write) {
 		write.writeDouble(0);
 		write.writeDouble(63);
 		write.writeDouble(64);
@@ -760,12 +759,12 @@ public class UnsafeInputOutputTest {
 	}
 
 	@Test
-	public void testBooleans () throws IOException {
+	public void testBooleans () {
 		runBooleanTest(new UnsafeOutput(4096));
 		runBooleanTest(new UnsafeOutput(new ByteArrayOutputStream()));
 	}
 
-	private void runBooleanTest (UnsafeOutput write) throws IOException {
+	private void runBooleanTest (UnsafeOutput write) {
 		for (int i = 0; i < 100; i++) {
 			write.writeBoolean(true);
 			write.writeBoolean(false);
@@ -773,18 +772,18 @@ public class UnsafeInputOutputTest {
 
 		Input read = new UnsafeInput(write.toBytes());
 		for (int i = 0; i < 100; i++) {
-			assertEquals(true, read.readBoolean());
-			assertEquals(false, read.readBoolean());
+			assertTrue(read.readBoolean());
+			assertFalse(read.readBoolean());
 		}
 	}
 
 	@Test
-	public void testChars () throws IOException {
+	public void testChars () {
 		runCharTest(new UnsafeOutput(4096));
 		runCharTest(new UnsafeOutput(new ByteArrayOutputStream()));
 	}
 
-	private void runCharTest (UnsafeOutput write) throws IOException {
+	private void runCharTest (UnsafeOutput write) {
 		write.writeChar((char)0);
 		write.writeChar((char)63);
 		write.writeChar((char)64);
@@ -809,12 +808,12 @@ public class UnsafeInputOutputTest {
 
 	// Check if writing varInts may produce more bytes than expected
 	@Test
-	public void testWriteTooManyBytes () throws IOException {
+	public void testWriteTooManyBytes () {
 		ByteArrayOutputStream os = new ByteArrayOutputStream(1);
 		runIntTest(new UnsafeOutput(os, 4), os);
 	}
 
-	private void runIntTest (UnsafeOutput write, ByteArrayOutputStream os) throws IOException {
+	private void runIntTest (UnsafeOutput write, ByteArrayOutputStream os) {
 		write.setVariableLengthEncoding(false);
 		write.writeInt(0, true);
 		write.writeInt(63, true);
@@ -830,6 +829,6 @@ public class UnsafeInputOutputTest {
 		assertEquals(63, read.readInt(true));
 		assertEquals(64, read.readInt(true));
 		assertEquals(65535, read.readInt(true));
-		assertEquals(true, read.end());
+		assertTrue(read.end());
 	}
 }

--- a/test/com/esotericsoftware/kryo/serializers/CollectionSerializerTest.java
+++ b/test/com/esotericsoftware/kryo/serializers/CollectionSerializerTest.java
@@ -19,7 +19,7 @@
 
 package com.esotericsoftware.kryo.serializers;
 
-import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.*;
 
 import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.KryoTestCase;
@@ -109,7 +109,7 @@ public class CollectionSerializerTest extends KryoTestCase {
 		Kryo kryo = new Kryo();
 		kryo.setRegistrationRequired(false);
 		List objects2 = kryo.copy(objects1);
-		assertFalse(objects1.get(0) == objects2.get(0));
+		assertNotSame(objects1.get(0), objects2.get(0));
 	}
 
 	static public class TreeSetSubclass<E> extends TreeSet<E> {

--- a/test/com/esotericsoftware/kryo/serializers/CollectionSerializerTest.java
+++ b/test/com/esotericsoftware/kryo/serializers/CollectionSerializerTest.java
@@ -19,6 +19,8 @@
 
 package com.esotericsoftware.kryo.serializers;
 
+import static org.junit.Assert.assertFalse;
+
 import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.KryoTestCase;
 import com.esotericsoftware.kryo.serializers.DefaultSerializers.StringSerializer;
@@ -101,6 +103,7 @@ public class CollectionSerializerTest extends KryoTestCase {
 		roundTrip(9, set);
 	}
 
+	@Test
 	public void testCopy () {
 		List objects1 = Collections.singletonList(new Object());
 		Kryo kryo = new Kryo();

--- a/test/com/esotericsoftware/kryo/serializers/CompatibleFieldSerializerTest.java
+++ b/test/com/esotericsoftware/kryo/serializers/CompatibleFieldSerializerTest.java
@@ -19,6 +19,8 @@
 
 package com.esotericsoftware.kryo.serializers;
 
+import static org.junit.Assert.*;
+
 import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.KryoTestCase;
 import com.esotericsoftware.kryo.SerializerFactory.CompatibleFieldSerializerFactory;
@@ -42,8 +44,6 @@ public class CompatibleFieldSerializerTest extends KryoTestCase {
 
 	private void testCompatibleFieldSerializer (int length, boolean references, final boolean chunked) {
 		kryo.setReferences(references);
-
-		CompatibleFieldSerializer serializer = new CompatibleFieldSerializer(kryo, ClassWithManyFields.class);
 		kryo.setDefaultSerializer(new CompatibleFieldSerializerFactory() {
 			public CompatibleFieldSerializer newSerializer (Kryo kryo, Class type) {
 				CompatibleFieldSerializer serializer = super.newSerializer(kryo, type);

--- a/test/com/esotericsoftware/kryo/serializers/DefaultSerializersTest.java
+++ b/test/com/esotericsoftware/kryo/serializers/DefaultSerializersTest.java
@@ -191,6 +191,7 @@ public class DefaultSerializersTest extends KryoTestCase {
 		assertNull(object);
 	}
 
+	@Test
 	public void testDateSerializer () {
 		kryo.register(Date.class);
 		roundTrip(10, new Date(-1234567));

--- a/test/com/esotericsoftware/kryo/serializers/DefaultSerializersTest.java
+++ b/test/com/esotericsoftware/kryo/serializers/DefaultSerializersTest.java
@@ -166,7 +166,7 @@ public class DefaultSerializersTest extends KryoTestCase {
 	}
 
 	@Test
-	public void testVoid () throws InstantiationException, IllegalAccessException {
+	public void testVoid () {
 		roundTrip(1, (Void)null);
 	}
 

--- a/test/com/esotericsoftware/kryo/serializers/EnumNameSerializerTest.java
+++ b/test/com/esotericsoftware/kryo/serializers/EnumNameSerializerTest.java
@@ -19,6 +19,8 @@
 
 package com.esotericsoftware.kryo.serializers;
 
+import static org.junit.Assert.*;
+
 import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.KryoTestCase;
 import com.esotericsoftware.kryo.io.Input;

--- a/test/com/esotericsoftware/kryo/serializers/EnumNameSerializerTest.java
+++ b/test/com/esotericsoftware/kryo/serializers/EnumNameSerializerTest.java
@@ -55,7 +55,7 @@ public class EnumNameSerializerTest extends KryoTestCase {
 	}
 
 	@Test
-	public void testEnumSetSerializerWithEnumNameSerializer () throws Exception {
+	public void testEnumSetSerializerWithEnumNameSerializer () {
 		kryo.addDefaultSerializer(Enum.class, EnumNameSerializer.class);
 		kryo.register(EnumSet.class);
 		kryo.register(TestNameEnum.class);

--- a/test/com/esotericsoftware/kryo/serializers/ExternalizableSerializerTest.java
+++ b/test/com/esotericsoftware/kryo/serializers/ExternalizableSerializerTest.java
@@ -19,7 +19,7 @@
 
 package com.esotericsoftware.kryo.serializers;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
 
 import com.esotericsoftware.kryo.KryoTestCase;
 import com.esotericsoftware.kryo.io.Input;

--- a/test/com/esotericsoftware/kryo/serializers/ExternalizableSerializerTest.java
+++ b/test/com/esotericsoftware/kryo/serializers/ExternalizableSerializerTest.java
@@ -19,6 +19,8 @@
 
 package com.esotericsoftware.kryo.serializers;
 
+import static org.junit.Assert.assertEquals;
+
 import com.esotericsoftware.kryo.KryoTestCase;
 import com.esotericsoftware.kryo.io.Input;
 import com.esotericsoftware.kryo.io.Output;

--- a/test/com/esotericsoftware/kryo/serializers/FieldSerializerInheritanceTest.java
+++ b/test/com/esotericsoftware/kryo/serializers/FieldSerializerInheritanceTest.java
@@ -19,6 +19,8 @@
 
 package com.esotericsoftware.kryo.serializers;
 
+import static org.junit.Assert.*;
+
 import com.esotericsoftware.kryo.KryoTestCase;
 import com.esotericsoftware.kryo.SerializerFactory.FieldSerializerFactory;
 

--- a/test/com/esotericsoftware/kryo/serializers/FieldSerializerTest.java
+++ b/test/com/esotericsoftware/kryo/serializers/FieldSerializerTest.java
@@ -212,12 +212,12 @@ public class FieldSerializerTest extends KryoTestCase {
 		kryo.setRegistrationRequired(false);
 		roundTrip(75, c);
 		C c2 = (C)object2;
-		assertTrue(c2.d == c2.d.e.f.d);
+		assertSame(c2.d, c2.d.e.f.d);
 
 		// Test reset clears unregistered class names.
 		roundTrip(75, c);
 		c2 = (C)object2;
-		assertTrue(c2.d == c2.d.e.f.d);
+		assertSame(c2.d, c2.d.e.f.d);
 
 		kryo = new Kryo();
 		kryo.register(A.class);
@@ -228,7 +228,7 @@ public class FieldSerializerTest extends KryoTestCase {
 		kryo.register(F.class);
 		roundTrip(15, c);
 		c2 = (C)object2;
-		assertTrue(c2.d == c2.d.e.f.d);
+		assertSame(c2.d, c2.d.e.f.d);
 	}
 
 	@Test
@@ -367,7 +367,7 @@ public class FieldSerializerTest extends KryoTestCase {
 	}
 
 	@Test
-	public void testCyclicGrgaph () throws Exception {
+	public void testCyclicGrgaph () {
 		kryo = new Kryo();
 		kryo.register(DefaultTypes.class);
 		kryo.register(byte[].class);
@@ -488,7 +488,7 @@ public class FieldSerializerTest extends KryoTestCase {
 		HasTransients objectWithTransients3 = kryo.copy(objectWithTransients1);
 		assertTrue("Objects should be different if copy does not include transient fields",
 			!objectWithTransients3.equals(objectWithTransients1));
-		assertEquals("transient fields should be null", objectWithTransients3.transientField1, null);
+		assertNull("transient fields should be null", objectWithTransients3.transientField1);
 
 		ser.getFieldSerializerConfig().setCopyTransient(true);
 		ser.updateFields();
@@ -511,7 +511,7 @@ public class FieldSerializerTest extends KryoTestCase {
 		HasTransients objectWithTransients3 = kryo.copy(objectWithTransients1);
 		assertTrue("Objects should be different if copy does not include transient fields",
 			!objectWithTransients3.equals(objectWithTransients1));
-		assertEquals("transient fields should be null", objectWithTransients3.transientField1, null);
+		assertNull("transient fields should be null", objectWithTransients3.transientField1);
 
 		ser.getFieldSerializerConfig().setCopyTransient(true);
 		ser.updateFields();
@@ -546,7 +546,7 @@ public class FieldSerializerTest extends KryoTestCase {
 		HasTransients objectWithTransients3 = ser.read(kryo, input, HasTransients.class);
 		assertTrue("Objects should be different if write does not include transient fields",
 			!objectWithTransients3.equals(objectWithTransients1));
-		assertEquals("transient fields should be null", objectWithTransients3.transientField1, null);
+		assertNull("transient fields should be null", objectWithTransients3.transientField1);
 
 		ser.getFieldSerializerConfig().setSerializeTransient(true);
 		ser.updateFields();
@@ -559,8 +559,7 @@ public class FieldSerializerTest extends KryoTestCase {
 		outBytes = outputStream.toByteArray();
 		input = new Input(outBytes);
 		HasTransients objectWithTransients2 = ser.read(kryo, input, HasTransients.class);
-		assertTrue("Objects should be equal if write includes transient fields",
-			objectWithTransients2.equals(objectWithTransients1));
+		assertEquals("Objects should be equal if write includes transient fields", objectWithTransients2, objectWithTransients1);
 	}
 
 	@Test
@@ -590,7 +589,7 @@ public class FieldSerializerTest extends KryoTestCase {
 		HasTransients objectWithTransients3 = ser.read(kryo, input, HasTransients.class);
 		assertTrue("Objects should be different if write does not include transient fields",
 			!objectWithTransients3.equals(objectWithTransients1));
-		assertEquals("transient fields should be null", objectWithTransients3.transientField1, null);
+		assertNull("transient fields should be null", objectWithTransients3.transientField1);
 
 		ser.getFieldSerializerConfig().setSerializeTransient(true);
 		ser.updateFields();
@@ -603,8 +602,7 @@ public class FieldSerializerTest extends KryoTestCase {
 		outBytes = outputStream.toByteArray();
 		input = new Input(outBytes);
 		HasTransients objectWithTransients2 = ser.read(kryo, input, HasTransients.class);
-		assertTrue("Objects should be equal if write includes transient fields",
-			objectWithTransients2.equals(objectWithTransients1));
+		assertEquals("Objects should be equal if write includes transient fields", objectWithTransients2, objectWithTransients1);
 	}
 
 	@Test
@@ -650,7 +648,7 @@ public class FieldSerializerTest extends KryoTestCase {
 			return;
 		}
 
-		assertFalse("Exception was expected", true);
+		fail("Exception was expected");
 	}
 
 	@Test
@@ -665,7 +663,7 @@ public class FieldSerializerTest extends KryoTestCase {
 			return;
 		}
 
-		assertFalse("Exception was expected", true);
+		fail("Exception was expected");
 	}
 
 	@Test
@@ -680,7 +678,7 @@ public class FieldSerializerTest extends KryoTestCase {
 			return;
 		}
 
-		assertFalse("Exception was expected", true);
+		fail("Exception was expected");
 	}
 
 	@Test

--- a/test/com/esotericsoftware/kryo/serializers/FieldSerializerTest.java
+++ b/test/com/esotericsoftware/kryo/serializers/FieldSerializerTest.java
@@ -19,6 +19,8 @@
 
 package com.esotericsoftware.kryo.serializers;
 
+import static org.junit.Assert.*;
+
 import com.esotericsoftware.kryo.DefaultSerializer;
 import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.KryoException;

--- a/test/com/esotericsoftware/kryo/serializers/GenericsTest.java
+++ b/test/com/esotericsoftware/kryo/serializers/GenericsTest.java
@@ -41,7 +41,7 @@ public class GenericsTest extends KryoTestCase {
 	}
 
 	@Test
-	public void testGenericClassWithGenericFields () throws Exception {
+	public void testGenericClassWithGenericFields () {
 		kryo.setReferences(true);
 		kryo.setRegistrationRequired(false);
 		kryo.register(BaseGeneric.class);
@@ -54,7 +54,7 @@ public class GenericsTest extends KryoTestCase {
 	}
 
 	@Test
-	public void testNonGenericClassWithGenericSuperclass () throws Exception {
+	public void testNonGenericClassWithGenericSuperclass () {
 		kryo.setReferences(true);
 		kryo.setRegistrationRequired(false);
 		kryo.register(BaseGeneric.class);
@@ -69,7 +69,7 @@ public class GenericsTest extends KryoTestCase {
 
 	// Test for/from https://github.com/EsotericSoftware/kryo/issues/377
 	@Test
-	public void testDifferentTypeArguments () throws Exception {
+	public void testDifferentTypeArguments () {
 		LongHolder o1 = new LongHolder(1L);
 		LongListHolder o2 = new LongListHolder(Arrays.asList(1L));
 

--- a/test/com/esotericsoftware/kryo/serializers/Java8ClosureSerializerTest.java
+++ b/test/com/esotericsoftware/kryo/serializers/Java8ClosureSerializerTest.java
@@ -19,7 +19,7 @@
 
 package com.esotericsoftware.kryo.serializers;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
 
 import com.esotericsoftware.kryo.KryoTestCase;
 import com.esotericsoftware.kryo.io.Input;
@@ -46,7 +46,7 @@ public class Java8ClosureSerializerTest extends KryoTestCase {
 	}
 
 	@Test
-	public void testSerializableClosure () throws Exception {
+	public void testSerializableClosure () {
 		Callable<Integer> closure1 = (Callable<Integer> & java.io.Serializable)( () -> 72363);
 
 		// The length cannot be checked reliable, as it can vary based on the JVM.

--- a/test/com/esotericsoftware/kryo/serializers/Java8ClosureSerializerTest.java
+++ b/test/com/esotericsoftware/kryo/serializers/Java8ClosureSerializerTest.java
@@ -19,6 +19,8 @@
 
 package com.esotericsoftware.kryo.serializers;
 
+import static org.junit.Assert.assertEquals;
+
 import com.esotericsoftware.kryo.KryoTestCase;
 import com.esotericsoftware.kryo.io.Input;
 import com.esotericsoftware.kryo.io.Output;

--- a/test/com/esotericsoftware/kryo/serializers/MapSerializerTest.java
+++ b/test/com/esotericsoftware/kryo/serializers/MapSerializerTest.java
@@ -199,7 +199,7 @@ public class MapSerializerTest extends KryoTestCase {
 	}
 
 	@Test
-	public void testSerializingMapAfterDeserializingMultipleReferencesToSameMap () throws Exception {
+	public void testSerializingMapAfterDeserializingMultipleReferencesToSameMap () {
 		Kryo kryo = new Kryo();
 		kryo.setRegistrationRequired(false);
 		Output output = new Output(4096);

--- a/test/com/esotericsoftware/kryo/serializers/TaggedFieldSerializerTest.java
+++ b/test/com/esotericsoftware/kryo/serializers/TaggedFieldSerializerTest.java
@@ -41,7 +41,7 @@ public class TaggedFieldSerializerTest extends KryoTestCase {
 	}
 
 	@Test
-	public void testTaggedFieldSerializer () throws FileNotFoundException {
+	public void testTaggedFieldSerializer () {
 		TestClass object1 = new TestClass();
 		object1.moo = 2;
 		object1.child = new TestClass();
@@ -53,11 +53,11 @@ public class TaggedFieldSerializerTest extends KryoTestCase {
 		kryo.register(TestClass.class);
 		kryo.register(AnotherClass.class);
 		TestClass object2 = roundTrip(57, object1);
-		assertTrue(object2.ignored == 0);
+		assertEquals(0, object2.ignored);
 	}
 
 	@Test
-	public void testAddedField () throws FileNotFoundException {
+	public void testAddedField () {
 		TestClass object1 = new TestClass();
 		object1.child = new TestClass();
 		object1.other = new AnotherClass();

--- a/test/com/esotericsoftware/kryo/serializers/TaggedFieldSerializerTest.java
+++ b/test/com/esotericsoftware/kryo/serializers/TaggedFieldSerializerTest.java
@@ -30,7 +30,6 @@ import com.esotericsoftware.kryo.serializers.TaggedFieldSerializer.Tag;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.io.FileNotFoundException;
 
 import org.junit.Test;
 

--- a/test/com/esotericsoftware/kryo/serializers/VersionedFieldSerializerTest.java
+++ b/test/com/esotericsoftware/kryo/serializers/VersionedFieldSerializerTest.java
@@ -19,7 +19,7 @@
 
 package com.esotericsoftware.kryo.serializers;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 import com.esotericsoftware.kryo.KryoTestCase;
 import com.esotericsoftware.kryo.serializers.VersionFieldSerializer.Since;
@@ -34,7 +34,7 @@ public class VersionedFieldSerializerTest extends KryoTestCase {
 	}
 
 	@Test
-	public void testVersionFieldSerializer () throws FileNotFoundException {
+	public void testVersionFieldSerializer () {
 		TestClass object1 = new TestClass();
 		object1.moo = 2;
 		object1.child = null;
@@ -51,8 +51,8 @@ public class VersionedFieldSerializerTest extends KryoTestCase {
 
 		TestClass object2 = roundTrip(25, object1);
 
-		assertTrue(object2.moo == object1.moo);
-		assertTrue(object2.other.value.equals(object1.other.value));
+		assertEquals(object2.moo, object1.moo);
+		assertEquals(object2.other.value, object1.other.value);
 	}
 
 	static public class TestClass {

--- a/test/com/esotericsoftware/kryo/serializers/VersionedFieldSerializerTest.java
+++ b/test/com/esotericsoftware/kryo/serializers/VersionedFieldSerializerTest.java
@@ -24,8 +24,6 @@ import static org.junit.Assert.*;
 import com.esotericsoftware.kryo.KryoTestCase;
 import com.esotericsoftware.kryo.serializers.VersionFieldSerializer.Since;
 
-import java.io.FileNotFoundException;
-
 import org.junit.Test;
 
 public class VersionedFieldSerializerTest extends KryoTestCase {

--- a/test/com/esotericsoftware/kryo/serializers/VersionedFieldSerializerTest.java
+++ b/test/com/esotericsoftware/kryo/serializers/VersionedFieldSerializerTest.java
@@ -19,6 +19,8 @@
 
 package com.esotericsoftware.kryo.serializers;
 
+import static org.junit.Assert.assertTrue;
+
 import com.esotericsoftware.kryo.KryoTestCase;
 import com.esotericsoftware.kryo.serializers.VersionFieldSerializer.Since;
 

--- a/test/com/esotericsoftware/kryo/util/GenericsUtilTest.java
+++ b/test/com/esotericsoftware/kryo/util/GenericsUtilTest.java
@@ -67,7 +67,7 @@ public class GenericsUtilTest {
 		// names = new String[] {"ArrayList<ArrayList<String>> fromFieldNested"};
 		for (String value1 : names) {
 			int index = value1.lastIndexOf(' ');
-			String type = value1.substring(0, index), name = value1.substring(index + 1);
+			String name = value1.substring(index + 1);
 
 			Field field = Test4.class.getField(name);
 			Class declaringClass = field.getDeclaringClass();

--- a/test/com/esotericsoftware/kryo/util/PoolTest.java
+++ b/test/com/esotericsoftware/kryo/util/PoolTest.java
@@ -19,6 +19,8 @@
 
 package com.esotericsoftware.kryo.util;
 
+import static org.junit.Assert.*;
+
 import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.KryoTestCase;
 import com.esotericsoftware.kryo.util.Pool;

--- a/test/com/esotericsoftware/kryo/util/PoolTest.java
+++ b/test/com/esotericsoftware/kryo/util/PoolTest.java
@@ -23,7 +23,6 @@ import static org.junit.Assert.*;
 
 import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.KryoTestCase;
-import com.esotericsoftware.kryo.util.Pool;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -65,7 +64,7 @@ public class PoolTest extends KryoTestCase {
 	public void getShouldReturnAvailableInstance () {
 		Kryo kryo = pool.obtain();
 		pool.free(kryo);
-		assertTrue(kryo == pool.obtain());
+		assertSame(kryo, pool.obtain());
 	}
 
 	@Test
@@ -82,7 +81,7 @@ public class PoolTest extends KryoTestCase {
 		Kryo kryo1 = pool.obtain();
 		assertEquals(0, pool.getFree());
 		Kryo kryo2 = pool.obtain();
-		assertFalse(kryo1 == kryo2);
+		assertNotSame(kryo1, kryo2);
 		pool.free(kryo1);
 		assertEquals(1, pool.getFree());
 		pool.free(kryo2);


### PR DESCRIPTION
Move to Junit4 Style test code(Part3). It is Final.

- Stop extending `org.junit.TestCase` at `KryoTestCase`. And I don't remove `KryoTestCase` :)
- Use assertion methods in `org.junit.Assert`, insted of methods in `org.junit.TestCase`
- Use suitable assertion method like `assertNull` `assertNotSame` `assertSame` `assertTrue` `assertFalse` insted of `assertEquals` if possible
- Remove unused throws statement at method signature.
- Use `@Test(expected = ExceptionClass.class)` where test expects to thrown exception
  as long as test code will be simple. 
Because Junit4 hasn't suitable assertion method for testing exception thrown.
And At Junit5, good assertion method like `assertThrown` is introduced.
So, I think that it is not reasonable that I modify test code now where I can write more clearly with using Junit5 assertion methods. 
Therefore I modify test code which expect to throw exception as long as I can modify simple.
  
