### PR TITLE
#693 JDK 11 Build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,6 @@ script:
   # install and publish snapshot with java 8
   # not via `after_success` but directly in `script`, since a failure would be silently ignored in `after_success`, which
   # is documented in https://docs.travis-ci.com/user/customizing-the-build#Breaking-the-Build
-  - jdk_switcher use openjdk8
   - if [ $TRAVIS_BRANCH = "master" ] && [ $TRAVIS_PULL_REQUEST = "false" ] && [ $IS_SNAPSHOT ]; then
       mvn -v && mvn -B -P requireSnapshot -DskipTests=true deploy --settings build/settings-sonatype.xml;
     else

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,32 +15,19 @@ env:
     - secure: kCOLgEveEDprSL3fOBeCc1/nmHVYEcNh/lRRWiJywFehOzKBTBF40pAWX7JtsWUPG8aPKGYFEE4sjYd+DF2DRknbuB2ZfAEgs9Xp9h5Mx1KztJYNiCfEnLciBBRDXA7t1M3TLKyT3ptA+Kk307cH2QHv9sUUnhnf0IofJyQhQvA=
   
 jdk:
-  #- openjdk7
-  - openjdk8
-
-before_install:
-  # required for testing jdk 11
-  - wget https://github.com/sormuras/bach/raw/master/install-jdk.sh -O $TRAVIS_BUILD_DIR/install-jdk.sh
-  - chmod u+x $TRAVIS_BUILD_DIR/install-jdk.sh
+  - openjdk11
 
 install:
-  # compile and test java 8
+  # compile and test java 11
   - mvn -B -V clean test
 
 script:
-  # compile tests with java 8
-  - jdk_switcher use openjdk8
+  # compile tests with java 11
   # separate "clean" from "install" because "clean install" would fail the pom-versioned module
   - mvn clean
   - mvn -B install
-  # test java 9 (only available via oraclejdk9)
-  - jdk_switcher use oraclejdk9
-  - mvn -v && mvn -B test
-  # test java 11
-  # see also https://docs.travis-ci.com/user/languages/java/#using-java-10-and-later
-  # and https://github.com/sormuras/bach#install-jdksh (because default travis docs didn't work)
-  - export JAVA_HOME=$HOME/openjdk11
-  - $TRAVIS_BUILD_DIR/install-jdk.sh --feature 11 --target $JAVA_HOME
+  # test java 8
+  - jdk_switcher use openjdk8
   - mvn -v && mvn -B test
   # install and publish snapshot with java 8
   # not via `after_success` but directly in `script`, since a failure would be silently ignored in `after_success`, which

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,10 +17,6 @@ env:
 jdk:
   - openjdk11
 
-install:
-  # compile and test java 11
-  - mvn -B -V clean test
-
 script:
   # compile tests with java 11
   # separate "clean" from "install" because "clean install" would fail the pom-versioned module

--- a/pom.xml
+++ b/pom.xml
@@ -171,7 +171,29 @@
 				</plugins>
 			</build>
 		</profile>
