### PR TITLE
#655 Fix generics corner cases

### DIFF
--- a/src/com/esotericsoftware/kryo/util/GenericsUtil.java
+++ b/src/com/esotericsoftware/kryo/util/GenericsUtil.java
@@ -110,11 +110,8 @@ public class GenericsUtil {
 		}
 
 		// We have exhausted looking through superclasses for a concrete generic type
-		// definition, so the current type must have been defined on the first class.
-		if (first) return type;
-
-		// If this happens, there is a case we need to handle.
-		throw new KryoException("Unable to resolve type variable: " + type);
+		// definition, so we return the type variable instead.
+		return type;
 	}
 
 	/** Resolves type variables for the type parameters of the specified type by using the class hierarchy between the specified

--- a/test/com/esotericsoftware/kryo/serializers/GenericsTest.java
+++ b/test/com/esotericsoftware/kryo/serializers/GenericsTest.java
@@ -30,7 +30,6 @@ import java.lang.invoke.SerializedLambda;
 import java.util.*;
 
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 public class GenericsTest extends KryoTestCase {
@@ -129,38 +128,54 @@ public class GenericsTest extends KryoTestCase {
 	// Test for https://github.com/EsotericSoftware/kryo/issues/654
 	@Test
 	public void testFieldWithGenericInterface () {
-		ClassWithGenericInterfaceField o = new ClassWithGenericInterfaceField();
+		final Holder<?> holder = new ClassArrayHolder(new Class[] {});
+		ClassWithGenericInterfaceField o = new ClassWithGenericInterfaceField(holder);
 
 		kryo.setRegistrationRequired(false);
 		kryo.register(SerializedLambda.class);
 		kryo.register(ClosureSerializer.Closure.class, new ClosureSerializer());
 
-		Output buffer = new Output(512, 4048);
-		kryo.writeClassAndObject(buffer, o);
-		buffer.flush();
-
-		Input input = new Input(buffer.getBuffer(), 0, buffer.position());
-		kryo.readObject(input, ClassWithGenericInterfaceField.class);
+		roundTrip(153, o);
 	}
 
 	// Test for https://github.com/EsotericSoftware/kryo/issues/655
 	@Test
 	public void testFieldWithGenericArrayType() {
-		final ClassArrayHolder o = new ClassArrayHolder(new Class[]{});
+		ClassArrayHolder o = new ClassArrayHolder(new Class[] {});
 
 		kryo.setRegistrationRequired(false);
-		Output buffer = new Output(512, 4048);
-		kryo.writeClassAndObject(buffer, o);
+
+		roundTrip(70, o);
 	}
 
 	// Test for https://github.com/EsotericSoftware/kryo/issues/655
 	@Test
 	public void testClassWithMultipleGenericTypes() {
-		final HolderWithAdditionalGenericType<String, Integer> o = new HolderWithAdditionalGenericType<>(1);
+		HolderWithAdditionalGenericType<String, Integer> o = new HolderWithAdditionalGenericType<>(1);
 
 		kryo.setRegistrationRequired(false);
-		Output buffer = new Output(512, 4048);
-		kryo.writeClassAndObject(buffer, o);
+
+		roundTrip(87, o);
+	}
+
+	// Test for https://github.com/EsotericSoftware/kryo/issues/655
+	@Test
+	public void testClassHierarchyWithChangingGenericTypeVariables () {
+		ClassHierarchyWithChangingTypeVariableNames.A<?> o = new ClassHierarchyWithChangingTypeVariableNames.A<>(Enum.class);
+
+		kryo.setRegistrationRequired(false);
+
+		roundTrip(131, o);
+	}
+
+	// Test for https://github.com/EsotericSoftware/kryo/issues/655
+	@Test
+	public void testClassHierarchyWithMultipleTypeVariables () {
+		ClassHierarchyWithMultipleTypeVariables.A<Integer, ?> o = new ClassHierarchyWithMultipleTypeVariables.A<>(Enum.class);
+
+		kryo.setRegistrationRequired(false);
+
+		roundTrip(110, o);
 	}
 
 	private interface Holder<V> {
@@ -176,6 +191,14 @@ public class GenericsTest extends KryoTestCase {
 
 		public V getValue () {
 			return value;
+		}
+
+		@Override
+		public boolean equals (Object o) {
+			if (this == o) return true;
+			if (o == null || getClass() != o.getClass()) return false;
+			final AbstractValueHolder<?> that = (AbstractValueHolder<?>)o;
+			return Objects.deepEquals(value, that.value);
 		}
 	}
 
@@ -198,7 +221,12 @@ public class GenericsTest extends KryoTestCase {
 	}
 
 	static class ClassArrayHolder extends AbstractValueHolder<Class<?>[]> {
-		public ClassArrayHolder(Class<?>[] value) {
+		/** Kryo Constructor */
+		ClassArrayHolder () {
+			super(null);
+		}
+
+		ClassArrayHolder (Class<?>[] value) {
 			super(value);
 		}
 	}
