### PR TITLE
Reduce TaggedFieldSerializer deserialization complexity from O(n^2) to O(n)

### DIFF
--- a/src/com/esotericsoftware/kryo/serializers/TaggedFieldSerializer.java
+++ b/src/com/esotericsoftware/kryo/serializers/TaggedFieldSerializer.java
@@ -36,8 +36,10 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.lang.reflect.Field;
-import java.util.Arrays;
-import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
 
 /** Serializes objects using direct field assignment for fields that have a <code>@Tag(int)</code> annotation, providing backward
  * compatibility and optional forward compatibility. This means fields can be added or renamed and optionally removed without
@@ -60,15 +62,9 @@ import java.util.Comparator;
  * flexibility for classes to evolve. This comes at the cost of one varint per field.
  * @author Nathan Sweet */
 public class TaggedFieldSerializer<T> extends FieldSerializer<T> {
-	static private final Comparator<CachedField> tagComparator = new Comparator<CachedField>() {
-		public int compare (CachedField o1, CachedField o2) {
-			return o1.field.getAnnotation(Tag.class).value() - o2.field.getAnnotation(Tag.class).value();
-		}
-	};
-
-	private int[] tags;
 	private int writeFieldCount;
-	private boolean[] deprecated;
+	private Map<Integer, CachedField> taggedFields;
+	private Set<Integer> deprecatedTags;
 	private final TaggedFieldSerializerConfig config;
 
 	public TaggedFieldSerializer (Kryo kryo, Class type) {
@@ -84,28 +80,29 @@ public class TaggedFieldSerializer<T> extends FieldSerializer<T> {
 	protected void initializeCachedFields () {
 		CachedField[] fields = cachedFields.fields;
 		// Remove untagged fields.
-		for (int i = 0, n = fields.length; i < n; i++) {
-			Field field = fields[i].field;
+		for (CachedField cachedField : fields) {
+			Field field = cachedField.field;
 			if (field.getAnnotation(Tag.class) == null) {
-				if (TRACE) trace("kryo", "Ignoring field without tag: " + fields[i]);
-				super.removeField(fields[i]);
+				if (TRACE) trace("kryo", "Ignoring field without tag: " + cachedField);
+				super.removeField(cachedField);
 			}
 		}
 		fields = cachedFields.fields; // removeField changes cached field array.
-		Arrays.sort(fields, tagComparator); // fields are sorted to easily check for reused tag values
 
 		// Cache tag values.
-		int n = fields.length;
-		writeFieldCount = n;
-		tags = new int[n];
-		deprecated = new boolean[n];
-		for (int i = 0; i < n; i++) {
-			Field field = fields[i].field;
-			tags[i] = field.getAnnotation(Tag.class).value();
-			if (i > 0 && tags[i] == tags[i - 1]) // Relies on fields having been sorted.
-				throw new KryoException("Duplicate tag " + tags[i] + " on fields: " + field + " and " + fields[i - 1].field);
+		writeFieldCount = fields.length;
+		taggedFields = new HashMap<>();
+		deprecatedTags = new HashSet<>();
+		for (CachedField cachedField : fields) {
+			Field field = cachedField.field;
+			int tag = field.getAnnotation(Tag.class).value();
+			if (taggedFields.containsKey(tag)) {
+				throw new KryoException(String.format("Duplicate tag %d on fields: %s and %s",
+						tag, field, taggedFields.get(tag)));
+			}
+			taggedFields.put(tag, cachedField);
 			if (field.getAnnotation(Deprecated.class) != null) {
-				deprecated[i] = true;
+				deprecatedTags.add(tag);
 				writeFieldCount--;
 			}
 		}
@@ -132,8 +129,6 @@ public class TaggedFieldSerializer<T> extends FieldSerializer<T> {
 		output.writeVarInt(writeFieldCount + 1, true);
 		writeHeader(kryo, output, object);
 
-		CachedField[] fields = cachedFields.fields;
-
 		boolean chunked = config.chunked, readUnknownTagData = config.readUnknownTagData;
 		Output fieldOutput;
 		OutputChunked outputChunked = null;
@@ -141,14 +136,14 @@ public class TaggedFieldSerializer<T> extends FieldSerializer<T> {
 			fieldOutput = outputChunked = new OutputChunked(output, config.chunkSize);
 		else
 			fieldOutput = output;
-		int[] tags = this.tags;
-		boolean[] deprecated = this.deprecated;
-		for (int i = 0, n = fields.length; i < n; i++) {
-			if (deprecated[i]) continue;
-			CachedField cachedField = fields[i];
 
-			if (TRACE) log("Write", fields[i], output.position());
-			output.writeVarInt(tags[i], true);
+		for (int tag : taggedFields.keySet()) {
+			if (deprecatedTags.contains(tag)) {
+				continue;
+			}
+			CachedField cachedField = taggedFields.get(tag);
+			if (TRACE) log("Write", cachedField, output.position());
+			output.writeVarInt(tag, true);
 
 			// Write the value class so the field data can be read even if the field is removed.
 			if (readUnknownTagData) {
@@ -190,8 +185,6 @@ public class TaggedFieldSerializer<T> extends FieldSerializer<T> {
 		T object = create(kryo, input, type);
 		kryo.reference(object);
 
-		CachedField[] fields = cachedFields.fields;
-
 		boolean chunked = config.chunked, readUnknownTagData = config.readUnknownTagData;
 		Input fieldInput;
 		InputChunked inputChunked = null;
@@ -199,16 +192,9 @@ public class TaggedFieldSerializer<T> extends FieldSerializer<T> {
 			fieldInput = inputChunked = new InputChunked(input, config.chunkSize);
 		else
 			fieldInput = input;
-		int[] tags = this.tags;
-		for (int i = 0, n = fieldCount; i < n; i++) {
+		for (int i = 0; i < fieldCount; i++) {
 			int tag = input.readVarInt(true);
-			CachedField cachedField = null;
-			for (int ii = 0, nn = tags.length; ii < nn; ii++) {
-				if (tags[ii] == tag) {
-					cachedField = fields[ii];
-					break;
-				}
-			}
+			CachedField cachedField = taggedFields.get(tag);
 
 			if (readUnknownTagData) {
 				Registration registration;


### PR DESCRIPTION
I noticed that the deserialization algorithm for TaggedFieldSerializer had a complexity of O(n^2), due to this O(n) search to find the field associated with each tag:

```
CachedField cachedField = null;
for (int ii = 0, nn = tags.length; ii < nn; ii++) {
  if (tags[ii] == tag) {
    cachedField = fields[ii];
    break;
  }
}
```

By caching the fields in a map instead of an array, I was able to reduce the complexity of this lookup to O(1).

```
CachedField cachedField = taggedFields.get(tag);
```

That's basically it. The rest of the change stems from `int[] tags` becoming `Map<Integer, CachedField> taggedFields`, and `boolean[] deprecated` becoming `Set<Integer> deprecatedTags`.

No interface changes. Just an internal/private algorithm change.