### PR TITLE
#693 Ensure copied map is immutable

### DIFF
--- a/src/com/esotericsoftware/kryo/serializers/ImmutableCollectionsSerializers.java
+++ b/src/com/esotericsoftware/kryo/serializers/ImmutableCollectionsSerializers.java
@@ -104,7 +104,7 @@ public final class ImmutableCollectionsSerializers {
 			for (Map.Entry<Object, Object> entry : original.entrySet()) {
 				copy.put(kryo.copy(entry.getKey()), kryo.copy(entry.getValue()));
 			}
-			return copy;
+			return Map.copyOf(copy);
 		}
 
 		static void addDefaultSerializers (Kryo kryo) {


### PR DESCRIPTION
I missed this in #727. The returned map should be immutable as well.