### PR TITLE
using writeClassAndObject instead of writeObject for captured args in ClosureSerializer#write

### DIFF
--- a/src/com/esotericsoftware/kryo/serializers/ClosureSerializer.java
+++ b/src/com/esotericsoftware/kryo/serializers/ClosureSerializer.java
@@ -66,7 +66,7 @@ public class ClosureSerializer extends Serializer {
 		int count = serializedLambda.getCapturedArgCount();
 		output.writeVarInt(count, true);
 		for (int i = 0; i < count; i++)
-			kryo.writeObject(output, serializedLambda.getCapturedArg(i));
+			kryo.writteClassAndObjec(output, serializedLambda.getCapturedArg(i));
 		try {
 			kryo.writeClass(output, Class.forName(serializedLambda.getCapturingClass().replace('/', '.')));
 		} catch (ClassNotFoundException ex) {

--- a/src/com/esotericsoftware/kryo/serializers/ClosureSerializer.java
+++ b/src/com/esotericsoftware/kryo/serializers/ClosureSerializer.java
@@ -66,7 +66,7 @@ public class ClosureSerializer extends Serializer {
 		int count = serializedLambda.getCapturedArgCount();
 		output.writeVarInt(count, true);
 		for (int i = 0; i < count; i++)
-			kryo.writteClassAndObjec(output, serializedLambda.getCapturedArg(i));
+			kryo.writeClassAndObject(output, serializedLambda.getCapturedArg(i));
 		try {
 			kryo.writeClass(output, Class.forName(serializedLambda.getCapturingClass().replace('/', '.')));
 		} catch (ClassNotFoundException ex) {


### PR DESCRIPTION
As my understanding, ClosureSerializer#write should write class names for captured args by writeClassAndObject instead of writeObject.