### PR TITLE
Consolidate generics hierarchy checks

### DIFF
--- a/src/com/esotericsoftware/kryo/serializers/FieldSerializer.java
+++ b/src/com/esotericsoftware/kryo/serializers/FieldSerializer.java
@@ -129,10 +129,6 @@ public class FieldSerializer<T> extends Serializer<T> {
 	/** Prepares the type variables for the serialized type. Must be balanced with {@link #popTypeVariables(int)} if >0 is
 	 * returned. */
 	protected int pushTypeVariables () {
-		if (genericsHierarchy.isEmpty()) {
-			return 0;
-		}
-
 		GenericType[] genericTypes = kryo.getGenerics().nextGenericTypes();
 		if (genericTypes == null) return 0;
 

--- a/src/com/esotericsoftware/kryo/util/DefaultGenerics.java
+++ b/src/com/esotericsoftware/kryo/util/DefaultGenerics.java
@@ -93,8 +93,10 @@ public final class DefaultGenerics implements Generics {
 
 	@Override
 	public int pushTypeVariables(GenericsHierarchy hierarchy, GenericType[] args) {
-		// Do not store type variables if we do not have arguments for all of them
-		if (args.length < hierarchy.rootTotal) return 0;
+		// Do not store type variables if hierarchy is empty or we do not have arguments for all root parameters
+		if (hierarchy.total == 0 || hierarchy.rootTotal > args.length) {
+			return 0;
+		}
 
 		int startSize = this.argumentsSize;
 

--- a/src/com/esotericsoftware/kryo/util/Generics.java
+++ b/src/com/esotericsoftware/kryo/util/Generics.java
@@ -146,10 +146,6 @@ public interface Generics {
 			buffer.append("]");
 			return buffer.toString();
 		}
-
-		public boolean isEmpty () {
-			return total == 0;
-		}
 	}
 
 	/** Stores a type and its type parameters, recursively. */


### PR DESCRIPTION
This PR moves the check in `FieldSerializer` introduced in #654 into `DefaultGenerics` so all hierarchy verification is done in that class.

This is purely a cleanup PR and should not change any behavior.

@magro: Please take a look.