### PR TITLE
#693 Align `travis.yml` with default Travis behavior

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,12 +17,14 @@ env:
 jdk:
   - openjdk11
 
+install:
+  # build with java 11
+  - mvn install -DskipTests=true -B -V
+
 script:
-  # compile tests with java 11
-  # separate "clean" from "install" because "clean install" would fail the pom-versioned module
-  - mvn clean
-  - mvn -B install
-  # test java 8
+  # run tests with java 11
+  - mvn test -B
+  # run tests with java 8
   - jdk_switcher use openjdk8
   - mvn -v && mvn -B test
   # install and publish snapshot with java 8


### PR DESCRIPTION
This PR uses the same approach as the [default Travis build](https://docs.travis-ci.com/user/languages/java/#projects-using-maven) for Maven projects:

- The `install` phase runs `mvn install`
- The `script` phase runs `mvn test`

The only difference is that I dropped `-Dmaven.javadoc.skip=true` from the `install` phase so JavaDocs are still generated.