### PR TITLE
Add automatic module name to jar manifest

### DIFF
--- a/pom-main.xml
+++ b/pom-main.xml
@@ -18,7 +18,7 @@
 		<dependency>
 			<groupId>com.esotericsoftware</groupId>
 			<artifactId>reflectasm</artifactId>
-			<version>1.11.7</version>
+			<version>1.11.8</version>
 		</dependency>
 		<dependency>
 			<groupId>org.objenesis</groupId>
@@ -28,12 +28,23 @@
 		<dependency>
 			<groupId>com.esotericsoftware</groupId>
 			<artifactId>minlog</artifactId>
-			<version>1.3.0</version>
+			<version>1.3.1</version>
 		</dependency>
 	</dependencies>
 
 	<build>
 		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-jar-plugin</artifactId>
+				<configuration>
+					<archive>
+						<manifestEntries>
+							<Automatic-Module-Name>com.esotericsoftware.kryo</Automatic-Module-Name>
+						</manifestEntries>
+					</archive>
+				</configuration>
+			</plugin>
 			<plugin>
 				<groupId>org.apache.felix</groupId>
 				<artifactId>maven-bundle-plugin</artifactId>


### PR DESCRIPTION
For the motivation see https://blog.joda.org/2017/05/java-se-9-jpms-automatic-modules.html

reflectasm and minlog are updated to versions that provide an
Automatic-Module-Name as well.

objenesis is not updated, because it only provides Automatic-Module-Name
with 3.0.1, which requires java 1.8 (since 3.0.0) and therefore would
require kryo to switch from 1.7 to 1.8.

Refs #626