### PR TITLE
Fixes for generic serialization issues

### DIFF
--- a/src/com/esotericsoftware/kryo/serializers/FieldSerializer.java
+++ b/src/com/esotericsoftware/kryo/serializers/FieldSerializer.java
@@ -129,6 +129,10 @@ public class FieldSerializer<T> extends Serializer<T> {
 	/** Prepares the type variables for the serialized type. Must be balanced with {@link #popTypeVariables(int)} if >0 is
 	 * returned. */
 	protected int pushTypeVariables () {
+		if (genericsHierarchy.isEmpty()) {
+			return 0;
+		}
+
 		GenericType[] genericTypes = kryo.getGenerics().nextGenericTypes();
 		if (genericTypes == null) return 0;
 

--- a/src/com/esotericsoftware/kryo/util/Generics.java
+++ b/src/com/esotericsoftware/kryo/util/Generics.java
@@ -248,6 +248,10 @@ public class Generics {
 			buffer.append("]");
 			return buffer.toString();
 		}
+
+		public boolean isEmpty() {
+			return total == 0;
+		}
 	}
 
 	/** Stores a type and its type parameters, recursively. */

--- a/src/com/esotericsoftware/kryo/util/GenericsUtil.java
+++ b/src/com/esotericsoftware/kryo/util/GenericsUtil.java
@@ -109,6 +109,10 @@ public class GenericsUtil {
 			}
 		}
 
+		// We have exhausted looking through superclasses for a concrete generic type
+		// definition, so the current type must have been defined on the first class.
+		if (first) return type;
+
 		// If this happens, there is a case we need to handle.
 		throw new KryoException("Unable to resolve type variable: " + type);
 	}

--- a/src/com/esotericsoftware/kryo/util/GenericsUtil.java
+++ b/src/com/esotericsoftware/kryo/util/GenericsUtil.java
@@ -100,6 +100,7 @@ public class GenericsUtil {
 				// Success, the type variable was explicitly declared.
 				if (arg instanceof Class) return arg;
 				if (arg instanceof ParameterizedType) return resolveType(fromClass, current, arg);
+				if (arg instanceof GenericArrayType) return resolveType(fromClass, current, arg);
 
 				if (arg instanceof TypeVariable) {
 					if (first) return type; // Failure, no more sub classes.

--- a/test/com/esotericsoftware/kryo/serializers/GenericsTest.java
+++ b/test/com/esotericsoftware/kryo/serializers/GenericsTest.java
@@ -128,7 +128,6 @@ public class GenericsTest extends KryoTestCase {
 
 	// Test for https://github.com/EsotericSoftware/kryo/issues/654
 	@Test
-	@Ignore("Currently failing")
 	public void testFieldWithGenericInterface () {
 		ClassWithGenericInterfaceField o = new ClassWithGenericInterfaceField();
 

--- a/test/com/esotericsoftware/kryo/serializers/GenericsTest.java
+++ b/test/com/esotericsoftware/kryo/serializers/GenericsTest.java
@@ -155,7 +155,6 @@ public class GenericsTest extends KryoTestCase {
 
 	// Test for https://github.com/EsotericSoftware/kryo/issues/655
 	@Test
-	@Ignore("Currently failing")
 	public void testClassWithMultipleGenericTypes() {
 		final HolderWithAdditionalGenericType<String, Integer> o = new HolderWithAdditionalGenericType<>(1);
 

--- a/test/com/esotericsoftware/kryo/serializers/GenericsTest.java
+++ b/test/com/esotericsoftware/kryo/serializers/GenericsTest.java
@@ -145,7 +145,6 @@ public class GenericsTest extends KryoTestCase {
 
 	// Test for https://github.com/EsotericSoftware/kryo/issues/655
 	@Test
-	@Ignore("Currently failing")
 	public void testFieldWithGenericArrayType() {
 		final ClassArrayHolder o = new ClassArrayHolder(new Class[]{});
 


### PR DESCRIPTION
This PR applies known fixes to resolve failing test-cases from #717.

It includes fixes suggested in:
- https://github.com/EsotericSoftware/kryo/pull/685
- https://github.com/EsotericSoftware/kryo/pull/707

All tests pass after applying these changes, but there might be additional corner cases as reported in #707. 

However, I believe that these 3 minor changes will resolve the vast majority of generics issues and should be reasonably safe:

- https://github.com/EsotericSoftware/kryo/commit/aefcde517ddd9ccf6020da52703b1e38c5e138a1 simply adds a missing handler for generic array types
- https://github.com/EsotericSoftware/kryo/commit/f2b6e292cc3f442140d54d3d62b6240004545f36 only applies in cases where an exception is currently thrown and can't really make matters worse
- https://github.com/EsotericSoftware/kryo/commit/ef353ecb0d9805a934e36a782b96d8dc5ee3246f is the only change that could potentially have negative effects on currently working code, but it is simple enough and all tests pass

I would suggest to merge this, create another RC and get more feedback from users.