-
+		<profile>
+			<id>until-java11</id>
+			<activation>
+				<!-- Use exclusive 11 range instead of inclusive 10, because an upper bound ",10]" is likely not to include most releases of 10,
+				   since they will have an additional "patch" release such as _05 that is not taken into consideration in the above range.
+				   See also http://maven.apache.org/guides/introduction/introduction-to-profiles.html#Details_on_profile_activation -->
+				<jdk>[1.5,11)</jdk>
+			</activation>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-surefire-plugin</artifactId>
+						<version>2.22.0</version>
+						<configuration>
+							<excludes>
+								<exclude>**/java11/*Test.java</exclude>
+							</excludes>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
 	</profiles>
 
 	<repositories>

--- a/src/com/esotericsoftware/kryo/io/ByteBufferInputStream.java
+++ b/src/com/esotericsoftware/kryo/io/ByteBufferInputStream.java
@@ -21,6 +21,7 @@ package com.esotericsoftware.kryo.io;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 
 /** An InputStream whose source is a {@link ByteBuffer}.
@@ -35,7 +36,7 @@ public class ByteBufferInputStream extends InputStream {
 	/** Creates a stream with a new non-direct buffer of the specified size. The position and limit of the buffer is zero. */
 	public ByteBufferInputStream (int bufferSize) {
 		this(ByteBuffer.allocate(bufferSize));
-		byteBuffer.flip();
+		flipBuffer(byteBuffer);
 	}
 
 	public ByteBufferInputStream (ByteBuffer byteBuffer) {
@@ -66,4 +67,9 @@ public class ByteBufferInputStream extends InputStream {
 	public int available () throws IOException {
 		return byteBuffer.remaining();
 	}
+
+	private void flipBuffer (Buffer buffer) {
+		buffer.flip();
+	}
+
 }

--- a/src/com/esotericsoftware/kryo/io/ByteBufferOutput.java
+++ b/src/com/esotericsoftware/kryo/io/ByteBufferOutput.java
@@ -24,6 +24,7 @@ import com.esotericsoftware.kryo.util.Util;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 
@@ -116,8 +117,8 @@ public class ByteBufferOutput extends Output {
 	public void setBuffer (byte[] bytes, int offset, int count) {
 		ByteBuffer buffer = ByteBuffer.allocateDirect(bytes.length);
 		buffer.put(bytes, offset, count);
-		buffer.position(0);
-		buffer.limit(bytes.length);
+		setBufferPosition(buffer, 0);
+		setBufferLimit(buffer, bytes.length);
 		setBuffer(buffer);
 	}
 
@@ -150,19 +151,31 @@ public class ByteBufferOutput extends Output {
 
 	public byte[] toBytes () {
 		byte[] newBuffer = new byte[position];
-		byteBuffer.position(0);
+		setBufferPosition(byteBuffer, 0);
 		byteBuffer.get(newBuffer, 0, position);
 		return newBuffer;
 	}
 
 	public void setPosition (int position) {
 		this.position = position;
-		this.byteBuffer.position(position);
+		setBufferPosition(byteBuffer, position);
 	}
 
 	public void reset () {
 		super.reset();
-		byteBuffer.position(0);
+		setBufferPosition(byteBuffer, 0);
+	}
+
+	private int getBufferPosition(Buffer buffer) {
+		return buffer.position();
+	}
+
+	private void setBufferPosition(Buffer buffer, int newPosition) {
+		buffer.position(newPosition);
+	}
+
+	private void setBufferLimit(Buffer buffer, int length) {
+		buffer.limit(length);
 	}
 
 	protected boolean require (int required) throws KryoException {
@@ -179,8 +192,8 @@ public class ByteBufferOutput extends Output {
 			capacity = Math.min(capacity * 2, maxCapacity);
 		} while (capacity - position < required);
 		ByteBuffer newBuffer = !byteBuffer.isDirect() ? ByteBuffer.allocate(capacity) : ByteBuffer.allocateDirect(capacity);
-		byteBuffer.position(0);
-		byteBuffer.limit(position);
+		setBufferPosition(byteBuffer, 0);
+		setBufferLimit(byteBuffer, position);
 		newBuffer.put(byteBuffer);
 		newBuffer.order(byteBuffer.order());
 		byteBuffer = newBuffer;
@@ -193,9 +206,9 @@ public class ByteBufferOutput extends Output {
 		if (outputStream == null) return;
 		try {
 			byte[] tmp = new byte[position];
-			byteBuffer.position(0);
+			setBufferPosition(byteBuffer, 0);
 			byteBuffer.get(tmp);
-			byteBuffer.position(0);
+			setBufferPosition(byteBuffer, 0);
 			outputStream.write(tmp, 0, position);
 		} catch (IOException ex) {
 			throw new KryoException(ex);
@@ -574,11 +587,11 @@ public class ByteBufferOutput extends Output {
 				byteBuffer.put((byte)c);
 				charIndex++;
 				if (charIndex == charCount) {
-					position = byteBuffer.position();
+					position = getBufferPosition(byteBuffer);
 					return;
 				}
 			}
-			position = byteBuffer.position();
+			position = getBufferPosition(byteBuffer);
 		}
 		if (charIndex < charCount) writeUtf8_slow(value, charCount, charIndex);
 	}
@@ -654,7 +667,7 @@ public class ByteBufferOutput extends Output {
 				byteBuffer.put((byte)(value >> 16));
 				byteBuffer.put((byte)(value >> 24));
 			}
-			position = byteBuffer.position();
+			position = getBufferPosition(byteBuffer);
 		} else {
 			for (int n = offset + count; offset < n; offset++)
 				writeInt(array[offset]);
@@ -676,7 +689,7 @@ public class ByteBufferOutput extends Output {
 				byteBuffer.put((byte)(value >>> 48));
 				byteBuffer.put((byte)(value >>> 56));
 			}
-			position = byteBuffer.position();
+			position = getBufferPosition(byteBuffer);
 		} else {
 			for (int n = offset + count; offset < n; offset++)
 				writeLong(array[offset]);
@@ -694,7 +707,7 @@ public class ByteBufferOutput extends Output {
 				byteBuffer.put((byte)(value >> 16));
 				byteBuffer.put((byte)(value >> 24));
 			}
-			position = byteBuffer.position();
+			position = getBufferPosition(byteBuffer);
 		} else {
 			for (int n = offset + count; offset < n; offset++)
 				writeFloat(array[offset]);
@@ -716,7 +729,7 @@ public class ByteBufferOutput extends Output {
 				byteBuffer.put((byte)(value >>> 48));
 				byteBuffer.put((byte)(value >>> 56));
 			}
-			position = byteBuffer.position();
+			position = getBufferPosition(byteBuffer);
 		} else {
 			for (int n = offset + count; offset < n; offset++)
 				writeDouble(array[offset]);
@@ -731,7 +744,7 @@ public class ByteBufferOutput extends Output {
 				byteBuffer.put((byte)value);
 				byteBuffer.put((byte)(value >>> 8));
 			}
-			position = byteBuffer.position();
+			position = getBufferPosition(byteBuffer);
 		} else {
 			for (int n = offset + count; offset < n; offset++)
 				writeShort(array[offset]);
@@ -746,7 +759,7 @@ public class ByteBufferOutput extends Output {
 				byteBuffer.put((byte)value);
 				byteBuffer.put((byte)(value >>> 8));
 			}
-			position = byteBuffer.position();
+			position = getBufferPosition(byteBuffer);
 		} else {
 			for (int n = offset + count; offset < n; offset++)
 				writeChar(array[offset]);
@@ -758,7 +771,7 @@ public class ByteBufferOutput extends Output {
 			require(count);
 			for (int n = offset + count; offset < n; offset++)
 				byteBuffer.put(array[offset] ? (byte)1 : 0);
-			position = byteBuffer.position();
+			position = getBufferPosition(byteBuffer);
 		} else {
 			for (int n = offset + count; offset < n; offset++)
 				writeBoolean(array[offset]);

--- a/src/com/esotericsoftware/kryo/unsafe/UnsafeByteBufferInput.java
+++ b/src/com/esotericsoftware/kryo/unsafe/UnsafeByteBufferInput.java
@@ -26,6 +26,7 @@ import com.esotericsoftware.kryo.io.ByteBufferInput;
 import com.esotericsoftware.kryo.util.Util;
 
 import java.io.InputStream;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 
 import sun.nio.ch.DirectBuffer;
@@ -103,24 +104,28 @@ public class UnsafeByteBufferInput extends ByteBufferInput {
 		bufferAddress = ((DirectBuffer)byteBuffer).address();
 	}
 
+	private void setBufferPosition( Buffer buffer,  int position) {
+		buffer.position(position);
+	}
+
 	public int read () throws KryoException {
 		if (optional(1) <= 0) return -1;
 		int result = unsafe.getByte(bufferAddress + position++) & 0xFF;
-		byteBuffer.position(position);
+		setBufferPosition(byteBuffer, position);
 		return result;
 	}
 
 	public byte readByte () throws KryoException {
 		if (position == limit) require(1);
 		byte result = unsafe.getByte(bufferAddress + position++);
-		byteBuffer.position(position);
+		setBufferPosition(byteBuffer, position);
 		return result;
 	}
 
 	public int readByteUnsigned () throws KryoException {
 		if (position == limit) require(1);
 		int result = unsafe.getByte(bufferAddress + position++) & 0xFF;
-		byteBuffer.position(position);
+		setBufferPosition(byteBuffer, position);
 		return result;
 	}
 
@@ -128,7 +133,7 @@ public class UnsafeByteBufferInput extends ByteBufferInput {
 		require(4);
 		int result = unsafe.getInt(bufferAddress + position);
 		position += 4;
-		byteBuffer.position(position);
+		setBufferPosition(byteBuffer, position);
 		return result;
 	}
 
@@ -136,7 +141,7 @@ public class UnsafeByteBufferInput extends ByteBufferInput {
 		require(8);
 		long result = unsafe.getLong(bufferAddress + position);
 		position += 8;
-		byteBuffer.position(position);
+		setBufferPosition(byteBuffer, position);
 		return result;
 	}
 
@@ -144,7 +149,7 @@ public class UnsafeByteBufferInput extends ByteBufferInput {
 		require(4);
 		float result = unsafe.getFloat(bufferAddress + position);
 		position += 4;
-		byteBuffer.position(position);
+		setBufferPosition(byteBuffer, position);
 		return result;
 	}
 
@@ -152,7 +157,7 @@ public class UnsafeByteBufferInput extends ByteBufferInput {
 		require(8);
 		double result = unsafe.getDouble(bufferAddress + position);
 		position += 8;
-		byteBuffer.position(position);
+		setBufferPosition(byteBuffer, position);
 		return result;
 	}
 
@@ -160,7 +165,7 @@ public class UnsafeByteBufferInput extends ByteBufferInput {
 		require(2);
 		short result = unsafe.getShort(bufferAddress + position);
 		position += 2;
-		byteBuffer.position(position);
+		setBufferPosition(byteBuffer, position);
 		return result;
 	}
 
@@ -168,14 +173,14 @@ public class UnsafeByteBufferInput extends ByteBufferInput {
 		require(2);
 		char result = unsafe.getChar(bufferAddress + position);
 		position += 2;
-		byteBuffer.position(position);
+		setBufferPosition(byteBuffer, position);
 		return result;
 	}
 
 	public boolean readBoolean () throws KryoException {
 		if (position == limit) require(1);
 		boolean result = unsafe.getByte(bufferAddress + position++) != 0;
-		byteBuffer.position(position);
+		setBufferPosition(byteBuffer, position);
 		return result;
 	}
 
@@ -237,6 +242,7 @@ public class UnsafeByteBufferInput extends ByteBufferInput {
 			copyCount = Math.min(count, capacity);
 			require(copyCount);
 		}
-		byteBuffer.position(position);
+		setBufferPosition(byteBuffer, position);
 	}
+
 }

--- a/src/com/esotericsoftware/kryo/unsafe/UnsafeByteBufferOutput.java
+++ b/src/com/esotericsoftware/kryo/unsafe/UnsafeByteBufferOutput.java
@@ -26,6 +26,7 @@ import com.esotericsoftware.kryo.io.ByteBufferOutput;
 import com.esotericsoftware.kryo.util.Util;
 
 import java.io.OutputStream;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 
 import sun.nio.ch.DirectBuffer;
@@ -113,70 +114,74 @@ public class UnsafeByteBufferOutput extends ByteBufferOutput {
 		bufferAddress = 0;
 	}
 
+	private void setBufferPosition (Buffer buffer, int position) {
+		buffer.position(position);
+	}
+
 	public void write (int value) throws KryoException {
 		if (position == capacity) require(1);
 		unsafe.putByte(bufferAddress + position++, (byte)value);
-		byteBuffer.position(position);
+		setBufferPosition(byteBuffer, position);
 	}
 
 	public void writeByte (byte value) throws KryoException {
 		if (position == capacity) require(1);
 		unsafe.putByte(bufferAddress + position++, value);
-		byteBuffer.position(position);
+		setBufferPosition(byteBuffer, position);
 	}
 
 	public void writeByte (int value) throws KryoException {
 		if (position == capacity) require(1);
 		unsafe.putByte(bufferAddress + position++, (byte)value);
-		byteBuffer.position(position);
+		setBufferPosition(byteBuffer, position);
 	}
 
 	public void writeInt (int value) throws KryoException {
 		require(4);
 		unsafe.putInt(bufferAddress + position, value);
 		position += 4;
-		byteBuffer.position(position);
+		setBufferPosition(byteBuffer, position);
 	}
 
 	public void writeLong (long value) throws KryoException {
 		require(8);
 		unsafe.putLong(bufferAddress + position, value);
 		position += 8;
-		byteBuffer.position(position);
+		setBufferPosition(byteBuffer, position);
 	}
 
 	public void writeFloat (float value) throws KryoException {
 		require(4);
 		unsafe.putFloat(bufferAddress + position, value);
 		position += 4;
-		byteBuffer.position(position);
+		setBufferPosition(byteBuffer, position);
 	}
 
 	public void writeDouble (double value) throws KryoException {
 		require(8);
 		unsafe.putDouble(bufferAddress + position, value);
 		position += 8;
-		byteBuffer.position(position);
+		setBufferPosition(byteBuffer, position);
 	}
 
 	public void writeShort (int value) throws KryoException {
 		require(2);
 		unsafe.putShort(bufferAddress + position, (short)value);
 		position += 2;
-		byteBuffer.position(position);
+		setBufferPosition(byteBuffer, position);
 	}
 
 	public void writeChar (char value) throws KryoException {
 		require(2);
 		unsafe.putChar(bufferAddress + position, value);
 		position += 2;
-		byteBuffer.position(position);
+		setBufferPosition(byteBuffer, position);
 	}
 
 	public void writeBoolean (boolean value) throws KryoException {
 		if (position == capacity) require(1);
 		unsafe.putByte(bufferAddress + position++, value ? (byte)1 : 0);
-		byteBuffer.position(position);
+		setBufferPosition(byteBuffer, position);
 	}
 
 	public void writeInts (int[] array, int offset, int count) throws KryoException {
@@ -223,6 +228,6 @@ public class UnsafeByteBufferOutput extends ByteBufferOutput {
 			copyCount = Math.min(capacity, count);
 			require(copyCount);
 		}
-		byteBuffer.position(position);
+		setBufferPosition(byteBuffer, position);
 	}
 }

--- a/test/com/esotericsoftware/kryo/KryoTestCase.java
+++ b/test/com/esotericsoftware/kryo/KryoTestCase.java
@@ -36,6 +36,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.lang.reflect.Array;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 
@@ -116,8 +117,7 @@ abstract public class KryoTestCase {
 			}
 
 			public Input createInput (byte[] buffer) {
-				ByteBuffer byteBuffer = ByteBuffer.allocateDirect(buffer.length);
-				byteBuffer.put(buffer).flip();
+				ByteBuffer byteBuffer = allocateByteBuffer(buffer);
 				return new ByteBufferInput(byteBuffer);
 			}
 		});
