### PR TITLE
#683 Add .importorder file for Eclipse

### DIFF
--- a/eclipse/.importorder
+++ b/eclipse/.importorder
@@ -1,0 +1,8 @@
+# Organize Import Order
+# Import this file in Window -> Preferences -> Java -> Code Style -> Organize Imports -> Import...
+0=\#
+1=com.esotericsoftware
+2=java
+3=javax
+4=org
+5=

--- a/test/com/esotericsoftware/kryo/ReferenceTest.java
+++ b/test/com/esotericsoftware/kryo/ReferenceTest.java
@@ -27,7 +27,6 @@ import com.esotericsoftware.kryo.serializers.MapSerializer;
 
 import java.lang.reflect.Field;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.TreeMap;
 

--- a/test/com/esotericsoftware/kryo/io/UnsafeByteBufferInputOutputTest.java
+++ b/test/com/esotericsoftware/kryo/io/UnsafeByteBufferInputOutputTest.java
@@ -28,7 +28,6 @@ import com.esotericsoftware.kryo.unsafe.UnsafeUtil;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.nio.ByteBuffer;
 import java.util.Random;
 
 import org.junit.Test;

--- a/test/com/esotericsoftware/kryo/serializers/ArraySerializerTest.java
+++ b/test/com/esotericsoftware/kryo/serializers/ArraySerializerTest.java
@@ -24,8 +24,6 @@ import static org.junit.Assert.*;
 import com.esotericsoftware.kryo.KryoTestCase;
 import com.esotericsoftware.kryo.serializers.DefaultArraySerializers.ObjectArraySerializer;
 
-import java.util.BitSet;
-
 import org.junit.Test;
 
 /** @author Nathan Sweet */

--- a/test/com/esotericsoftware/kryo/serializers/GenericsTest.java
+++ b/test/com/esotericsoftware/kryo/serializers/GenericsTest.java
@@ -26,7 +26,14 @@ import com.esotericsoftware.kryo.serializers.GenericsTest.A.DontPassToSuper;
 import com.esotericsoftware.kryo.serializers.GenericsTest.ClassWithMap.MapKey;
 
 import java.io.Serializable;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 import java.util.function.Supplier;
 
 import org.junit.Before;


### PR DESCRIPTION
This PR:

- Adds an `.importorder` file for Eclipse to make it easier for contributors to follow the project's code style.
- Applies the import order to all project files 
(4 files were changed. 1 was not following project style and 3 contained unused imports)