### PR TITLE
Update objenesis, push source/target version to 1.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,12 +23,9 @@ install:
   - mvn -B -V clean test
 
 script:
-  # compile tests with java 8, but with testSource/testTarget 1.7 (disabled java8 profile), so that we can run tests with java 7
+  # compile tests with java 8
   - jdk_switcher use oraclejdk8
-  - mvn -B -P!java8 clean install
-  # test java 7
-  - jdk_switcher use openjdk7
-  - mvn -v && mvn -B test
+  - mvn -B clean install
   # test java 9 (only available via oraclejdk9)
   - jdk_switcher use oraclejdk9
   - mvn -v && mvn -B test

--- a/pom-main.xml
+++ b/pom-main.xml
@@ -23,7 +23,7 @@
 		<dependency>
 			<groupId>org.objenesis</groupId>
 			<artifactId>objenesis</artifactId>
-			<version>2.6</version>
+			<version>3.0.1</version>
 		</dependency>
 		<dependency>
 			<groupId>com.esotericsoftware</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -39,9 +39,8 @@
 	</developers>
 
 	<properties>
-		<javac.target>1.7</javac.target>
+		<javac.target>1.8</javac.target>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<test.exclude>**/Java8*Test.java</test.exclude>
 	</properties>
 
 	<modules>
@@ -79,9 +78,6 @@
 						<source>${javac.target}</source>
 						<target>${javac.target}</target>
 						<encoding>utf-8</encoding>
-						<testExcludes>
-							<testExclude>${test.exclude}</testExclude>
-						</testExcludes>
 					</configuration>
 				</plugin>
 
@@ -156,42 +152,6 @@
 			</build>
 		</profile>
 
-		<profile>
-			<id>until-java8</id>
-			<activation>
-				<!-- Use exclusive 1.8 range instead of inclusive 1.7, because an upper bound ",1.7]" is likely not to include most releases of 1.7,
-				   since they will have an additional "patch" release such as _05 that is not taken into consideration in the above range.
-				   See also: http://maven.apache.org/guides/introduction/introduction-to-profiles.html#Details_on_profile_activation -->
-				<jdk>[1.5,1.8)</jdk>
-			</activation>
-			<build>
-				<plugins>
-					<plugin>
-						<groupId>org.apache.maven.plugins</groupId>
-						<artifactId>maven-surefire-plugin</artifactId>
-						<version>2.22.0</version>
-						<configuration>
-							<excludes>
-								<exclude>**/Java8*Test.java</exclude>
-							</excludes>
-						</configuration>
-					</plugin>
-				</plugins>
-			</build>
-		</profile>
-
-		<profile>
-			<id>java8</id>
-			<!-- To disable this profile run mvn with '-P !java8' (maybe escape the exclamation mark). -->
-			<activation><jdk>[1.8,)</jdk></activation>
-			<!-- Use properties to change compiler configuration because overriding build/plugin config just did not work. -->
-			<properties>
-				<!-- Setting an empty values does not override/set the property. -->
-				<test.exclude>someValueWhichDoesNotExist</test.exclude>
-				<maven.compiler.testSource>1.8</maven.compiler.testSource>
-				<maven.compiler.testTarget>1.8</maven.compiler.testTarget>
-			</properties>
-		</profile>
 	</profiles>
 
 	<repositories>

--- a/test/com/esotericsoftware/kryo/serializers/ClosureSerializerTest.java
+++ b/test/com/esotericsoftware/kryo/serializers/ClosureSerializerTest.java
@@ -31,9 +31,8 @@ import java.util.concurrent.Callable;
 import org.junit.Before;
 import org.junit.Test;
 
-/** Test for java 8 closures. For JDK < 1.8 exclude from the surefire tests via the "until-java8" profile in pom.xml (which
- * excludes "Java8*Tests"). */
-public class Java8ClosureSerializerTest extends KryoTestCase {
+/** Test for java 8 closures. */
+public class ClosureSerializerTest extends KryoTestCase {
 	@Before
 	public void setUp () throws Exception {
 		super.setUp();

--- a/test/com/esotericsoftware/kryo/serializers/OptionalSerializersTest.java
+++ b/test/com/esotericsoftware/kryo/serializers/OptionalSerializersTest.java
@@ -30,9 +30,8 @@ import java.util.OptionalLong;
 import org.junit.Before;
 import org.junit.Test;
 
-/** Test for java 8 Optional* serializers. Excluded from surefire tests via the "until-java8" profile in pom.xml which excludes
- * "Java8*Tests". */
-public class Java8OptionalSerializersTest extends KryoTestCase {
+/** Test for java 8 Optional* serializers. */
+public class OptionalSerializersTest extends KryoTestCase {
 
 	{
 		supportsCopy = true;

--- a/test/com/esotericsoftware/kryo/serializers/TimeSerializersTest.java
+++ b/test/com/esotericsoftware/kryo/serializers/TimeSerializersTest.java
@@ -40,9 +40,8 @@ import java.time.ZonedDateTime;
 import org.junit.Before;
 import org.junit.Test;
 
-/** Test for java 8 java.time.* serializers. Excluded from surefire tests via the "until-java8" profile in pom.xml which excludes
- * "Java8*Tests". */
-public class Java8TimeSerializersTest extends KryoTestCase {
+/** Test for java 8 java.time.* serializers. */
+public class TimeSerializersTest extends KryoTestCase {
 
 	@Before
 	public void setUp () throws Exception {


### PR DESCRIPTION
objenesis 3.0.1 comes with an Automatic Module Name, i.e. with that
kryo does no longer depend on any library that's not explicitely named.
For details / the motivation see also [this post](https://blog.joda.org/2017/05/java-se-9-jpms-automatic-modules.html).

Because objenesis 3.0.1 only supports java 8, the source/target version
is pushed accordingly.