### PR TITLE
Avoid NPE writing StringBuilder/StringBuffer

### DIFF
--- a/src/com/esotericsoftware/kryo/serializers/DefaultSerializers.java
+++ b/src/com/esotericsoftware/kryo/serializers/DefaultSerializers.java
@@ -438,7 +438,7 @@ public class DefaultSerializers {
 		}
 
 		public void write (Kryo kryo, Output output, StringBuffer object) {
-			output.writeString(object.toString());
+			output.writeString(object == null ? null : object.toString());
 		}
 
 		public StringBuffer read (Kryo kryo, Input input, Class<? extends StringBuffer> type) {
@@ -459,7 +459,7 @@ public class DefaultSerializers {
 		}
 
 		public void write (Kryo kryo, Output output, StringBuilder object) {
-			output.writeString(object.toString());
+			output.writeString(object == null ? null : object.toString());
 		}
 
 		public StringBuilder read (Kryo kryo, Input input, Class<? extends StringBuilder> type) {


### PR DESCRIPTION
If a null StringBuilder or StringBuffer is provided, a NullPointerException occurs. Since these serializers both do `setAcceptsNull(true)`, a null is passed to their `write` methods which needs to be handled.