### PR TITLE
#721 Only store type variables if all of them have type arguments

### DIFF
--- a/src/com/esotericsoftware/kryo/util/Generics.java
+++ b/src/com/esotericsoftware/kryo/util/Generics.java
@@ -117,6 +117,9 @@ public class Generics {
 	 * @param args May contain null for type arguments that aren't known.
 	 * @return The number of entries that were pushed. */
 	public int pushTypeVariables (GenericsHierarchy hierarchy, GenericType[] args) {
+		// Do not store type variables if we do not have arguments for all of them
+		if (args.length < hierarchy.rootTotal) return 0;
+
 		int startSize = this.argumentsSize;
 
 		// Ensure arguments capacity.
@@ -180,7 +183,10 @@ public class Generics {
 	/** Stores the type parameters for a class and, for parameters passed to super classes, the corresponding super class type
 	 * parameters. */
 	static public class GenericsHierarchy {
+		/* total number of type parameters in the hierarchy */
 		final int total;
+		/* total number of type parameters at the root of the hierarchy */
+		final int rootTotal;
 		final int[] counts;
 		final TypeVariable[] parameters;
 
@@ -222,6 +228,7 @@ public class Generics {
 			} while (current != null);
 
 			this.total = total;
+			this.rootTotal = type.getTypeParameters().length;
 			this.counts = counts.toArray();
 			this.parameters = parameters.toArray(new TypeVariable[parameters.size()]);
 		}


### PR DESCRIPTION
This PR resolves #721. It does not store generic type parameters if there aren't as many arguments as type parameters at the root of the generics hierarchy.

This is the cleanest solution I could think of and the previously failing test-case for #721 is the only test affected by the new condition. However, it is only a workaround. It might actually be possible to match the argument to the correct type parameter, but given that this is a rare corner case, I think we can live with not optimizing generics.