@@ -206,8 +234,22 @@ public class GenericsTest extends KryoTestCase {
 	static class HolderWithAdditionalGenericType<BT, OT> extends AbstractValueHolder<OT> {
 		private BT value;
 
+		/** Kryo Constructor */
+		HolderWithAdditionalGenericType () {
+			super(null);
+		}
+
 		HolderWithAdditionalGenericType(OT value) {
 			super(value);
+		}
+
+		@Override
+		public boolean equals (Object o) {
+			if (this == o) return true;
+			if (o == null || getClass() != o.getClass()) return false;
+			if (!super.equals(o)) return false;
+			final HolderWithAdditionalGenericType<?, ?> that = (HolderWithAdditionalGenericType<?, ?>)o;
+			return Objects.equals(value, that.value);
 		}
 	}
 
@@ -356,9 +398,79 @@ public class GenericsTest extends KryoTestCase {
 	}
 
 	static class ClassWithGenericInterfaceField {
+		Holder<?> input;
 
-		private final Holder<?> input = (Holder<?> & Serializable) () -> null;
+		/** Kryo Constructor */
+		ClassWithGenericInterfaceField () {
+		}
 
+		ClassWithGenericInterfaceField (Holder<?> holder) {
+			input = holder;
+		}
+
+		@Override
+		public boolean equals (Object o) {
+			if (this == o) return true;
+			if (o == null || getClass() != o.getClass()) return false;
+			final ClassWithGenericInterfaceField that = (ClassWithGenericInterfaceField)o;
+			return Objects.equals(input, that.input);
+		}
+	}
+
+	static class ClassHierarchyWithChangingTypeVariableNames {
+		static final class A<T> extends B<T> {
+			T d;
+
+			/** Kryo Constructor */
+			A () {
+			}
+
+			A (T d) {
+				this.d = d;
+			}
+
+			@Override
+			public boolean equals (Object o) {
+				if (this == o) return true;
+				if (o == null || getClass() != o.getClass()) return false;
+				final A<?> a = (A<?>)o;
+				return Objects.equals(d, a.d);
+			}
+		}
+
+		static class B<E> extends C<E> {
+		}
+
+		static class C<E> {
+		}
+	}
+
+	static class ClassHierarchyWithMultipleTypeVariables {
+		static class A<T, S> extends B<T> {
+			Class<S> s;
+
+			/** Kryo Constructor */
+			A () {
+			}
+
+			A (Class<S> s) {
+				this.s = s;
+			}
+
+			@Override
+			public boolean equals (Object o) {
+				if (this == o) return true;
+				if (o == null || getClass() != o.getClass()) return false;
+				final A<?, ?> a = (A<?, ?>)o;
+				return Objects.equals(s, a.s);
+			}
+		}
+
+		static class B<T> extends C<T> {
+		}
+
+		public static class C<T> {
+		}
 	}
 
 }


### PR DESCRIPTION
This PR is a follow-up to #718.

The original PR solved many currently known generics issues, but I uncovered two more corner cases while testing against my main app.

The test `ClassHierarchyWithChangingTypeVariableNames` shows that in some cases it is **impossible** to correctly resolve the generic type using the current generics logic. It relies on matching type parameter names, but the test uses different names for the same type in different levels of the inheritance hierarchy.

While this sounds like bad news, this knowledge leads to a very simple solution. Instead of throwing an exception when type parameters cannot be resolved, we simply have to give up and return the type variable.