@@ -162,13 +162,19 @@ abstract public class KryoTestCase {
 			}
 
 			public Input createInput (byte[] buffer) {
-				ByteBuffer byteBuffer = ByteBuffer.allocateDirect(buffer.length);
-				byteBuffer.put(buffer).flip();
+				ByteBuffer byteBuffer = allocateByteBuffer(buffer);
 				return new UnsafeByteBufferInput(byteBuffer);
 			}
 		});
 
 		return object2;
+	}
+
+	private ByteBuffer allocateByteBuffer(byte[] buffer) {
+		ByteBuffer byteBuffer = ByteBuffer.allocateDirect(buffer.length);
+		byteBuffer.put(buffer);
+		((Buffer) byteBuffer).flip();
+		return byteBuffer;
 	}
 
 	/** @param length Pass Integer.MIN_VALUE to disable checking the length. */

--- a/test/com/esotericsoftware/kryo/io/ByteBufferInputOutputTest.java
+++ b/test/com/esotericsoftware/kryo/io/ByteBufferInputOutputTest.java
@@ -24,6 +24,7 @@ import static org.junit.Assert.*;
 import com.esotericsoftware.kryo.KryoTestCase;
 
 import java.io.ByteArrayInputStream;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 
 import org.junit.Test;
@@ -78,7 +79,7 @@ public class ByteBufferInputOutputTest extends KryoTestCase {
 		outputBuffer.writeInt(10);
 
 		ByteBuffer byteBuffer = outputBuffer.getByteBuffer().duplicate();
-		byteBuffer.flip();
+		((Buffer) byteBuffer).flip();
 
 		ByteBufferInput inputBuffer = new ByteBufferInput(byteBuffer);
 		inputBuffer.skip(5);

--- a/test/com/esotericsoftware/kryo/io/InputOutputTest.java
+++ b/test/com/esotericsoftware/kryo/io/InputOutputTest.java
@@ -31,6 +31,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.util.Random;
 
@@ -896,7 +897,7 @@ public class InputOutputTest extends KryoTestCase {
 		testOutput.flush();
 
 		ByteBufferInputStream testInputs = new ByteBufferInputStream();
-		buf.flip();
+		((Buffer) buf).flip();
 		testInputs.setByteBuffer(buf);
 		Input input = new Input(testInputs, 512);
 		byte[] toRead = new byte[512];

--- a/test/com/esotericsoftware/kryo/serializers/GenericsTest.java
+++ b/test/com/esotericsoftware/kryo/serializers/GenericsTest.java
@@ -30,6 +30,7 @@ import java.util.*;
 import java.util.function.Supplier;
 
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 public class GenericsTest extends KryoTestCase {


### PR DESCRIPTION
This PR adds support for building with JDK11 while still being able to run tests with JDK8.

This enables Kryo to support JDK9+ classes like `java.util.ImmutableCollections` while still targeting JDK8 environments.

The same approach was taken to support JDK8 classes such as `Optional` (#362). 

This time things are a little more complicated though. JDK9 introduced new covariant return types for some methods on `ByteBuffer`, making the code backwards incompatible (see https://github.com/EsotericSoftware/kryo/issues/693#issuecomment-630096985).

The only way around this issue that does not require additional artifacts for newer JDK versions is to use implicit or explicit casts for these methods. This PR adds these casts. It doesn't look great and is brittle (we have to rely on CI builds to catch accidental new usages of incompatible methods). But it still might make sense to go down this road to support newer JDK classes with minimal effort.

