### PR TITLE
add dubbo to products using Kryo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1256,7 +1256,7 @@ There are a number of projects using Kryo. A few are listed below. Please submit
 - [Jive](http://www.jivesoftware.com/jivespace/blogs/jivespace/2010/07/29/the-jive-sbs-cache-redesign-part-3)
 - [DestroyAllHumans](https://code.google.com/p/destroyallhumans/) (controls a [robot](http://www.youtube.com/watch?v=ZeZ3R38d3Cg)!)
 - [Mybatis Redis-Cache](https://github.com/mybatis/redis-cache) (MyBatis Redis Cache adapter)
-- [Apache Dubbo(incubating)](https://github.com/apache/incubator-dubbo) (a high-performance, java based, open source RPC framework)
+- [Apache Dubbo](https://github.com/apache/incubator-dubbo) (high performance, open source RPC framework)
 
 ### Scala
 

--- a/README.md
+++ b/README.md
@@ -1256,6 +1256,7 @@ There are a number of projects using Kryo. A few are listed below. Please submit
 - [Jive](http://www.jivesoftware.com/jivespace/blogs/jivespace/2010/07/29/the-jive-sbs-cache-redesign-part-3)
 - [DestroyAllHumans](https://code.google.com/p/destroyallhumans/) (controls a [robot](http://www.youtube.com/watch?v=ZeZ3R38d3Cg)!)
 - [Mybatis Redis-Cache](https://github.com/mybatis/redis-cache) (MyBatis Redis Cache adapter)
+- [Apache Dubbo(incubating)](https://github.com/apache/incubator-dubbo) (a high-performance, java based, open source RPC framework)
 
 ### Scala
 


### PR DESCRIPTION
Apache Dubbo™ (incubating) is a high-performance, java based open source RPC framework. It started incubating since 16th Feb, 2018.

In Dubbo, we have a serialization extension with Kryo, here it is: https://github.com/apache/incubator-dubbo/tree/master/dubbo-serialization/dubbo-serialization-kryo

We'll appreciate that if Dubbo can be placed under `products using Kryo`. Please let me know if other works needed. Thanks again.