### PR TITLE
Fix test when building with JDK11

### DIFF
--- a/test/com/esotericsoftware/kryo/SerializationCompatTestData.java
+++ b/test/com/esotericsoftware/kryo/SerializationCompatTestData.java
@@ -218,7 +218,7 @@ public class SerializationCompatTestData {
 			_integerArray = new Integer[] {13};
 
 			_date = new Date(42);
-			_calendar = Calendar.getInstance();
+			_calendar = Calendar.getInstance(Locale.ENGLISH);
 			_calendar.setTimeZone(TimeZone.getTimeZone("America/Los_Angeles"));
 			_calendar.set(2009, Calendar.JANUARY, 25, 10, 29, 0);
 			_calendar.set(Calendar.MILLISECOND, 0);


### PR DESCRIPTION
This PR corrects a test failure when building with JDK11.

Locale providers changed with JDK11, resulting in slightly different default behavior:

- https://javachannel.org/posts/help-my-java-locale-is-wrong-in-jdk11/
- https://www.oracle.com/java/technologies/javase/jdk11-suported-locales.html#providers