### PR TITLE
Add missing `@Override` annotations

### DIFF
--- a/src/com/esotericsoftware/kryo/Kryo.java
+++ b/src/com/esotericsoftware/kryo/Kryo.java
@@ -875,6 +875,7 @@ public class Kryo implements Poolable {
 	 * {@link #getOriginalToCopyMap() original to copy map}, and the {@link #getGraphContext() graph context}. If
 	 * {@link #setAutoReset(boolean) auto reset} is true, this method is called automatically when an object graph has been
 	 * completely serialized or deserialized. If overridden, the super method must be called. */
+	@Override
 	public void reset () {
 		depth = 0;
 		if (graphContext != null) graphContext.clear(2048);

--- a/src/com/esotericsoftware/kryo/KryoException.java
+++ b/src/com/esotericsoftware/kryo/KryoException.java
@@ -40,6 +40,7 @@ public class KryoException extends RuntimeException {
 		super(cause);
 	}
 
+	@Override
 	public String getMessage () {
 		if (trace == null) return super.getMessage();
 		StringBuffer buffer = new StringBuffer(512);

--- a/src/com/esotericsoftware/kryo/SerializerFactory.java
+++ b/src/com/esotericsoftware/kryo/SerializerFactory.java
@@ -43,6 +43,7 @@ public interface SerializerFactory<T extends Serializer> {
 
 	/** A serializer factory which always returns true for {@link #isSupported(Class)}. */
 	static public abstract class BaseSerializerFactory<T extends Serializer> implements SerializerFactory<T> {
+		@Override
 		public boolean isSupported (Class type) {
 			return true;
 		}
@@ -60,6 +61,7 @@ public interface SerializerFactory<T extends Serializer> {
 			this.serializerClass = serializerClass;
 		}
 
+		@Override
 		public T newSerializer (Kryo kryo, Class type) {
 			return newSerializer(kryo, serializerClass, type);
 		}
@@ -98,6 +100,7 @@ public interface SerializerFactory<T extends Serializer> {
 			this.serializer = serializer;
 		}
 
+		@Override
 		public T newSerializer (Kryo kryo, Class type) {
 			return serializer;
 		}
@@ -120,6 +123,7 @@ public interface SerializerFactory<T extends Serializer> {
 			return config;
 		}
 
+		@Override
 		public FieldSerializer newSerializer (Kryo kryo, Class type) {
 			return new FieldSerializer(kryo, type, config.clone());
 		}
@@ -142,6 +146,7 @@ public interface SerializerFactory<T extends Serializer> {
 			return config;
 		}
 
+		@Override
 		public TaggedFieldSerializer newSerializer (Kryo kryo, Class type) {
 			return new TaggedFieldSerializer(kryo, type, config.clone());
 		}
@@ -164,6 +169,7 @@ public interface SerializerFactory<T extends Serializer> {
 			return config;
 		}
 
+		@Override
 		public VersionFieldSerializer newSerializer (Kryo kryo, Class type) {
 			return new VersionFieldSerializer(kryo, type, config.clone());
 		}
@@ -186,6 +192,7 @@ public interface SerializerFactory<T extends Serializer> {
 			return config;
 		}
 
+		@Override
 		public CompatibleFieldSerializer newSerializer (Kryo kryo, Class type) {
 			return new CompatibleFieldSerializer(kryo, type, config.clone());
 		}

--- a/src/com/esotericsoftware/kryo/io/ByteBufferInput.java
+++ b/src/com/esotericsoftware/kryo/io/ByteBufferInput.java
@@ -89,6 +89,7 @@ public class ByteBufferInput extends Input {
 	/** Throws {@link UnsupportedOperationException} because this input uses a ByteBuffer, not a byte[].
 	 * @deprecated
 	 * @see #getByteBuffer() */
+	@Override
 	public byte[] getBuffer () {
 		throw new UnsupportedOperationException("This input does not used a byte[], see #getByteBuffer().");
 	}
@@ -96,6 +97,7 @@ public class ByteBufferInput extends Input {
 	/** Throws {@link UnsupportedOperationException} because this input uses a ByteBuffer, not a byte[].
 	 * @deprecated
 	 * @see #setBuffer(ByteBuffer) */
+	@Override
 	public void setBuffer (byte[] bytes) {
 		throw new UnsupportedOperationException("This input does not used a byte[], see #setByteBuffer(ByteBuffer).");
 	}
@@ -103,6 +105,7 @@ public class ByteBufferInput extends Input {
 	/** Throws {@link UnsupportedOperationException} because this input uses a ByteBuffer, not a byte[].
 	 * @deprecated
 	 * @see #setBuffer(ByteBuffer) */
+	@Override
 	public void setBuffer (byte[] bytes, int offset, int count) {
 		throw new UnsupportedOperationException("This input does not used a byte[], see #setByteBufferByteBuffer().");
 	}
@@ -124,12 +127,14 @@ public class ByteBufferInput extends Input {
 		return byteBuffer;
 	}
 
+	@Override
 	public void setInputStream (InputStream inputStream) {
 		this.inputStream = inputStream;
 		limit = 0;
 		reset();
 	}
 
+	@Override
 	public void reset () {
 		super.reset();
 		setBufferPosition(byteBuffer, 0);
@@ -159,6 +164,7 @@ public class ByteBufferInput extends Input {
 		}
 	}
 
+	@Override
 	protected int require (int required) throws KryoException {
 		int remaining = limit - position;
 		if (remaining >= required) return remaining;
@@ -202,6 +208,7 @@ public class ByteBufferInput extends Input {
 	 * @param optional Must be > 0.
 	 * @return the number of bytes remaining, but not more than optional, or -1 if {@link #fill(ByteBuffer, int, int)} is unable to
 	 *         provide more bytes. */
+	@Override
 	protected int optional (int optional) throws KryoException {
 		int remaining = limit - position;
 		if (remaining >= optional) return optional;
@@ -236,16 +243,19 @@ public class ByteBufferInput extends Input {
 
 	// InputStream:
 
+	@Override
 	public int read () throws KryoException {
 		if (optional(1) <= 0) return -1;
 		position++;
 		return byteBuffer.get() & 0xFF;
 	}
 
+	@Override
 	public int read (byte[] bytes) throws KryoException {
 		return read(bytes, 0, bytes.length);
 	}
 
+	@Override
 	public int read (byte[] bytes, int offset, int count) throws KryoException {
 		if (bytes == null) throw new IllegalArgumentException("bytes cannot be null.");
 		int startingCount = count;
@@ -267,21 +277,25 @@ public class ByteBufferInput extends Input {
 		return startingCount - count;
 	}
 
+	@Override
 	public void setPosition (int position) {
 		this.position = position;
 		setBufferPosition(byteBuffer, position);
 	}
 
+	@Override
 	public void setLimit (int limit) {
 		this.limit = limit;
 		setBufferLimit(byteBuffer, limit);
 	}
 
+	@Override
 	public void skip (int count) throws KryoException {
 		super.skip(count);
 		setBufferPosition(byteBuffer, position);
 	}
 
+	@Override
 	public long skip (long count) throws KryoException {
 		long remaining = count;
 		while (remaining > 0) {
@@ -292,6 +306,7 @@ public class ByteBufferInput extends Input {
 		return count;
 	}
 
+	@Override
 	public void close () throws KryoException {
 		if (inputStream != null) {
 			try {
@@ -319,24 +334,28 @@ public class ByteBufferInput extends Input {
 
 	// byte:
 
+	@Override
 	public byte readByte () throws KryoException {
 		if (position == limit) require(1);
 		position++;
 		return byteBuffer.get();
 	}
 
+	@Override
 	public int readByteUnsigned () throws KryoException {
 		if (position == limit) require(1);
 		position++;
 		return byteBuffer.get() & 0xFF;
 	}
 
+	@Override
 	public byte[] readBytes (int length) throws KryoException {
 		byte[] bytes = new byte[length];
 		readBytes(bytes, 0, length);
 		return bytes;
 	}
 
+	@Override
 	public void readBytes (byte[] bytes, int offset, int count) throws KryoException {
 		if (bytes == null) throw new IllegalArgumentException("bytes cannot be null.");
 		int copyCount = Math.min(limit - position, count);
@@ -353,6 +372,7 @@ public class ByteBufferInput extends Input {
 
 	// int:
 
+	@Override
 	public int readInt () throws KryoException {
 		require(4);
 		position += 4;
@@ -363,6 +383,7 @@ public class ByteBufferInput extends Input {
 			| (byteBuffer.get() & 0xFF) << 24;
 	}
 
+	@Override
 	public int readVarInt (boolean optimizePositive) throws KryoException {
 		if (require(1) < 5) return readVarInt_slow(optimizePositive);
 		int b = byteBuffer.get();
@@ -421,6 +442,7 @@ public class ByteBufferInput extends Input {
 		return optimizePositive ? result : ((result >>> 1) ^ -(result & 1));
 	}
 
+	@Override
 	public boolean canReadVarInt () throws KryoException {
 		if (limit - position >= 5) return true;
 		if (optional(5) <= 0) return false;
@@ -439,6 +461,7 @@ public class ByteBufferInput extends Input {
 
 	/** Reads the boolean part of a varint flag. The position is not advanced, {@link #readVarIntFlag(boolean)} should be used to
 	 * advance the position. */
+	@Override
 	public boolean readVarIntFlag () {
 		if (position == limit) require(1);
 		return (byteBuffer.get(position) & 0x80) != 0;
@@ -446,6 +469,7 @@ public class ByteBufferInput extends Input {
 
 	/** Reads the 1-5 byte int part of a varint flag. The position is advanced so if the boolean part is needed it should be read
 	 * first with {@link #readVarIntFlag()}. */
+	@Override
 	public int readVarIntFlag (boolean optimizePositive) {
 		if (require(1) < 5) return readVarIntFlag_slow(optimizePositive);
 		int b = byteBuffer.get();
@@ -506,6 +530,7 @@ public class ByteBufferInput extends Input {
 
 	// long:
 
+	@Override
 	public long readLong () throws KryoException {
 		require(8);
 		position += 8;
@@ -520,6 +545,7 @@ public class ByteBufferInput extends Input {
 			| (long)byteBuffer.get() << 56;
 	}
 
+	@Override
 	public long readVarLong (boolean optimizePositive) throws KryoException {
 		if (require(1) < 9) return readVarLong_slow(optimizePositive);
 		int b = byteBuffer.get();
@@ -618,6 +644,7 @@ public class ByteBufferInput extends Input {
 		return optimizePositive ? result : ((result >>> 1) ^ -(result & 1));
 	}
 
+	@Override
 	public boolean canReadVarLong () throws KryoException {
 		if (limit - position >= 9) return true;
 		if (optional(5) <= 0) return false;
@@ -644,6 +671,7 @@ public class ByteBufferInput extends Input {
 
 	// float:
 
+	@Override
 	public float readFloat () throws KryoException {
 		require(4);
 		ByteBuffer byteBuffer = this.byteBuffer;
@@ -657,6 +685,7 @@ public class ByteBufferInput extends Input {
 
 	// double:
 
+	@Override
 	public double readDouble () throws KryoException {
 		require(8);
 		ByteBuffer byteBuffer = this.byteBuffer;
@@ -674,6 +703,7 @@ public class ByteBufferInput extends Input {
 
 	// boolean:
 
+	@Override
 	public boolean readBoolean () throws KryoException {
 		if (position == limit) require(1);
 		position++;
@@ -682,12 +712,14 @@ public class ByteBufferInput extends Input {
 
 	// short:
 
+	@Override
 	public short readShort () throws KryoException {
 		require(2);
 		position += 2;
 		return (short)((byteBuffer.get() & 0xFF) | ((byteBuffer.get() & 0xFF) << 8));
 	}
 
+	@Override
 	public int readShortUnsigned () throws KryoException {
 		require(2);
 		position += 2;
@@ -696,6 +728,7 @@ public class ByteBufferInput extends Input {
 
 	// char:
 
+	@Override
 	public char readChar () throws KryoException {
 		require(2);
 		position += 2;
@@ -704,6 +737,7 @@ public class ByteBufferInput extends Input {
 
 	// String:
 
+	@Override
 	public String readString () {
 		if (!readVarIntFlag()) return readAsciiString(); // ASCII.
 		// Null, empty, or UTF8.
@@ -719,6 +753,7 @@ public class ByteBufferInput extends Input {
 		return new String(chars, 0, charCount);
 	}
 
+	@Override
 	public StringBuilder readStringBuilder () {
 		if (!readVarIntFlag()) return new StringBuilder(readAsciiString()); // ASCII.
 		// Null, empty, or UTF8.
@@ -832,6 +867,7 @@ public class ByteBufferInput extends Input {
 
 	// Primitive arrays:
 
+	@Override
 	public int[] readInts (int length) throws KryoException {
 		int[] array = new int[length];
 		if (optional(length << 2) == length << 2) {
@@ -850,6 +886,7 @@ public class ByteBufferInput extends Input {
 		return array;
 	}
 
+	@Override
 	public long[] readLongs (int length) throws KryoException {
 		long[] array = new long[length];
 		if (optional(length << 3) == length << 3) {
@@ -872,6 +909,7 @@ public class ByteBufferInput extends Input {
 		return array;
 	}
 
+	@Override
 	public float[] readFloats (int length) throws KryoException {
 		float[] array = new float[length];
 		if (optional(length << 2) == length << 2) {
@@ -890,6 +928,7 @@ public class ByteBufferInput extends Input {
 		return array;
 	}
 
+	@Override
 	public double[] readDoubles (int length) throws KryoException {
 		double[] array = new double[length];
 		if (optional(length << 3) == length << 3) {
@@ -912,6 +951,7 @@ public class ByteBufferInput extends Input {
 		return array;
 	}
 
+	@Override
 	public short[] readShorts (int length) throws KryoException {
 		short[] array = new short[length];
 		if (optional(length << 1) == length << 1) {
@@ -926,6 +966,7 @@ public class ByteBufferInput extends Input {
 		return array;
 	}
 
+	@Override
 	public char[] readChars (int length) throws KryoException {
 		char[] array = new char[length];
 		if (optional(length << 1) == length << 1) {
@@ -940,6 +981,7 @@ public class ByteBufferInput extends Input {
 		return array;
 	}
 
+	@Override
 	public boolean[] readBooleans (int length) throws KryoException {
 		boolean[] array = new boolean[length];
 		if (optional(length) == length) {

--- a/src/com/esotericsoftware/kryo/io/ByteBufferInputStream.java
+++ b/src/com/esotericsoftware/kryo/io/ByteBufferInputStream.java
@@ -51,11 +51,13 @@ public class ByteBufferInputStream extends InputStream {
 		this.byteBuffer = byteBuffer;
 	}
 
+	@Override
 	public int read () throws IOException {
 		if (!byteBuffer.hasRemaining()) return -1;
 		return byteBuffer.get() & 0xFF;
 	}
 
+	@Override
 	public int read (byte[] bytes, int offset, int length) throws IOException {
 		if (length == 0) return 0;
 		int count = Math.min(byteBuffer.remaining(), length);
@@ -64,6 +66,7 @@ public class ByteBufferInputStream extends InputStream {
 		return count;
 	}
 
+	@Override
 	public int available () throws IOException {
 		return byteBuffer.remaining();
 	}

--- a/src/com/esotericsoftware/kryo/io/ByteBufferOutput.java
+++ b/src/com/esotericsoftware/kryo/io/ByteBufferOutput.java
@@ -87,6 +87,7 @@ public class ByteBufferOutput extends Output {
 		this.outputStream = outputStream;
 	}
 
+	@Override
 	public OutputStream getOutputStream () {
 		return outputStream;
 	}
@@ -94,6 +95,7 @@ public class ByteBufferOutput extends Output {
 	/** Throws {@link UnsupportedOperationException} because this output uses a ByteBuffer, not a byte[].
 	 * @deprecated
 	 * @see #getByteBuffer() */
+	@Override
 	public byte[] getBuffer () {
 		throw new UnsupportedOperationException("This buffer does not used a byte[], see #getByteBuffer().");
 	}
@@ -101,6 +103,7 @@ public class ByteBufferOutput extends Output {
 	/** Throws {@link UnsupportedOperationException} because this output uses a ByteBuffer, not a byte[].
 	 * @deprecated
 	 * @see #getByteBuffer() */
+	@Override
 	public void setBuffer (byte[] buffer) {
 		throw new UnsupportedOperationException("This buffer does not used a byte[], see #setByteBuffer(ByteBuffer).");
 	}
@@ -108,6 +111,7 @@ public class ByteBufferOutput extends Output {
 	/** Throws {@link UnsupportedOperationException} because this output uses a ByteBuffer, not a byte[].
 	 * @deprecated
 	 * @see #getByteBuffer() */
+	@Override
 	public void setBuffer (byte[] buffer, int maxBufferSize) {
 		throw new UnsupportedOperationException("This buffer does not used a byte[], see #setByteBuffer(ByteBuffer).");
 	}
@@ -149,6 +153,7 @@ public class ByteBufferOutput extends Output {
 		return byteBuffer;
 	}
 
+	@Override
 	public byte[] toBytes () {
 		byte[] newBuffer = new byte[position];
 		setBufferPosition(byteBuffer, 0);
@@ -156,11 +161,13 @@ public class ByteBufferOutput extends Output {
 		return newBuffer;
 	}
 
+	@Override
 	public void setPosition (int position) {
 		this.position = position;
 		setBufferPosition(byteBuffer, position);
 	}
 
+	@Override
 	public void reset () {
 		super.reset();
 		setBufferPosition(byteBuffer, 0);
@@ -178,6 +185,7 @@ public class ByteBufferOutput extends Output {
 		buffer.limit(length);
 	}
 
+	@Override
 	protected boolean require (int required) throws KryoException {
 		if (capacity - position >= required) return false;
 		flush();
@@ -202,6 +210,7 @@ public class ByteBufferOutput extends Output {
 
 	// OutputStream:
 
+	@Override
 	public void flush () throws KryoException {
 		if (outputStream == null) return;
 		try {
@@ -217,6 +226,7 @@ public class ByteBufferOutput extends Output {
 		position = 0;
 	}
 
+	@Override
 	public void close () throws KryoException {
 		flush();
 		if (outputStream != null) {
@@ -227,40 +237,47 @@ public class ByteBufferOutput extends Output {
 		}
 	}
 
+	@Override
 	public void write (int value) throws KryoException {
 		if (position == capacity) require(1);
 		byteBuffer.put((byte)value);
 		position++;
 	}
 
+	@Override
 	public void write (byte[] bytes) throws KryoException {
 		if (bytes == null) throw new IllegalArgumentException("bytes cannot be null.");
 		writeBytes(bytes, 0, bytes.length);
 	}
 
+	@Override
 	public void write (byte[] bytes, int offset, int length) throws KryoException {
 		writeBytes(bytes, offset, length);
 	}
 
 	// byte:
 
+	@Override
 	public void writeByte (byte value) throws KryoException {
 		if (position == capacity) require(1);
 		byteBuffer.put(value);
 		position++;
 	}
 
+	@Override
 	public void writeByte (int value) throws KryoException {
 		if (position == capacity) require(1);
 		byteBuffer.put((byte)value);
 		position++;
 	}
 
+	@Override
 	public void writeBytes (byte[] bytes) throws KryoException {
 		if (bytes == null) throw new IllegalArgumentException("bytes cannot be null.");
 		writeBytes(bytes, 0, bytes.length);
 	}
 
+	@Override
 	public void writeBytes (byte[] bytes, int offset, int count) throws KryoException {
 		if (bytes == null) throw new IllegalArgumentException("bytes cannot be null.");
 		int copyCount = Math.min(capacity - position, count);
@@ -277,6 +294,7 @@ public class ByteBufferOutput extends Output {
 
 	// int:
 
+	@Override
 	public void writeInt (int value) throws KryoException {
 		require(4);
 		position += 4;
@@ -287,6 +305,7 @@ public class ByteBufferOutput extends Output {
 		byteBuffer.put((byte)(value >> 24));
 	}
 
+	@Override
 	public int writeVarInt (int value, boolean optimizePositive) throws KryoException {
 		if (!optimizePositive) value = (value << 1) ^ (value >> 31);
 		if (value >>> 7 == 0) {
@@ -332,6 +351,7 @@ public class ByteBufferOutput extends Output {
 		return 5;
 	}
 
+	@Override
 	public int writeVarIntFlag (boolean flag, int value, boolean optimizePositive) throws KryoException {
 		if (!optimizePositive) value = (value << 1) ^ (value >> 31);
 		int first = (value & 0x3F) | (flag ? 0x80 : 0); // Mask first 6 bits, bit 8 is the flag.
@@ -380,6 +400,7 @@ public class ByteBufferOutput extends Output {
 
 	// long:
 
+	@Override
 	public void writeLong (long value) throws KryoException {
 		require(8);
 		position += 8;
@@ -394,6 +415,7 @@ public class ByteBufferOutput extends Output {
 		byteBuffer.put((byte)(value >>> 56));
 	}
 
+	@Override
 	public int writeVarLong (long value, boolean optimizePositive) throws KryoException {
 		if (!optimizePositive) value = (value << 1) ^ (value >> 63);
 		if (value >>> 7 == 0) {
@@ -495,6 +517,7 @@ public class ByteBufferOutput extends Output {
 
 	// float:
 
+	@Override
 	public void writeFloat (float value) throws KryoException {
 		require(4);
 		ByteBuffer byteBuffer = this.byteBuffer;
@@ -508,6 +531,7 @@ public class ByteBufferOutput extends Output {
 
 	// double:
 
+	@Override
 	public void writeDouble (double value) throws KryoException {
 		require(8);
 		position += 8;
@@ -525,6 +549,7 @@ public class ByteBufferOutput extends Output {
 
 	// short:
 
+	@Override
 	public void writeShort (int value) throws KryoException {
 		require(2);
 		position += 2;
@@ -534,6 +559,7 @@ public class ByteBufferOutput extends Output {
 
 	// char:
 
+	@Override
 	public void writeChar (char value) throws KryoException {
 		require(2);
 		position += 2;
@@ -543,6 +569,7 @@ public class ByteBufferOutput extends Output {
 
 	// boolean:
 
+	@Override
 	public void writeBoolean (boolean value) throws KryoException {
 		if (position == capacity) require(1);
 		byteBuffer.put((byte)(value ? 1 : 0));
@@ -551,6 +578,7 @@ public class ByteBufferOutput extends Output {
 
 	// String:
 
+	@Override
 	public void writeString (String value) throws KryoException {
 		if (value == null) {
 			writeByte(0x80); // 0 means null, bit 8 means UTF8.
@@ -596,6 +624,7 @@ public class ByteBufferOutput extends Output {
 		if (charIndex < charCount) writeUtf8_slow(value, charCount, charIndex);
 	}
 
+	@Override
 	public void writeAscii (String value) throws KryoException {
 		if (value == null) {
 			writeByte(0x80); // 0 means null, bit 8 means UTF8.
@@ -656,6 +685,7 @@ public class ByteBufferOutput extends Output {
 
 	// Primitive arrays:
 
+	@Override
 	public void writeInts (int[] array, int offset, int count) throws KryoException {
 		if (capacity >= count << 2) {
 			require(count << 2);
@@ -674,6 +704,7 @@ public class ByteBufferOutput extends Output {
 		}
 	}
 
+	@Override
 	public void writeLongs (long[] array, int offset, int count) throws KryoException {
 		if (capacity >= count << 3) {
 			require(count << 3);
@@ -696,6 +727,7 @@ public class ByteBufferOutput extends Output {
 		}
 	}
 
+	@Override
 	public void writeFloats (float[] array, int offset, int count) throws KryoException {
 		if (capacity >= count << 2) {
 			require(count << 2);
@@ -714,6 +746,7 @@ public class ByteBufferOutput extends Output {
 		}
 	}
 
+	@Override
 	public void writeDoubles (double[] array, int offset, int count) throws KryoException {
 		if (capacity >= count << 3) {
 			require(count << 3);
@@ -736,6 +769,7 @@ public class ByteBufferOutput extends Output {
 		}
 	}
 
+	@Override
 	public void writeShorts (short[] array, int offset, int count) throws KryoException {
 		if (capacity >= count << 1) {
 			require(count << 1);
@@ -751,6 +785,7 @@ public class ByteBufferOutput extends Output {
 		}
 	}
 
+	@Override
 	public void writeChars (char[] array, int offset, int count) throws KryoException {
 		if (capacity >= count << 1) {
 			require(count << 1);
@@ -766,6 +801,7 @@ public class ByteBufferOutput extends Output {
 		}
 	}
 
+	@Override
 	public void writeBooleans (boolean[] array, int offset, int count) throws KryoException {
 		if (capacity >= count) {
 			require(count);

--- a/src/com/esotericsoftware/kryo/io/ByteBufferOutputStream.java
+++ b/src/com/esotericsoftware/kryo/io/ByteBufferOutputStream.java
@@ -50,11 +50,13 @@ public class ByteBufferOutputStream extends OutputStream {
 		this.byteBuffer = byteBuffer;
 	}
 
+	@Override
 	public void write (int b) throws IOException {
 		if (!byteBuffer.hasRemaining()) flush();
 		byteBuffer.put((byte)b);
 	}
 
+	@Override
 	public void write (byte[] bytes, int offset, int length) throws IOException {
 		if (byteBuffer.remaining() < length) flush();
 		byteBuffer.put(bytes, offset, length);

--- a/src/com/esotericsoftware/kryo/io/Input.java
+++ b/src/com/esotericsoftware/kryo/io/Input.java
@@ -157,6 +157,7 @@ public class Input extends InputStream implements Poolable {
 	}
 
 	/** Sets the position and total to zero. */
+	@Override
 	@SuppressWarnings("sync-override")
 	public void reset () {
 		position = 0;
@@ -271,11 +272,13 @@ public class Input extends InputStream implements Poolable {
 
 	// InputStream:
 
+	@Override
 	public int available () throws IOException {
 		return limit - position + (inputStream != null ? inputStream.available() : 0);
 	}
 
 	/** Reads a single byte as an int from 0 to 255, or -1 if there are no more bytes are available. */
+	@Override
 	public int read () throws KryoException {
 		if (optional(1) <= 0) return -1;
 		return buffer[position++] & 0xFF;
@@ -283,12 +286,14 @@ public class Input extends InputStream implements Poolable {
 
 	/** Reads bytes.length bytes or less and writes them to the specified byte[], starting at 0, and returns the number of bytes
 	 * read. */
+	@Override
 	public int read (byte[] bytes) throws KryoException {
 		return read(bytes, 0, bytes.length);
 	}
 
 	/** Reads count bytes or less and writes them to the specified byte[], starting at offset, and returns the number of bytes read
 	 * or -1 if no more bytes are available. */
+	@Override
 	public int read (byte[] bytes, int offset, int count) throws KryoException {
 		if (bytes == null) throw new IllegalArgumentException("bytes cannot be null.");
 		int startingCount = count;
@@ -311,6 +316,7 @@ public class Input extends InputStream implements Poolable {
 	}
 
 	/** Discards the specified number of bytes. */
+	@Override
 	public long skip (long count) throws KryoException {
 		long remaining = count;
 		while (remaining > 0) {
@@ -322,6 +328,7 @@ public class Input extends InputStream implements Poolable {
 	}
 
 	/** Closes the underlying InputStream, if any. */
+	@Override
 	public void close () throws KryoException {
 		if (inputStream != null) {
 			try {

--- a/src/com/esotericsoftware/kryo/io/InputChunked.java
+++ b/src/com/esotericsoftware/kryo/io/InputChunked.java
@@ -51,21 +51,25 @@ public class InputChunked extends Input {
 		super(inputStream, bufferSize);
 	}
 
+	@Override
 	public void setInputStream (InputStream inputStream) {
 		super.setInputStream(inputStream);
 		chunkSize = -1;
 	}
 
+	@Override
 	public void setBuffer (byte[] bytes, int offset, int count) {
 		super.setBuffer(bytes, offset, count);
 		chunkSize = -1;
 	}
 
+	@Override
 	public void reset () {
 		super.reset();
 		chunkSize = -1;
 	}
 
+	@Override
 	protected int fill (byte[] buffer, int offset, int count) throws KryoException {
 		if (chunkSize == -1) { // No current chunk, expect a new chunk.
 			if (!readChunkSize()) return -1;

--- a/src/com/esotericsoftware/kryo/io/KryoDataInput.java
+++ b/src/com/esotericsoftware/kryo/io/KryoDataInput.java
@@ -39,10 +39,12 @@ public class KryoDataInput implements DataInput, AutoCloseable {
 		this.input = input;
 	}
 
+	@Override
 	public void readFully (byte[] b) throws IOException {
 		readFully(b, 0, b.length);
 	}
 
+	@Override
 	public void readFully (byte[] b, int off, int len) throws IOException {
 		try {
 			input.readBytes(b, off, len);
@@ -51,46 +53,57 @@ public class KryoDataInput implements DataInput, AutoCloseable {
 		}
 	}
 
+	@Override
 	public int skipBytes (int n) throws IOException {
 		return (int)input.skip((long)n);
 	}
 
+	@Override
 	public boolean readBoolean () throws IOException {
 		return input.readBoolean();
 	}
 
+	@Override
 	public byte readByte () throws IOException {
 		return input.readByte();
 	}
 
+	@Override
 	public int readUnsignedByte () throws IOException {
 		return input.readByteUnsigned();
 	}
 
+	@Override
 	public short readShort () throws IOException {
 		return input.readShort();
 	}
 
+	@Override
 	public int readUnsignedShort () throws IOException {
 		return input.readShortUnsigned();
 	}
 
+	@Override
 	public char readChar () throws IOException {
 		return input.readChar();
 	}
 
+	@Override
 	public int readInt () throws IOException {
 		return input.readInt();
 	}
 
+	@Override
 	public long readLong () throws IOException {
 		return input.readLong();
 	}
 
+	@Override
 	public float readFloat () throws IOException {
 		return input.readFloat();
 	}
 
+	@Override
 	public double readDouble () throws IOException {
 		return input.readDouble();
 	}
@@ -98,6 +111,7 @@ public class KryoDataInput implements DataInput, AutoCloseable {
 	/** Not implemented.
 	 * @throws UnsupportedOperationException when called.
 	 * @deprecated this method is not supported in this implementation. */
+	@Override
 	public String readLine () throws UnsupportedOperationException {
 		throw new UnsupportedOperationException();
 	}
@@ -106,10 +120,12 @@ public class KryoDataInput implements DataInput, AutoCloseable {
 	 * {@link KryoDataOutput#writeUTF(String)}, {@link com.esotericsoftware.kryo.io.Output#writeString(String)}, and
 	 * {@link com.esotericsoftware.kryo.io.Output#writeAscii(String)}.
 	 * @return May be null. */
+	@Override
 	public String readUTF () throws IOException {
 		return input.readString();
 	}
 
+	@Override
 	public void close () throws Exception {
 		input.close();
 	}

--- a/src/com/esotericsoftware/kryo/io/KryoDataOutput.java
+++ b/src/com/esotericsoftware/kryo/io/KryoDataOutput.java
@@ -35,50 +35,62 @@ public class KryoDataOutput implements DataOutput, AutoCloseable {
 		this.output = output;
 	}
 
+	@Override
 	public void write (int b) throws IOException {
 		output.write(b);
 	}
 
+	@Override
 	public void write (byte[] b) throws IOException {
 		output.write(b);
 	}
 
+	@Override
 	public void write (byte[] b, int off, int len) throws IOException {
 		output.write(b, off, len);
 	}
 
+	@Override
 	public void writeBoolean (boolean v) throws IOException {
 		output.writeBoolean(v);
 	}
 
+	@Override
 	public void writeByte (int v) throws IOException {
 		output.writeByte(v);
 	}
 
+	@Override
 	public void writeShort (int v) throws IOException {
 		output.writeShort(v);
 	}
 
+	@Override
 	public void writeChar (int v) throws IOException {
 		output.writeChar((char)v);
 	}
 
+	@Override
 	public void writeInt (int v) throws IOException {
 		output.writeInt(v);
 	}
 
+	@Override
 	public void writeLong (long v) throws IOException {
 		output.writeLong(v);
 	}
 
+	@Override
 	public void writeFloat (float v) throws IOException {
 		output.writeFloat(v);
 	}
 
+	@Override
 	public void writeDouble (double v) throws IOException {
 		output.writeDouble(v);
 	}
 
+	@Override
 	public void writeBytes (String s) throws IOException {
 		int len = s.length();
 		for (int i = 0; i < len; i++) {
@@ -86,6 +98,7 @@ public class KryoDataOutput implements DataOutput, AutoCloseable {
 		}
 	}
 
+	@Override
 	public void writeChars (String s) throws IOException {
 		int len = s.length();
 		for (int i = 0; i < len; i++) {
@@ -95,10 +108,12 @@ public class KryoDataOutput implements DataOutput, AutoCloseable {
 		}
 	}
 
+	@Override
 	public void writeUTF (String s) throws IOException {
 		output.writeString(s);
 	}
 
+	@Override
 	public void close () throws Exception {
 		output.close();
 	}

--- a/src/com/esotericsoftware/kryo/io/KryoObjectInput.java
+++ b/src/com/esotericsoftware/kryo/io/KryoObjectInput.java
@@ -37,30 +37,37 @@ public class KryoObjectInput extends KryoDataInput implements ObjectInput {
 		this.kryo = kryo;
 	}
 
+	@Override
 	public Object readObject () throws ClassNotFoundException, IOException {
 		return kryo.readClassAndObject(input);
 	}
 
+	@Override
 	public int read () throws IOException {
 		return input.read();
 	}
 
+	@Override
 	public int read (byte[] b) throws IOException {
 		return input.read(b);
 	}
 
+	@Override
 	public int read (byte[] b, int off, int len) throws IOException {
 		return input.read(b, off, len);
 	}
 
+	@Override
 	public long skip (long n) throws IOException {
 		return input.skip(n);
 	}
 
+	@Override
 	public int available () throws IOException {
 		return 0;
 	}
 
+	@Override
 	public void close () throws IOException {
 		input.close();
 	}

--- a/src/com/esotericsoftware/kryo/io/KryoObjectOutput.java
+++ b/src/com/esotericsoftware/kryo/io/KryoObjectOutput.java
@@ -38,14 +38,17 @@ public class KryoObjectOutput extends KryoDataOutput implements ObjectOutput {
 		this.kryo = kryo;
 	}
 
+	@Override
 	public void writeObject (Object object) throws IOException {
 		kryo.writeClassAndObject(output, object);
 	}
 
+	@Override
 	public void flush () throws IOException {
 		output.flush();
 	}
 
+	@Override
 	public void close () throws IOException {
 		output.close();
 	}

--- a/src/com/esotericsoftware/kryo/io/Output.java
+++ b/src/com/esotericsoftware/kryo/io/Output.java
@@ -169,6 +169,7 @@ public class Output extends OutputStream implements AutoCloseable, Poolable {
 	}
 
 	/** Sets the position and total to 0. */
+	@Override
 	public void reset () {
 		position = 0;
 		total = 0;
@@ -199,6 +200,7 @@ public class Output extends OutputStream implements AutoCloseable, Poolable {
 
 	/** Flushes the buffered bytes. The default implementation writes the buffered bytes to the {@link #getOutputStream()
 	 * OutputStream}, if any, and sets the position to 0. Can be overridden to flush the bytes somewhere else. */
+	@Override
 	public void flush () throws KryoException {
 		if (outputStream == null) return;
 		try {
@@ -212,6 +214,7 @@ public class Output extends OutputStream implements AutoCloseable, Poolable {
 	}
 
 	/** Flushes any buffered bytes and closes the underlying OutputStream, if any. */
+	@Override
 	public void close () throws KryoException {
 		flush();
 		if (outputStream != null) {
@@ -223,18 +226,21 @@ public class Output extends OutputStream implements AutoCloseable, Poolable {
 	}
 
 	/** Writes a byte. */
+	@Override
 	public void write (int value) throws KryoException {
 		if (position == capacity) require(1);
 		buffer[position++] = (byte)value;
 	}
 
 	/** Writes the bytes. Note the number of bytes is not written. */
+	@Override
 	public void write (byte[] bytes) throws KryoException {
 		if (bytes == null) throw new IllegalArgumentException("bytes cannot be null.");
 		writeBytes(bytes, 0, bytes.length);
 	}
 
 	/** Writes the bytes. Note the number of bytes is not written. */
+	@Override
 	public void write (byte[] bytes, int offset, int length) throws KryoException {
 		writeBytes(bytes, offset, length);
 	}

--- a/src/com/esotericsoftware/kryo/io/OutputChunked.java
+++ b/src/com/esotericsoftware/kryo/io/OutputChunked.java
@@ -50,6 +50,7 @@ public class OutputChunked extends Output {
 		super(outputStream, bufferSize);
 	}
 
+	@Override
 	public void flush () throws KryoException {
 		if (position() > 0) {
 			try {

--- a/src/com/esotericsoftware/kryo/serializers/AsmField.java
+++ b/src/com/esotericsoftware/kryo/serializers/AsmField.java
@@ -35,14 +35,17 @@ class AsmField extends ReflectField {
 		super(field, serializer, genericType);
 	}
 
+	@Override
 	public Object get (Object object) throws IllegalAccessException {
 		return access.get(object, accessIndex);
 	}
 
+	@Override
 	public void set (Object object, Object value) throws IllegalAccessException {
 		access.set(object, accessIndex, value);
 	}
 
+	@Override
 	public void copy (Object original, Object copy) {
 		try {
 			access.set(copy, accessIndex, fieldSerializer.kryo.copy(access.get(original, accessIndex)));
@@ -61,6 +64,7 @@ class AsmField extends ReflectField {
 			super(field);
 		}
 
+		@Override
 		public void write (Output output, Object object) {
 			if (varEncoding)
 				output.writeVarInt(access.getInt(object, accessIndex), false);
@@ -68,6 +72,7 @@ class AsmField extends ReflectField {
 				output.writeInt(access.getInt(object, accessIndex));
 		}
 
+		@Override
 		public void read (Input input, Object object) {
 			if (varEncoding)
 				access.setInt(object, accessIndex, input.readVarInt(false));
@@ -75,6 +80,7 @@ class AsmField extends ReflectField {
 				access.setInt(object, accessIndex, input.readInt());
 		}
 
+		@Override
 		public void copy (Object original, Object copy) {
 			access.setInt(copy, accessIndex, access.getInt(original, accessIndex));
 		}
@@ -85,14 +91,17 @@ class AsmField extends ReflectField {
 			super(field);
 		}
 
+		@Override
 		public void write (Output output, Object object) {
 			output.writeFloat(access.getFloat(object, accessIndex));
 		}
 
+		@Override
 		public void read (Input input, Object object) {
 			access.setFloat(object, accessIndex, input.readFloat());
 		}
 
+		@Override
 		public void copy (Object original, Object copy) {
 			access.setFloat(copy, accessIndex, access.getFloat(original, accessIndex));
 		}
@@ -103,14 +112,17 @@ class AsmField extends ReflectField {
 			super(field);
 		}
 
+		@Override
 		public void write (Output output, Object object) {
 			output.writeShort(access.getShort(object, accessIndex));
 		}
 
+		@Override
 		public void read (Input input, Object object) {
 			access.setShort(object, accessIndex, input.readShort());
 		}
 
+		@Override
 		public void copy (Object original, Object copy) {
 			access.setShort(copy, accessIndex, access.getShort(original, accessIndex));
 		}
@@ -121,14 +133,17 @@ class AsmField extends ReflectField {
 			super(field);
 		}
 
+		@Override
 		public void write (Output output, Object object) {
 			output.writeByte(access.getByte(object, accessIndex));
 		}
 
+		@Override
 		public void read (Input input, Object object) {
 			access.setByte(object, accessIndex, input.readByte());
 		}
 
+		@Override
 		public void copy (Object original, Object copy) {
 			access.setByte(copy, accessIndex, access.getByte(original, accessIndex));
 		}
@@ -139,14 +154,17 @@ class AsmField extends ReflectField {
 			super(field);
 		}
 
+		@Override
 		public void write (Output output, Object object) {
 			output.writeBoolean(access.getBoolean(object, accessIndex));
 		}
 
+		@Override
 		public void read (Input input, Object object) {
 			access.setBoolean(object, accessIndex, input.readBoolean());
 		}
 
+		@Override
 		public void copy (Object original, Object copy) {
 			access.setBoolean(copy, accessIndex, access.getBoolean(original, accessIndex));
 		}
@@ -157,14 +175,17 @@ class AsmField extends ReflectField {
 			super(field);
 		}
 
+		@Override
 		public void write (Output output, Object object) {
 			output.writeChar(access.getChar(object, accessIndex));
 		}
 
+		@Override
 		public void read (Input input, Object object) {
 			access.setChar(object, accessIndex, input.readChar());
 		}
 
+		@Override
 		public void copy (Object original, Object copy) {
 			access.setChar(copy, accessIndex, access.getChar(original, accessIndex));
 		}
@@ -175,6 +196,7 @@ class AsmField extends ReflectField {
 			super(field);
 		}
 
+		@Override
 		public void write (Output output, Object object) {
 			if (varEncoding)
 				output.writeVarLong(access.getLong(object, accessIndex), false);
@@ -182,6 +204,7 @@ class AsmField extends ReflectField {
 				output.writeLong(access.getLong(object, accessIndex));
 		}
 
+		@Override
 		public void read (Input input, Object object) {
 			if (varEncoding)
 				access.setLong(object, accessIndex, input.readVarLong(false));
@@ -189,6 +212,7 @@ class AsmField extends ReflectField {
 				access.setLong(object, accessIndex, input.readLong());
 		}
 
+		@Override
 		public void copy (Object original, Object copy) {
 			access.setLong(copy, accessIndex, access.getLong(original, accessIndex));
 		}
@@ -199,14 +223,17 @@ class AsmField extends ReflectField {
 			super(field);
 		}
 
+		@Override
 		public void write (Output output, Object object) {
 			output.writeDouble(access.getDouble(object, accessIndex));
 		}
 
+		@Override
 		public void read (Input input, Object object) {
 			access.setDouble(object, accessIndex, input.readDouble());
 		}
 
+		@Override
 		public void copy (Object original, Object copy) {
 			access.setDouble(copy, accessIndex, access.getDouble(original, accessIndex));
 		}
@@ -217,14 +244,17 @@ class AsmField extends ReflectField {
 			super(field);
 		}
 
+		@Override
 		public void write (Output output, Object object) {
 			output.writeString(access.getString(object, accessIndex));
 		}
 
+		@Override
 		public void read (Input input, Object object) {
 			access.set(object, accessIndex, input.readString());
 		}
 
+		@Override
 		public void copy (Object original, Object copy) {
 			access.set(copy, accessIndex, access.getString(original, accessIndex));
 		}

--- a/src/com/esotericsoftware/kryo/serializers/BeanSerializer.java
+++ b/src/com/esotericsoftware/kryo/serializers/BeanSerializer.java
@@ -62,6 +62,7 @@ public class BeanSerializer<T> extends Serializer<T> {
 		// Methods are sorted by alpha so the order of the data is known.
 		PropertyDescriptor[] descriptors = info.getPropertyDescriptors();
 		Arrays.sort(descriptors, new Comparator<PropertyDescriptor>() {
+			@Override
 			public int compare (PropertyDescriptor o1, PropertyDescriptor o2) {
 				return o1.getName().compareTo(o2.getName());
 			}
@@ -105,6 +106,7 @@ public class BeanSerializer<T> extends Serializer<T> {
 		}
 	}
 
+	@Override
 	public void write (Kryo kryo, Output output, T object) {
 		Class type = object.getClass();
 		for (int i = 0, n = properties.length; i < n; i++) {
@@ -132,6 +134,7 @@ public class BeanSerializer<T> extends Serializer<T> {
 		}
 	}
 
+	@Override
 	public T read (Kryo kryo, Input input, Class<? extends T> type) {
 		T object = kryo.newInstance(type);
 		kryo.reference(object);
@@ -162,6 +165,7 @@ public class BeanSerializer<T> extends Serializer<T> {
 		return object;
 	}
 
+	@Override
 	public T copy (Kryo kryo, T original) {
 		T copy = (T)kryo.newInstance(original.getClass());
 		for (int i = 0, n = properties.length; i < n; i++) {

--- a/src/com/esotericsoftware/kryo/serializers/BlowfishSerializer.java
+++ b/src/com/esotericsoftware/kryo/serializers/BlowfishSerializer.java
@@ -43,10 +43,12 @@ public class BlowfishSerializer extends Serializer {
 		keySpec = new SecretKeySpec(key, "Blowfish");
 	}
 
+	@Override
 	public void write (Kryo kryo, Output output, Object object) {
 		Cipher cipher = getCipher(Cipher.ENCRYPT_MODE);
 		CipherOutputStream cipherStream = new CipherOutputStream(output, cipher);
 		Output cipherOutput = new Output(cipherStream, 256) {
+			@Override
 			public void close () throws KryoException {
 				// Don't allow the CipherOutputStream to close the output.
 			}
@@ -60,12 +62,14 @@ public class BlowfishSerializer extends Serializer {
 		}
 	}
 
+	@Override
 	public Object read (Kryo kryo, Input input, Class type) {
 		Cipher cipher = getCipher(Cipher.DECRYPT_MODE);
 		CipherInputStream cipherInput = new CipherInputStream(input, cipher);
 		return serializer.read(kryo, new Input(cipherInput, 256), type);
 	}
 
+	@Override
 	public Object copy (Kryo kryo, Object original) {
 		return serializer.copy(kryo, original);
 	}

--- a/src/com/esotericsoftware/kryo/serializers/CachedFields.java
+++ b/src/com/esotericsoftware/kryo/serializers/CachedFields.java
@@ -242,6 +242,7 @@ class CachedFields implements Comparator<CachedField> {
 		return new ReflectField(field, serializer, genericType);
 	}
 
+	@Override
 	public int compare (CachedField o1, CachedField o2) {
 		// Fields are sorted by name so the order of the data is known.
 		return o1.name.compareTo(o2.name);

--- a/src/com/esotericsoftware/kryo/serializers/ClosureSerializer.java
+++ b/src/com/esotericsoftware/kryo/serializers/ClosureSerializer.java
@@ -61,6 +61,7 @@ public class ClosureSerializer extends Serializer {
 		}
 	}
 
+	@Override
 	public void write (Kryo kryo, Output output, Object object) {
 		SerializedLambda serializedLambda = toSerializedLambda(object);
 		int count = serializedLambda.getCapturedArgCount();
@@ -82,6 +83,7 @@ public class ClosureSerializer extends Serializer {
 		output.writeString(serializedLambda.getInstantiatedMethodType());
 	}
 
+	@Override
 	public Object read (Kryo kryo, Input input, Class type) {
 		int count = input.readVarInt(true);
 		Object[] capturedArgs = new Object[count];
@@ -97,6 +99,7 @@ public class ClosureSerializer extends Serializer {
 		}
 	}
 
+	@Override
 	public Object copy (Kryo kryo, Object original) {
 		try {
 			return readResolve.invoke(toSerializedLambda(original));

--- a/src/com/esotericsoftware/kryo/serializers/CollectionSerializer.java
+++ b/src/com/esotericsoftware/kryo/serializers/CollectionSerializer.java
@@ -81,6 +81,7 @@ public class CollectionSerializer<T extends Collection> extends Serializer<T> {
 		return this.elementSerializer;
 	}
 
+	@Override
 	public void write (Kryo kryo, Output output, T collection) {
 		if (collection == null) {
 			output.writeByte(NULL);
@@ -177,6 +178,7 @@ public class CollectionSerializer<T extends Collection> extends Serializer<T> {
 		return collection;
 	}
 
+	@Override
 	public T read (Kryo kryo, Input input, Class<? extends T> type) {
 		Class elementClass = this.elementClass;
 		Serializer elementSerializer = this.elementSerializer;
@@ -254,6 +256,7 @@ public class CollectionSerializer<T extends Collection> extends Serializer<T> {
 		return (T)kryo.newInstance(original.getClass());
 	}
 
+	@Override
 	public T copy (Kryo kryo, T original) {
 		T copy = createCopy(kryo, original);
 		kryo.reference(copy);

--- a/src/com/esotericsoftware/kryo/serializers/CompatibleFieldSerializer.java
+++ b/src/com/esotericsoftware/kryo/serializers/CompatibleFieldSerializer.java
@@ -57,6 +57,7 @@ public class CompatibleFieldSerializer<T> extends FieldSerializer<T> {
 		this.config = config;
 	}
 
+	@Override
 	public void write (Kryo kryo, Output output, T object) {
 		int pop = pushTypeVariables();
 
@@ -109,6 +110,7 @@ public class CompatibleFieldSerializer<T> extends FieldSerializer<T> {
 		if (pop > 0) popTypeVariables(pop);
 	}
 
+	@Override
 	public T read (Kryo kryo, Input input, Class<? extends T> type) {
 		int pop = pushTypeVariables();
 
@@ -248,6 +250,7 @@ public class CompatibleFieldSerializer<T> extends FieldSerializer<T> {
 		boolean readUnknownFieldData = true, chunked;
 		int chunkSize = 1024;
 
+		@Override
 		public CompatibleFieldSerializerConfig clone () {
 			return (CompatibleFieldSerializerConfig)super.clone(); // Clone is ok as we have only primitive fields.
 		}

--- a/src/com/esotericsoftware/kryo/serializers/DefaultArraySerializers.java
+++ b/src/com/esotericsoftware/kryo/serializers/DefaultArraySerializers.java
@@ -38,6 +38,7 @@ public class DefaultArraySerializers {
 			setAcceptsNull(true);
 		}
 
+		@Override
 		public void write (Kryo kryo, Output output, byte[] object) {
 			if (object == null) {
 				output.writeByte(NULL);
@@ -47,12 +48,14 @@ public class DefaultArraySerializers {
 			output.writeBytes(object);
 		}
 
+		@Override
 		public byte[] read (Kryo kryo, Input input, Class type) {
 			int length = input.readVarInt(true);
 			if (length == NULL) return null;
 			return input.readBytes(length - 1);
 		}
 
+		@Override
 		public byte[] copy (Kryo kryo, byte[] original) {
 			byte[] copy = new byte[original.length];
 			System.arraycopy(original, 0, copy, 0, copy.length);
@@ -65,6 +68,7 @@ public class DefaultArraySerializers {
 			setAcceptsNull(true);
 		}
 
+		@Override
 		public void write (Kryo kryo, Output output, int[] object) {
 			if (object == null) {
 				output.writeByte(NULL);
@@ -74,12 +78,14 @@ public class DefaultArraySerializers {
 			output.writeInts(object, 0, object.length, false);
 		}
 
+		@Override
 		public int[] read (Kryo kryo, Input input, Class type) {
 			int length = input.readVarInt(true);
 			if (length == NULL) return null;
 			return input.readInts(length - 1, false);
 		}
 
+		@Override
 		public int[] copy (Kryo kryo, int[] original) {
 			int[] copy = new int[original.length];
 			System.arraycopy(original, 0, copy, 0, copy.length);
@@ -92,6 +98,7 @@ public class DefaultArraySerializers {
 			setAcceptsNull(true);
 		}
 
+		@Override
 		public void write (Kryo kryo, Output output, float[] object) {
 			if (object == null) {
 				output.writeByte(NULL);
@@ -101,12 +108,14 @@ public class DefaultArraySerializers {
 			output.writeFloats(object, 0, object.length);
 		}
 
+		@Override
 		public float[] read (Kryo kryo, Input input, Class type) {
 			int length = input.readVarInt(true);
 			if (length == NULL) return null;
 			return input.readFloats(length - 1);
 		}
 
+		@Override
 		public float[] copy (Kryo kryo, float[] original) {
 			float[] copy = new float[original.length];
 			System.arraycopy(original, 0, copy, 0, copy.length);
@@ -119,6 +128,7 @@ public class DefaultArraySerializers {
 			setAcceptsNull(true);
 		}
 
+		@Override
 		public void write (Kryo kryo, Output output, long[] object) {
 			if (object == null) {
 				output.writeByte(NULL);
@@ -128,12 +138,14 @@ public class DefaultArraySerializers {
 			output.writeLongs(object, 0, object.length, false);
 		}
 
+		@Override
 		public long[] read (Kryo kryo, Input input, Class type) {
 			int length = input.readVarInt(true);
 			if (length == NULL) return null;
 			return input.readLongs(length - 1, false);
 		}
 
+		@Override
 		public long[] copy (Kryo kryo, long[] original) {
 			long[] copy = new long[original.length];
 			System.arraycopy(original, 0, copy, 0, copy.length);
@@ -146,6 +158,7 @@ public class DefaultArraySerializers {
 			setAcceptsNull(true);
 		}
 
+		@Override
 		public void write (Kryo kryo, Output output, short[] object) {
 			if (object == null) {
 				output.writeByte(NULL);
@@ -155,12 +168,14 @@ public class DefaultArraySerializers {
 			output.writeShorts(object, 0, object.length);
 		}
 
+		@Override
 		public short[] read (Kryo kryo, Input input, Class type) {
 			int length = input.readVarInt(true);
 			if (length == NULL) return null;
 			return input.readShorts(length - 1);
 		}
 
+		@Override
 		public short[] copy (Kryo kryo, short[] original) {
 			short[] copy = new short[original.length];
 			System.arraycopy(original, 0, copy, 0, copy.length);
@@ -173,6 +188,7 @@ public class DefaultArraySerializers {
 			setAcceptsNull(true);
 		}
 
+		@Override
 		public void write (Kryo kryo, Output output, char[] object) {
 			if (object == null) {
 				output.writeByte(NULL);
@@ -182,12 +198,14 @@ public class DefaultArraySerializers {
 			output.writeChars(object, 0, object.length);
 		}
 
+		@Override
 		public char[] read (Kryo kryo, Input input, Class type) {
 			int length = input.readVarInt(true);
 			if (length == NULL) return null;
 			return input.readChars(length - 1);
 		}
 
+		@Override
 		public char[] copy (Kryo kryo, char[] original) {
 			char[] copy = new char[original.length];
 			System.arraycopy(original, 0, copy, 0, copy.length);
@@ -200,6 +218,7 @@ public class DefaultArraySerializers {
 			setAcceptsNull(true);
 		}
 
+		@Override
 		public void write (Kryo kryo, Output output, double[] object) {
 			if (object == null) {
 				output.writeByte(NULL);
@@ -209,12 +228,14 @@ public class DefaultArraySerializers {
 			output.writeDoubles(object, 0, object.length);
 		}
 
+		@Override
 		public double[] read (Kryo kryo, Input input, Class type) {
 			int length = input.readVarInt(true);
 			if (length == NULL) return null;
 			return input.readDoubles(length - 1);
 		}
 
+		@Override
 		public double[] copy (Kryo kryo, double[] original) {
 			double[] copy = new double[original.length];
 			System.arraycopy(original, 0, copy, 0, copy.length);
@@ -227,6 +248,7 @@ public class DefaultArraySerializers {
 			setAcceptsNull(true);
 		}
 
+		@Override
 		public void write (Kryo kryo, Output output, boolean[] object) {
 			if (object == null) {
 				output.writeByte(NULL);
@@ -237,6 +259,7 @@ public class DefaultArraySerializers {
 				output.writeBoolean(object[i]);
 		}
 
+		@Override
 		public boolean[] read (Kryo kryo, Input input, Class type) {
 			int length = input.readVarInt(true);
 			if (length == NULL) return null;
@@ -246,6 +269,7 @@ public class DefaultArraySerializers {
 			return array;
 		}
 
+		@Override
 		public boolean[] copy (Kryo kryo, boolean[] original) {
 			boolean[] copy = new boolean[original.length];
 			System.arraycopy(original, 0, copy, 0, copy.length);
@@ -258,6 +282,7 @@ public class DefaultArraySerializers {
 			setAcceptsNull(true);
 		}
 
+		@Override
 		public void write (Kryo kryo, Output output, String[] object) {
 			if (object == null) {
 				output.writeByte(NULL);
@@ -274,6 +299,7 @@ public class DefaultArraySerializers {
 			}
 		}
 
+		@Override
 		public String[] read (Kryo kryo, Input input, Class type) {
 			int length = input.readVarInt(true);
 			if (length == NULL) return null;
@@ -289,6 +315,7 @@ public class DefaultArraySerializers {
 			return array;
 		}
 
+		@Override
 		public String[] copy (Kryo kryo, String[] original) {
 			String[] copy = new String[original.length];
 			System.arraycopy(original, 0, copy, 0, copy.length);
@@ -312,6 +339,7 @@ public class DefaultArraySerializers {
 			if (isFinal) setElementsAreSameType(true);
 		}
 
+		@Override
 		public void write (Kryo kryo, Output output, Object[] object) {
 			if (object == null) {
 				output.writeByte(NULL);
@@ -335,6 +363,7 @@ public class DefaultArraySerializers {
 			}
 		}
 
+		@Override
 		public Object[] read (Kryo kryo, Input input, Class type) {
 			int n = input.readVarInt(true);
 			if (n == NULL) return null;
@@ -358,6 +387,7 @@ public class DefaultArraySerializers {
 			return object;
 		}
 
+		@Override
 		public Object[] copy (Kryo kryo, Object[] original) {
 			int n = original.length;
 			Object[] copy = (Object[])Array.newInstance(original.getClass().getComponentType(), n);

--- a/src/com/esotericsoftware/kryo/serializers/DefaultSerializers.java
+++ b/src/com/esotericsoftware/kryo/serializers/DefaultSerializers.java
@@ -63,89 +63,107 @@ import java.util.TreeSet;
  * @author Nathan Sweet */
 public class DefaultSerializers {
 	static public class VoidSerializer extends ImmutableSerializer {
+		@Override
 		public void write (Kryo kryo, Output output, Object object) {
 		}
 
+		@Override
 		public Object read (Kryo kryo, Input input, Class type) {
 			return null;
 		}
 	}
 
 	static public class BooleanSerializer extends ImmutableSerializer<Boolean> {
+		@Override
 		public void write (Kryo kryo, Output output, Boolean object) {
 			output.writeBoolean(object);
 		}
 
+		@Override
 		public Boolean read (Kryo kryo, Input input, Class<? extends Boolean> type) {
 			return input.readBoolean();
 		}
 	}
 
 	static public class ByteSerializer extends ImmutableSerializer<Byte> {
+		@Override
 		public void write (Kryo kryo, Output output, Byte object) {
 			output.writeByte(object);
 		}
 
+		@Override
 		public Byte read (Kryo kryo, Input input, Class<? extends Byte> type) {
 			return input.readByte();
 		}
 	}
 
 	static public class CharSerializer extends ImmutableSerializer<Character> {
+		@Override
 		public void write (Kryo kryo, Output output, Character object) {
 			output.writeChar(object);
 		}
 
+		@Override
 		public Character read (Kryo kryo, Input input, Class<? extends Character> type) {
 			return input.readChar();
 		}
 	}
 
 	static public class ShortSerializer extends ImmutableSerializer<Short> {
+		@Override
 		public void write (Kryo kryo, Output output, Short object) {
 			output.writeShort(object);
 		}
 
+		@Override
 		public Short read (Kryo kryo, Input input, Class<? extends Short> type) {
 			return input.readShort();
 		}
 	}
 
 	static public class IntSerializer extends ImmutableSerializer<Integer> {
+		@Override
 		public void write (Kryo kryo, Output output, Integer object) {
 			output.writeInt(object, false);
 		}
 
+		@Override
 		public Integer read (Kryo kryo, Input input, Class<? extends Integer> type) {
 			return input.readInt(false);
 		}
 	}
 
 	static public class LongSerializer extends ImmutableSerializer<Long> {
+		@Override
 		public void write (Kryo kryo, Output output, Long object) {
 			output.writeVarLong(object, false);
 		}
 
+		@Override
 		public Long read (Kryo kryo, Input input, Class<? extends Long> type) {
 			return input.readVarLong(false);
 		}
 	}
 
 	static public class FloatSerializer extends ImmutableSerializer<Float> {
+		@Override
 		public void write (Kryo kryo, Output output, Float object) {
 			output.writeFloat(object);
 		}
 
+		@Override
 		public Float read (Kryo kryo, Input input, Class<? extends Float> type) {
 			return input.readFloat();
 		}
 	}
 
 	static public class DoubleSerializer extends ImmutableSerializer<Double> {
+		@Override
 		public void write (Kryo kryo, Output output, Double object) {
 			output.writeDouble(object);
 		}
 
+		@Override
 		public Double read (Kryo kryo, Input input, Class<? extends Double> type) {
 			return input.readDouble();
 		}
@@ -157,10 +175,12 @@ public class DefaultSerializers {
 			setAcceptsNull(true);
 		}
 
+		@Override
 		public void write (Kryo kryo, Output output, String object) {
 			output.writeString(object);
 		}
 
+		@Override
 		public String read (Kryo kryo, Input input, Class<? extends String> type) {
 			return input.readString();
 		}
@@ -173,6 +193,7 @@ public class DefaultSerializers {
 			setAcceptsNull(true);
 		}
 
+		@Override
 		public void write (Kryo kryo, Output output, BigInteger object) {
 			if (object == null) {
 				output.writeByte(NULL);
@@ -190,6 +211,7 @@ public class DefaultSerializers {
 			output.writeBytes(bytes);
 		}
 
+		@Override
 		public BigInteger read (Kryo kryo, Input input, Class<? extends BigInteger> type) {
 			int length = input.readVarInt(true);
 			if (length == NULL) return null;
@@ -233,6 +255,7 @@ public class DefaultSerializers {
 			setAcceptsNull(true);
 		}
 
+		@Override
 		public void write (Kryo kryo, Output output, BigDecimal object) {
 			if (object == null) {
 				output.writeByte(NULL);
@@ -249,6 +272,7 @@ public class DefaultSerializers {
 			output.writeInt(object.scale(), false);
 		}
 
+		@Override
 		public BigDecimal read (Kryo kryo, Input input, Class<? extends BigDecimal> type) {
 			BigInteger unscaledValue = bigIntegerSerializer.read(kryo, input, BigInteger.class);
 			if (unscaledValue == null) return null;
@@ -282,11 +306,13 @@ public class DefaultSerializers {
 			setAcceptsNull(true);
 		}
 
+		@Override
 		public void write (Kryo kryo, Output output, Class type) {
 			kryo.writeClass(output, type);
 			if (type != null && (type.isPrimitive() || isWrapperClass(type))) output.writeBoolean(type.isPrimitive());
 		}
 
+		@Override
 		public Class read (Kryo kryo, Input input, Class<? extends Class> ignored) {
 			Registration registration = kryo.readClass(input);
 			if (registration == null) return null;
@@ -332,14 +358,17 @@ public class DefaultSerializers {
 			}
 		}
 
+		@Override
 		public void write (Kryo kryo, Output output, Date object) {
 			output.writeVarLong(object.getTime(), true);
 		}
 
+		@Override
 		public Date read (Kryo kryo, Input input, Class<? extends Date> type) {
 			return create(kryo, type, input.readVarLong(true));
 		}
 
+		@Override
 		public Date copy (Kryo kryo, Date original) {
 			return create(kryo, original.getClass(), original.getTime());
 		}
@@ -363,6 +392,7 @@ public class DefaultSerializers {
 				throw new IllegalArgumentException("The type must be an enum: " + type);
 		}
 
+		@Override
 		public void write (Kryo kryo, Output output, Enum object) {
 			if (object == null) {
 				output.writeVarInt(NULL, true);
@@ -371,6 +401,7 @@ public class DefaultSerializers {
 			output.writeVarInt(object.ordinal() + 1, true);
 		}
 
+		@Override
 		public Enum read (Kryo kryo, Input input, Class<? extends Enum> type) {
 			int ordinal = input.readVarInt(true);
 			if (ordinal == NULL) return null;
@@ -383,6 +414,7 @@ public class DefaultSerializers {
 	}
 
 	static public class EnumSetSerializer extends Serializer<EnumSet> {
+		@Override
 		public void write (Kryo kryo, Output output, EnumSet object) {
 			Serializer serializer;
 			if (object.isEmpty()) {
@@ -397,6 +429,7 @@ public class DefaultSerializers {
 				serializer.write(kryo, output, element);
 		}
 
+		@Override
 		public EnumSet read (Kryo kryo, Input input, Class<? extends EnumSet> type) {
 			Registration registration = kryo.readClass(input);
 			EnumSet object = EnumSet.noneOf(registration.getType());
@@ -407,6 +440,7 @@ public class DefaultSerializers {
 			return object;
 		}
 
+		@Override
 		public EnumSet copy (Kryo kryo, EnumSet original) {
 			return EnumSet.copyOf(original);
 		}
@@ -418,10 +452,12 @@ public class DefaultSerializers {
 			setAcceptsNull(true);
 		}
 
+		@Override
 		public void write (Kryo kryo, Output output, Currency object) {
 			output.writeString(object == null ? null : object.getCurrencyCode());
 		}
 
+		@Override
 		public Currency read (Kryo kryo, Input input, Class<? extends Currency> type) {
 			String currencyCode = input.readString();
 			if (currencyCode == null) return null;
@@ -435,16 +471,19 @@ public class DefaultSerializers {
 			setAcceptsNull(true);
 		}
 
+		@Override
 		public void write (Kryo kryo, Output output, StringBuffer object) {
 			output.writeString(object == null ? null : object.toString());
 		}
 
+		@Override
 		public StringBuffer read (Kryo kryo, Input input, Class<? extends StringBuffer> type) {
 			String value = input.readString();
 			if (value == null) return null;
 			return new StringBuffer(value);
 		}
 
+		@Override
 		public StringBuffer copy (Kryo kryo, StringBuffer original) {
 			return new StringBuffer(original);
 		}
@@ -456,24 +495,29 @@ public class DefaultSerializers {
 			setAcceptsNull(true);
 		}
 
+		@Override
 		public void write (Kryo kryo, Output output, StringBuilder object) {
 			output.writeString(object == null ? null : object.toString());
 		}
 
+		@Override
 		public StringBuilder read (Kryo kryo, Input input, Class<? extends StringBuilder> type) {
 			return input.readStringBuilder();
 		}
 
+		@Override
 		public StringBuilder copy (Kryo kryo, StringBuilder original) {
 			return new StringBuilder(original);
 		}
 	}
 
 	static public class KryoSerializableSerializer extends Serializer<KryoSerializable> {
+		@Override
 		public void write (Kryo kryo, Output output, KryoSerializable object) {
 			object.write(kryo, output);
 		}
 
+		@Override
 		public KryoSerializable read (Kryo kryo, Input input, Class<? extends KryoSerializable> type) {
 			KryoSerializable object = kryo.newInstance(type);
 			kryo.reference(object);
@@ -486,9 +530,11 @@ public class DefaultSerializers {
 	 * {@link Collections#EMPTY_LIST}.
 	 * @author <a href="mailto:martin.grotzke@javakaffee.de">Martin Grotzke</a> */
 	static public class CollectionsEmptyListSerializer extends ImmutableSerializer<Collection> {
+		@Override
 		public void write (Kryo kryo, Output output, Collection object) {
 		}
 
+		@Override
 		public Collection read (Kryo kryo, Input input, Class<? extends Collection> type) {
 			return Collections.EMPTY_LIST;
 		}
@@ -498,9 +544,11 @@ public class DefaultSerializers {
 	 * {@link Collections#EMPTY_MAP}.
 	 * @author <a href="mailto:martin.grotzke@javakaffee.de">Martin Grotzke</a> */
 	static public class CollectionsEmptyMapSerializer extends ImmutableSerializer<Map> {
+		@Override
 		public void write (Kryo kryo, Output output, Map object) {
 		}
 
+		@Override
 		public Map read (Kryo kryo, Input input, Class<? extends Map> type) {
 			return Collections.EMPTY_MAP;
 		}
@@ -510,9 +558,11 @@ public class DefaultSerializers {
 	 * {@link Collections#EMPTY_SET}.
 	 * @author <a href="mailto:martin.grotzke@javakaffee.de">Martin Grotzke</a> */
 	static public class CollectionsEmptySetSerializer extends ImmutableSerializer<Set> {
+		@Override
 		public void write (Kryo kryo, Output output, Set object) {
 		}
 
+		@Override
 		public Set read (Kryo kryo, Input input, Class<? extends Set> type) {
 			return Collections.EMPTY_SET;
 		}
@@ -521,14 +571,17 @@ public class DefaultSerializers {
 	/** Serializer for lists created via {@link Collections#singletonList(Object)}.
 	 * @author <a href="mailto:martin.grotzke@javakaffee.de">Martin Grotzke</a> */
 	static public class CollectionsSingletonListSerializer extends Serializer<List> {
+		@Override
 		public void write (Kryo kryo, Output output, List object) {
 			kryo.writeClassAndObject(output, object.get(0));
 		}
 
+		@Override
 		public List read (Kryo kryo, Input input, Class<? extends List> type) {
 			return Collections.singletonList(kryo.readClassAndObject(input));
 		}
 
+		@Override
 		public List copy (Kryo kryo, List original) {
 			return Collections.singletonList(kryo.copy(original.get(0)));
 		}
@@ -537,18 +590,21 @@ public class DefaultSerializers {
 	/** Serializer for maps created via {@link Collections#singletonMap(Object, Object)}.
 	 * @author <a href="mailto:martin.grotzke@javakaffee.de">Martin Grotzke</a> */
 	static public class CollectionsSingletonMapSerializer extends Serializer<Map> {
+		@Override
 		public void write (Kryo kryo, Output output, Map object) {
 			Entry entry = (Entry)object.entrySet().iterator().next();
 			kryo.writeClassAndObject(output, entry.getKey());
 			kryo.writeClassAndObject(output, entry.getValue());
 		}
 
+		@Override
 		public Map read (Kryo kryo, Input input, Class<? extends Map> type) {
 			Object key = kryo.readClassAndObject(input);
 			Object value = kryo.readClassAndObject(input);
 			return Collections.singletonMap(key, value);
 		}
 
+		@Override
 		public Map copy (Kryo kryo, Map original) {
 			Entry entry = (Entry)original.entrySet().iterator().next();
 			return Collections.singletonMap(kryo.copy(entry.getKey()), kryo.copy(entry.getValue()));
@@ -558,14 +614,17 @@ public class DefaultSerializers {
 	/** Serializer for sets created via {@link Collections#singleton(Object)}.
 	 * @author <a href="mailto:martin.grotzke@javakaffee.de">Martin Grotzke</a> */
 	static public class CollectionsSingletonSetSerializer extends Serializer<Set> {
+		@Override
 		public void write (Kryo kryo, Output output, Set object) {
 			kryo.writeClassAndObject(output, object.iterator().next());
 		}
 
+		@Override
 		public Set read (Kryo kryo, Input input, Class<? extends Set> type) {
 			return Collections.singleton(kryo.readClassAndObject(input));
 		}
 
+		@Override
 		public Set copy (Kryo kryo, Set original) {
 			return Collections.singleton(kryo.copy(original.iterator().next()));
 		}
@@ -574,10 +633,12 @@ public class DefaultSerializers {
 	/** Serializer for {@link TimeZone}. Assumes the timezones are immutable.
 	 * @author Tumi <serverperformance@gmail.com> */
 	static public class TimeZoneSerializer extends ImmutableSerializer<TimeZone> {
+		@Override
 		public void write (Kryo kryo, Output output, TimeZone object) {
 			output.writeString(object.getID());
 		}
 
+		@Override
 		public TimeZone read (Kryo kryo, Input input, Class<? extends TimeZone> type) {
 			return TimeZone.getTimeZone(input.readString());
 		}
@@ -591,6 +652,7 @@ public class DefaultSerializers {
 
 		TimeZoneSerializer timeZoneSerializer = new TimeZoneSerializer();
 
+		@Override
 		public void write (Kryo kryo, Output output, Calendar object) {
 			timeZoneSerializer.write(kryo, output, object.getTimeZone()); // can't be null
 			output.writeVarLong(object.getTimeInMillis(), true);
@@ -603,6 +665,7 @@ public class DefaultSerializers {
 				output.writeVarLong(DEFAULT_GREGORIAN_CUTOVER, false);
 		}
 
+		@Override
 		public Calendar read (Kryo kryo, Input input, Class<? extends Calendar> type) {
 			Calendar result = Calendar.getInstance(timeZoneSerializer.read(kryo, input, TimeZone.class));
 			result.setTimeInMillis(input.readVarLong(true));
@@ -615,6 +678,7 @@ public class DefaultSerializers {
 			return result;
 		}
 
+		@Override
 		public Calendar copy (Kryo kryo, Calendar original) {
 			return (Calendar)original.clone();
 		}
@@ -623,14 +687,17 @@ public class DefaultSerializers {
 	/** Serializer for {@link TreeMap} and any subclass.
 	 * @author Tumi <serverperformance@gmail.com> (enhacements) */
 	static public class TreeMapSerializer extends MapSerializer<TreeMap> {
+		@Override
 		protected void writeHeader (Kryo kryo, Output output, TreeMap treeSet) {
 			kryo.writeClassAndObject(output, treeSet.comparator());
 		}
 
+		@Override
 		protected TreeMap create (Kryo kryo, Input input, Class<? extends TreeMap> type, int size) {
 			return createTreeMap(type, (Comparator)kryo.readClassAndObject(input));
 		}
 
+		@Override
 		protected TreeMap createCopy (Kryo kryo, TreeMap original) {
 			return createTreeMap(original.getClass(), original.comparator());
 		}
@@ -656,14 +723,17 @@ public class DefaultSerializers {
 	/** Serializer for {@link TreeMap} and any subclass.
 	 * @author Tumi <serverperformance@gmail.com> (enhacements) */
 	static public class TreeSetSerializer extends CollectionSerializer<TreeSet> {
+		@Override
 		protected void writeHeader (Kryo kryo, Output output, TreeSet treeSet) {
 			kryo.writeClassAndObject(output, treeSet.comparator());
 		}
 
+		@Override
 		protected TreeSet create (Kryo kryo, Input input, Class<? extends TreeSet> type, int size) {
 			return createTreeSet(type, (Comparator)kryo.readClassAndObject(input));
 		}
 
+		@Override
 		protected TreeSet createCopy (Kryo kryo, TreeSet original) {
 			return createTreeSet(original.getClass(), original.comparator());
 		}
@@ -689,14 +759,17 @@ public class DefaultSerializers {
 	/** Serializer for {@link PriorityQueue} and any subclass.
 	 * @author Nathan Sweet */
 	static public class PriorityQueueSerializer extends CollectionSerializer<PriorityQueue> {
+		@Override
 		protected void writeHeader (Kryo kryo, Output output, PriorityQueue queue) {
 			kryo.writeClassAndObject(output, queue.comparator());
 		}
 
+		@Override
 		protected PriorityQueue create (Kryo kryo, Input input, Class<? extends PriorityQueue> type, int size) {
 			return createPriorityQueue(type, size, (Comparator)kryo.readClassAndObject(input));
 		}
 
+		@Override
 		protected PriorityQueue createCopy (Kryo kryo, PriorityQueue original) {
 			return createPriorityQueue(original.getClass(), original.size(), original.comparator());
 		}
@@ -764,12 +837,14 @@ public class DefaultSerializers {
 			return new Locale(language, country, variant);
 		}
 
+		@Override
 		public void write (Kryo kryo, Output output, Locale l) {
 			output.writeAscii(l.getLanguage());
 			output.writeAscii(l.getCountry());
 			output.writeString(l.getVariant());
 		}
 
+		@Override
 		public Locale read (Kryo kryo, Input input, Class<? extends Locale> type) {
 			String language = input.readString();
 			String country = input.readString();
@@ -785,10 +860,12 @@ public class DefaultSerializers {
 
 	/** Serializer for {@link Charset}. */
 	static public class CharsetSerializer extends ImmutableSerializer<Charset> {
+		@Override
 		public void write (Kryo kryo, Output output, Charset object) {
 			output.writeString(object.name());
 		}
 
+		@Override
 		public Charset read (Kryo kryo, Input input, Class<? extends Charset> type) {
 			return Charset.forName(input.readString());
 		}
@@ -796,10 +873,12 @@ public class DefaultSerializers {
 
 	/** Serializer for {@link URL}. */
 	static public class URLSerializer extends ImmutableSerializer<URL> {
+		@Override
 		public void write (Kryo kryo, Output output, URL object) {
 			output.writeString(object.toExternalForm());
 		}
 
+		@Override
 		public URL read (Kryo kryo, Input input, Class<? extends URL> type) {
 			try {
 				return new java.net.URL(input.readString());
@@ -811,28 +890,33 @@ public class DefaultSerializers {
 
 	/** Serializer for {@link Arrays#asList(Object...)}. */
 	static public class ArraysAsListSerializer extends CollectionSerializer<List> {
+		@Override
 		protected List create (Kryo kryo, Input input, Class type, int size) {
 			return new ArrayList(size);
 		}
 
+		@Override
 		public List read (Kryo kryo, Input input, Class type) {
 			List list = super.read(kryo, input, type);
 			if (list == null) return null;
 			return Arrays.asList(list.toArray());
 		}
 
+		@Override
 		public List copy (Kryo kryo, List original) {
 			return Arrays.asList(original.toArray());
 		}
 	}
 
 	static public class BitSetSerializer extends Serializer<BitSet> {
+		@Override
 		public void write (Kryo kryo, Output output, BitSet set) {
 			long[] values = set.toLongArray();
 			output.writeVarInt(values.length, true);
 			output.writeLongs(values, 0, values.length);
 		}
 
+		@Override
 		public BitSet read (Kryo kryo, Input input, Class type) {
 			int length = input.readVarInt(true);
 			long[] values = input.readLongs(length);
@@ -840,6 +924,7 @@ public class DefaultSerializers {
 			return set;
 		}
 
+		@Override
 		public BitSet copy (Kryo kryo, BitSet original) {
 			return BitSet.valueOf(original.toLongArray());
 		}

--- a/src/com/esotericsoftware/kryo/serializers/DeflateSerializer.java
+++ b/src/com/esotericsoftware/kryo/serializers/DeflateSerializer.java
@@ -42,6 +42,7 @@ public class DeflateSerializer extends Serializer {
 		this.serializer = serializer;
 	}
 
+	@Override
 	public void write (Kryo kryo, Output output, Object object) {
 		OutputChunked outputChunked = new OutputChunked(output, 256);
 		Deflater deflater = new Deflater(compressionLevel, noHeaders);
@@ -59,6 +60,7 @@ public class DeflateSerializer extends Serializer {
 		outputChunked.endChunk();
 	}
 
+	@Override
 	public Object read (Kryo kryo, Input input, Class type) {
 		// The inflater would read from input beyond the compressed bytes if chunked enoding wasn't used.
 		Inflater inflater = new Inflater(noHeaders);
@@ -80,6 +82,7 @@ public class DeflateSerializer extends Serializer {
 		this.compressionLevel = compressionLevel;
 	}
 
+	@Override
 	public Object copy (Kryo kryo, Object original) {
 		return serializer.copy(kryo, original);
 	}

--- a/src/com/esotericsoftware/kryo/serializers/EnumMapSerializer.java
+++ b/src/com/esotericsoftware/kryo/serializers/EnumMapSerializer.java
@@ -32,10 +32,12 @@ public class EnumMapSerializer extends MapSerializer<EnumMap> {
 		this.enumType = enumType;
 	}
 
+	@Override
 	protected EnumMap create (Kryo kryo, Input input, Class<? extends EnumMap> type, int size) {
 		return new EnumMap(enumType);
 	}
 
+	@Override
 	protected EnumMap createCopy (Kryo kryo, EnumMap original) {
 		return new EnumMap(original);
 	}

--- a/src/com/esotericsoftware/kryo/serializers/EnumNameSerializer.java
+++ b/src/com/esotericsoftware/kryo/serializers/EnumNameSerializer.java
@@ -33,10 +33,12 @@ public class EnumNameSerializer extends ImmutableSerializer<Enum> {
 		this.enumType = enumType;
 	}
 
+	@Override
 	public void write (Kryo kryo, Output output, Enum object) {
 		output.writeString(object.name());
 	}
 
+	@Override
 	public Enum read (Kryo kryo, Input input, Class type) {
 		String name = input.readString();
 		try {

--- a/src/com/esotericsoftware/kryo/serializers/ExternalizableSerializer.java
+++ b/src/com/esotericsoftware/kryo/serializers/ExternalizableSerializer.java
@@ -47,6 +47,7 @@ public class ExternalizableSerializer extends Serializer {
 	private KryoObjectInput objectInput = null;
 	private KryoObjectOutput objectOutput = null;
 
+	@Override
 	public void write (Kryo kryo, Output output, Object object) {
 		JavaSerializer serializer = getJavaSerializerIfRequired(object.getClass());
 		if (serializer == null)
@@ -55,6 +56,7 @@ public class ExternalizableSerializer extends Serializer {
 			serializer.write(kryo, output, object);
 	}
 
+	@Override
 	public Object read (Kryo kryo, Input input, Class type) {
 		JavaSerializer serializer = getJavaSerializerIfRequired(type);
 		if (serializer == null) return readExternal(kryo, input, type);

--- a/src/com/esotericsoftware/kryo/serializers/FieldSerializer.java
+++ b/src/com/esotericsoftware/kryo/serializers/FieldSerializer.java
@@ -98,6 +98,7 @@ public class FieldSerializer<T> extends Serializer<T> {
 		cachedFields.rebuild();
 	}
 
+	@Override
 	public void write (Kryo kryo, Output output, T object) {
 		int pop = pushTypeVariables();
 
@@ -110,6 +111,7 @@ public class FieldSerializer<T> extends Serializer<T> {
 		if (pop > 0) popTypeVariables(pop);
 	}
 
+	@Override
 	public T read (Kryo kryo, Input input, Class<? extends T> type) {
 		int pop = pushTypeVariables();
 
@@ -211,6 +213,7 @@ public class FieldSerializer<T> extends Serializer<T> {
 		return (T)kryo.newInstance(original.getClass());
 	}
 
+	@Override
 	public T copy (Kryo kryo, T original) {
 		T copy = createCopy(kryo, original);
 		kryo.reference(copy);
@@ -383,6 +386,7 @@ public class FieldSerializer<T> extends Serializer<T> {
 		boolean varEncoding = true;
 		boolean extendedFieldNames;
 
+		@Override
 		public FieldSerializerConfig clone () {
 			try {
 				return (FieldSerializerConfig)super.clone(); // Clone is ok as we have only primitive fields.

--- a/src/com/esotericsoftware/kryo/serializers/JavaSerializer.java
+++ b/src/com/esotericsoftware/kryo/serializers/JavaSerializer.java
@@ -40,6 +40,7 @@ import java.io.ObjectStreamClass;
  * @see KryoSerializable
  * @author Nathan Sweet */
 public class JavaSerializer extends Serializer {
+	@Override
 	public void write (Kryo kryo, Output output, Object object) {
 		try {
 			ObjectMap graphContext = kryo.getGraphContext();
@@ -55,6 +56,7 @@ public class JavaSerializer extends Serializer {
 		}
 	}
 
+	@Override
 	public Object read (Kryo kryo, Input input, Class type) {
 		try {
 			ObjectMap graphContext = kryo.getGraphContext();
@@ -81,6 +83,7 @@ public class JavaSerializer extends Serializer {
 			this.kryo = kryo;
 		}
 
+		@Override
 		protected Class resolveClass (ObjectStreamClass type) {
 			try {
 				return Class.forName(type.getName(), false, kryo.getClassLoader());

--- a/src/com/esotericsoftware/kryo/serializers/MapSerializer.java
+++ b/src/com/esotericsoftware/kryo/serializers/MapSerializer.java
@@ -112,6 +112,7 @@ public class MapSerializer<T extends Map> extends Serializer<T> {
 		this.valuesCanBeNull = valuesCanBeNull;
 	}
 
+	@Override
 	public void write (Kryo kryo, Output output, T map) {
 		if (map == null) {
 			output.writeByte(0);
@@ -183,6 +184,7 @@ public class MapSerializer<T extends Map> extends Serializer<T> {
 		return kryo.newInstance(type);
 	}
 
+	@Override
 	public T read (Kryo kryo, Input input, Class<? extends T> type) {
 		int length = input.readVarInt(true);
 		if (length == 0) return null;
@@ -243,6 +245,7 @@ public class MapSerializer<T extends Map> extends Serializer<T> {
 		return (T)kryo.newInstance(original.getClass());
 	}
 
+	@Override
 	public T copy (Kryo kryo, T original) {
 		T copy = createCopy(kryo, original);
 		for (Iterator iter = original.entrySet().iterator(); iter.hasNext();) {

--- a/src/com/esotericsoftware/kryo/serializers/OptionalSerializers.java
+++ b/src/com/esotericsoftware/kryo/serializers/OptionalSerializers.java
@@ -47,15 +47,18 @@ public final class OptionalSerializers {
 			setAcceptsNull(false);
 		}
 
+		@Override
 		public void write (Kryo kryo, Output output, Optional object) {
 			Object nullable = object.isPresent() ? object.get() : null;
 			kryo.writeClassAndObject(output, nullable);
 		}
 
+		@Override
 		public Optional read (Kryo kryo, Input input, Class type) {
 			return Optional.ofNullable(kryo.readClassAndObject(input));
 		}
 
+		@Override
 		public Optional copy (Kryo kryo, Optional original) {
 			if (original.isPresent()) {
 				return Optional.of(kryo.copy(original.get()));
@@ -65,11 +68,13 @@ public final class OptionalSerializers {
 	}
 
 	static public class OptionalIntSerializer extends ImmutableSerializer<OptionalInt> {
+		@Override
 		public void write (Kryo kryo, Output output, OptionalInt object) {
 			output.writeBoolean(object.isPresent());
 			if (object.isPresent()) output.writeInt(object.getAsInt());
 		}
 
+		@Override
 		public OptionalInt read (Kryo kryo, Input input, Class type) {
 			boolean present = input.readBoolean();
 			return present ? OptionalInt.of(input.readInt()) : OptionalInt.empty();
@@ -77,11 +82,13 @@ public final class OptionalSerializers {
 	}
 
 	static public class OptionalLongSerializer extends ImmutableSerializer<OptionalLong> {
+		@Override
 		public void write (Kryo kryo, Output output, OptionalLong object) {
 			output.writeBoolean(object.isPresent());
 			if (object.isPresent()) output.writeLong(object.getAsLong());
 		}
 
+		@Override
 		public OptionalLong read (Kryo kryo, Input input, Class type) {
 			boolean present = input.readBoolean();
 			return present ? OptionalLong.of(input.readLong()) : OptionalLong.empty();
@@ -89,11 +96,13 @@ public final class OptionalSerializers {
 	}
 
 	static public class OptionalDoubleSerializer extends ImmutableSerializer<OptionalDouble> {
+		@Override
 		public void write (Kryo kryo, Output output, OptionalDouble object) {
 			output.writeBoolean(object.isPresent());
 			if (object.isPresent()) output.writeDouble(object.getAsDouble());
 		}
 
+		@Override
 		public OptionalDouble read (Kryo kryo, Input input, Class type) {
 			boolean present = input.readBoolean();
 			return present ? OptionalDouble.of(input.readDouble()) : OptionalDouble.empty();

--- a/src/com/esotericsoftware/kryo/serializers/ReflectField.java
+++ b/src/com/esotericsoftware/kryo/serializers/ReflectField.java
@@ -51,6 +51,7 @@ class ReflectField extends CachedField {
 		field.set(object, value);
 	}
 
+	@Override
 	public void write (Output output, Object object) {
 		Kryo kryo = fieldSerializer.kryo;
 		try {
@@ -95,6 +96,7 @@ class ReflectField extends CachedField {
 		}
 	}
 
+	@Override
 	public void read (Input input, Object object) {
 		Kryo kryo = fieldSerializer.kryo;
 		try {
@@ -144,6 +146,7 @@ class ReflectField extends CachedField {
 		return valueClass;
 	}
 
+	@Override
 	public void copy (Object original, Object copy) {
 		try {
 			set(copy, fieldSerializer.kryo.copy(get(original)));
@@ -164,6 +167,7 @@ class ReflectField extends CachedField {
 			super(field);
 		}
 
+		@Override
 		public void write (Output output, Object object) {
 			try {
 				if (varEncoding)
@@ -177,6 +181,7 @@ class ReflectField extends CachedField {
 			}
 		}
 
+		@Override
 		public void read (Input input, Object object) {
 			try {
 				if (varEncoding)
@@ -190,6 +195,7 @@ class ReflectField extends CachedField {
 			}
 		}
 
+		@Override
 		public void copy (Object original, Object copy) {
 			try {
 				field.setInt(copy, field.getInt(original));
@@ -206,6 +212,7 @@ class ReflectField extends CachedField {
 			super(field);
 		}
 
+		@Override
 		public void write (Output output, Object object) {
 			try {
 				output.writeFloat(field.getFloat(object));
@@ -216,6 +223,7 @@ class ReflectField extends CachedField {
 			}
 		}
 
+		@Override
 		public void read (Input input, Object object) {
 			try {
 				field.setFloat(object, input.readFloat());
@@ -226,6 +234,7 @@ class ReflectField extends CachedField {
 			}
 		}
 
+		@Override
 		public void copy (Object original, Object copy) {
 			try {
 				field.setFloat(copy, field.getFloat(original));
@@ -242,6 +251,7 @@ class ReflectField extends CachedField {
 			super(field);
 		}
 
+		@Override
 		public void write (Output output, Object object) {
 			try {
 				output.writeShort(field.getShort(object));
@@ -252,6 +262,7 @@ class ReflectField extends CachedField {
 			}
 		}
 
+		@Override
 		public void read (Input input, Object object) {
 			try {
 				field.setShort(object, input.readShort());
@@ -262,6 +273,7 @@ class ReflectField extends CachedField {
 			}
 		}
 
+		@Override
 		public void copy (Object original, Object copy) {
 			try {
 				field.setShort(copy, field.getShort(original));
@@ -278,6 +290,7 @@ class ReflectField extends CachedField {
 			super(field);
 		}
 
+		@Override
 		public void write (Output output, Object object) {
 			try {
 				output.writeByte(field.getByte(object));
@@ -288,6 +301,7 @@ class ReflectField extends CachedField {
 			}
 		}
 
+		@Override
 		public void read (Input input, Object object) {
 			try {
 				field.setByte(object, input.readByte());
@@ -298,6 +312,7 @@ class ReflectField extends CachedField {
 			}
 		}
 
+		@Override
 		public void copy (Object original, Object copy) {
 			try {
 				field.setByte(copy, field.getByte(original));
@@ -314,6 +329,7 @@ class ReflectField extends CachedField {
 			super(field);
 		}
 
+		@Override
 		public void write (Output output, Object object) {
 			try {
 				output.writeBoolean(field.getBoolean(object));
@@ -324,6 +340,7 @@ class ReflectField extends CachedField {
 			}
 		}
 
+		@Override
 		public void read (Input input, Object object) {
 			try {
 				field.setBoolean(object, input.readBoolean());
@@ -334,6 +351,7 @@ class ReflectField extends CachedField {
 			}
 		}
 
+		@Override
 		public void copy (Object original, Object copy) {
 			try {
 				field.setBoolean(copy, field.getBoolean(original));
@@ -350,6 +368,7 @@ class ReflectField extends CachedField {
 			super(field);
 		}
 
+		@Override
 		public void write (Output output, Object object) {
 			try {
 				output.writeChar(field.getChar(object));
@@ -360,6 +379,7 @@ class ReflectField extends CachedField {
 			}
 		}
 
+		@Override
 		public void read (Input input, Object object) {
 			try {
 				field.setChar(object, input.readChar());
@@ -370,6 +390,7 @@ class ReflectField extends CachedField {
 			}
 		}
 
+		@Override
 		public void copy (Object original, Object copy) {
 			try {
 				field.setChar(copy, field.getChar(original));
@@ -386,6 +407,7 @@ class ReflectField extends CachedField {
 			super(field);
 		}
 
+		@Override
 		public void write (Output output, Object object) {
 			try {
 				if (varEncoding)
@@ -399,6 +421,7 @@ class ReflectField extends CachedField {
 			}
 		}
 
+		@Override
 		public void read (Input input, Object object) {
 			try {
 				if (varEncoding)
@@ -412,6 +435,7 @@ class ReflectField extends CachedField {
 			}
 		}
 
+		@Override
 		public void copy (Object original, Object copy) {
 			try {
 				field.setLong(copy, field.getLong(original));
@@ -428,6 +452,7 @@ class ReflectField extends CachedField {
 			super(field);
 		}
 
+		@Override
 		public void write (Output output, Object object) {
 			try {
 				output.writeDouble(field.getDouble(object));
@@ -438,6 +463,7 @@ class ReflectField extends CachedField {
 			}
 		}
 
+		@Override
 		public void read (Input input, Object object) {
 			try {
 				field.setDouble(object, input.readDouble());
@@ -448,6 +474,7 @@ class ReflectField extends CachedField {
 			}
 		}
 
+		@Override
 		public void copy (Object original, Object copy) {
 			try {
 				field.setDouble(copy, field.getDouble(original));

--- a/src/com/esotericsoftware/kryo/serializers/TaggedFieldSerializer.java
+++ b/src/com/esotericsoftware/kryo/serializers/TaggedFieldSerializer.java
@@ -74,6 +74,7 @@ public class TaggedFieldSerializer<T> extends FieldSerializer<T> {
 		setAcceptsNull(true);
 	}
 
+	@Override
 	protected void initializeCachedFields () {
 		CachedField[] fields = cachedFields.fields;
 		// Remove untagged fields.
@@ -101,16 +102,19 @@ public class TaggedFieldSerializer<T> extends FieldSerializer<T> {
 		this.writeTags = (CachedField[])writeTags.toArray(new CachedField[writeTags.size()]);
 	}
 
+	@Override
 	public void removeField (String fieldName) {
 		super.removeField(fieldName);
 		initializeCachedFields();
 	}
 
+	@Override
 	public void removeField (CachedField field) {
 		super.removeField(field);
 		initializeCachedFields();
 	}
 
+	@Override
 	public void write (Kryo kryo, Output output, T object) {
 		if (object == null) {
 			output.writeByte(NULL);
@@ -166,6 +170,7 @@ public class TaggedFieldSerializer<T> extends FieldSerializer<T> {
 	protected void writeHeader (Kryo kryo, Output output, T object) {
 	}
 
+	@Override
 	public T read (Kryo kryo, Input input, Class<? extends T> type) {
 		int fieldCount = input.readVarInt(true);
 		if (fieldCount == NULL) return null;
@@ -253,6 +258,7 @@ public class TaggedFieldSerializer<T> extends FieldSerializer<T> {
 		boolean readUnknownTagData, chunked;
 		int chunkSize = 1024;
 
+		@Override
 		public TaggedFieldSerializerConfig clone () {
 			return (TaggedFieldSerializerConfig)super.clone(); // Clone is ok as we have only primitive fields.
 		}

--- a/src/com/esotericsoftware/kryo/serializers/TimeSerializers.java
+++ b/src/com/esotericsoftware/kryo/serializers/TimeSerializers.java
@@ -68,11 +68,13 @@ public final class TimeSerializers {
 	}
 
 	static public class DurationSerializer extends ImmutableSerializer<Duration> {
+		@Override
 		public void write (Kryo kryo, Output out, Duration duration) {
 			out.writeLong(duration.getSeconds());
 			out.writeInt(duration.getNano(), true);
 		}
 
+		@Override
 		public Duration read (Kryo kryo, Input in, Class type) {
 			long seconds = in.readLong();
 			int nanos = in.readInt(true);
@@ -81,11 +83,13 @@ public final class TimeSerializers {
 	}
 
 	static public class InstantSerializer extends ImmutableSerializer<Instant> {
+		@Override
 		public void write (Kryo kryo, Output out, Instant instant) {
 			out.writeVarLong(instant.getEpochSecond(), true);
 			out.writeInt(instant.getNano(), true);
 		}
 
+		@Override
 		public Instant read (Kryo kryo, Input in, Class type) {
 			long seconds = in.readVarLong(true);
 			int nanos = in.readInt(true);
@@ -94,6 +98,7 @@ public final class TimeSerializers {
 	}
 
 	static public class LocalDateSerializer extends ImmutableSerializer<LocalDate> {
+		@Override
 		public void write (Kryo kryo, Output out, LocalDate date) {
 			write(out, date);
 		}
@@ -104,6 +109,7 @@ public final class TimeSerializers {
 			out.writeByte(date.getDayOfMonth());
 		}
 
+		@Override
 		public LocalDate read (Kryo kryo, Input in, Class type) {
 			return read(in);
 		}
@@ -117,11 +123,13 @@ public final class TimeSerializers {
 	}
 
 	static public class LocalDateTimeSerializer extends ImmutableSerializer<LocalDateTime> {
+		@Override
 		public void write (Kryo kryo, Output out, LocalDateTime dateTime) {
 			LocalDateSerializer.write(out, dateTime.toLocalDate());
 			LocalTimeSerializer.write(out, dateTime.toLocalTime());
 		}
 
+		@Override
 		public LocalDateTime read (Kryo kryo, Input in, Class type) {
 			LocalDate date = LocalDateSerializer.read(in);
 			LocalTime time = LocalTimeSerializer.read(in);
@@ -130,6 +138,7 @@ public final class TimeSerializers {
 	}
 
 	static public class LocalTimeSerializer extends ImmutableSerializer<LocalTime> {
+		@Override
 		public void write (Kryo kryo, Output out, LocalTime time) {
 			write(out, time);
 		}
@@ -156,6 +165,7 @@ public final class TimeSerializers {
 			}
 		}
 
+		@Override
 		public LocalTime read (Kryo kryo, Input in, Class type) {
 			return read(in);
 		}
@@ -185,6 +195,7 @@ public final class TimeSerializers {
 	}
 
 	static public class ZoneOffsetSerializer extends ImmutableSerializer<ZoneOffset> {
+		@Override
 		public void write (Kryo kryo, Output out, ZoneOffset obj) {
 			write(out, obj);
 		}
@@ -198,6 +209,7 @@ public final class TimeSerializers {
 			}
 		}
 
+		@Override
 		public ZoneOffset read (Kryo kryo, Input in, Class type) {
 			return read(in);
 		}
@@ -209,6 +221,7 @@ public final class TimeSerializers {
 	}
 
 	static public class ZoneIdSerializer extends ImmutableSerializer<ZoneId> {
+		@Override
 		public void write (Kryo kryo, Output out, ZoneId obj) {
 			write(out, obj);
 		}
@@ -217,6 +230,7 @@ public final class TimeSerializers {
 			out.writeString(obj.getId());
 		}
 
+		@Override
 		public ZoneId read (Kryo kryo, Input in, Class type) {
 			return read(in);
 		}
@@ -228,11 +242,13 @@ public final class TimeSerializers {
 	}
 
 	static public class OffsetTimeSerializer extends ImmutableSerializer<OffsetTime> {
+		@Override
 		public void write (Kryo kryo, Output out, OffsetTime obj) {
 			LocalTimeSerializer.write(out, obj.toLocalTime());
 			ZoneOffsetSerializer.write(out, obj.getOffset());
 		}
 
+		@Override
 		public OffsetTime read (Kryo kryo, Input in, Class type) {
 			LocalTime time = LocalTimeSerializer.read(in);
 			ZoneOffset offset = ZoneOffsetSerializer.read(in);
@@ -241,12 +257,14 @@ public final class TimeSerializers {
 	}
 
 	static public class OffsetDateTimeSerializer extends ImmutableSerializer<OffsetDateTime> {
+		@Override
 		public void write (Kryo kryo, Output out, OffsetDateTime obj) {
 			LocalDateSerializer.write(out, obj.toLocalDate());
 			LocalTimeSerializer.write(out, obj.toLocalTime());
 			ZoneOffsetSerializer.write(out, obj.getOffset());
 		}
 
+		@Override
 		public OffsetDateTime read (Kryo kryo, Input in, Class type) {
 			LocalDate date = LocalDateSerializer.read(in);
 			LocalTime time = LocalTimeSerializer.read(in);
@@ -256,12 +274,14 @@ public final class TimeSerializers {
 	}
 
 	static public class ZonedDateTimeSerializer extends ImmutableSerializer<ZonedDateTime> {
+		@Override
 		public void write (Kryo kryo, Output out, ZonedDateTime obj) {
 			LocalDateSerializer.write(out, obj.toLocalDate());
 			LocalTimeSerializer.write(out, obj.toLocalTime());
 			ZoneIdSerializer.write(out, obj.getZone());
 		}
 
+		@Override
 		public ZonedDateTime read (Kryo kryo, Input in, Class type) {
 			LocalDate date = LocalDateSerializer.read(in);
 			LocalTime time = LocalTimeSerializer.read(in);
@@ -271,21 +291,25 @@ public final class TimeSerializers {
 	}
 
 	static public class YearSerializer extends ImmutableSerializer<Year> {
+		@Override
 		public void write (Kryo kryo, Output out, Year obj) {
 			out.writeVarInt(obj.getValue(), true);
 		}
 
+		@Override
 		public Year read (Kryo kryo, Input in, Class type) {
 			return Year.of(in.readInt(true));
 		}
 	}
 
 	static public class YearMonthSerializer extends ImmutableSerializer<YearMonth> {
+		@Override
 		public void write (Kryo kryo, Output out, YearMonth obj) {
 			out.writeVarInt(obj.getYear(), true);
 			out.writeByte(obj.getMonthValue());
 		}
 
+		@Override
 		public YearMonth read (Kryo kryo, Input in, Class type) {
 			int year = in.readInt(true);
 			byte month = in.readByte();
@@ -294,11 +318,13 @@ public final class TimeSerializers {
 	}
 
 	static public class MonthDaySerializer extends ImmutableSerializer<MonthDay> {
+		@Override
 		public void write (Kryo kryo, Output out, MonthDay obj) {
 			out.writeByte(obj.getMonthValue());
 			out.writeByte(obj.getDayOfMonth());
 		}
 
+		@Override
 		public MonthDay read (Kryo kryo, Input in, Class type) {
 			byte month = in.readByte();
 			byte day = in.readByte();
@@ -307,12 +333,14 @@ public final class TimeSerializers {
 	}
 
 	static public class PeriodSerializer extends ImmutableSerializer<Period> {
+		@Override
 		public void write (Kryo kryo, Output out, Period obj) {
 			out.writeVarInt(obj.getYears(), true);
 			out.writeVarInt(obj.getMonths(), true);
 			out.writeVarInt(obj.getDays(), true);
 		}
 
+		@Override
 		public Period read (Kryo kryo, Input in, Class type) {
 			int years = in.readInt(true);
 			int months = in.readInt(true);

--- a/src/com/esotericsoftware/kryo/serializers/UnsafeField.java
+++ b/src/com/esotericsoftware/kryo/serializers/UnsafeField.java
@@ -38,14 +38,17 @@ class UnsafeField extends ReflectField {
 		offset = unsafe.objectFieldOffset(field);
 	}
 
+	@Override
 	public Object get (Object object) throws IllegalAccessException {
 		return unsafe.getObject(object, offset);
 	}
 
+	@Override
 	public void set (Object object, Object value) throws IllegalAccessException {
 		unsafe.putObject(object, offset, value);
 	}
 
+	@Override
 	public void copy (Object original, Object copy) {
 		try {
 			unsafe.putObject(copy, offset, fieldSerializer.kryo.copy(unsafe.getObject(original, offset)));
@@ -65,6 +68,7 @@ class UnsafeField extends ReflectField {
 			offset = unsafe.objectFieldOffset(field);
 		}
 
+		@Override
 		public void write (Output output, Object object) {
 			if (varEncoding)
 				output.writeVarInt(unsafe.getInt(object, offset), false);
@@ -72,6 +76,7 @@ class UnsafeField extends ReflectField {
 				output.writeInt(unsafe.getInt(object, offset));
 		}
 
+		@Override
 		public void read (Input input, Object object) {
 			if (varEncoding)
 				unsafe.putInt(object, offset, input.readVarInt(false));
@@ -79,6 +84,7 @@ class UnsafeField extends ReflectField {
 				unsafe.putInt(object, offset, input.readInt());
 		}
 
+		@Override
 		public void copy (Object original, Object copy) {
 			unsafe.putInt(copy, offset, unsafe.getInt(original, offset));
 		}
@@ -90,14 +96,17 @@ class UnsafeField extends ReflectField {
 			offset = unsafe.objectFieldOffset(field);
 		}
 
+		@Override
 		public void write (Output output, Object object) {
 			output.writeFloat(unsafe.getFloat(object, offset));
 		}
 
+		@Override
 		public void read (Input input, Object object) {
 			unsafe.putFloat(object, offset, input.readFloat());
 		}
 
+		@Override
 		public void copy (Object original, Object copy) {
 			unsafe.putFloat(copy, offset, unsafe.getFloat(original, offset));
 		}
@@ -109,14 +118,17 @@ class UnsafeField extends ReflectField {
 			offset = unsafe.objectFieldOffset(field);
 		}
 
+		@Override
 		public void write (Output output, Object object) {
 			output.writeShort(unsafe.getShort(object, offset));
 		}
 
+		@Override
 		public void read (Input input, Object object) {
 			unsafe.putShort(object, offset, input.readShort());
 		}
 
+		@Override
 		public void copy (Object original, Object copy) {
 			unsafe.putShort(copy, offset, unsafe.getShort(original, offset));
 		}
@@ -128,14 +140,17 @@ class UnsafeField extends ReflectField {
 			offset = unsafe.objectFieldOffset(field);
 		}
 
+		@Override
 		public void write (Output output, Object object) {
 			output.writeByte(unsafe.getByte(object, offset));
 		}
 
+		@Override
 		public void read (Input input, Object object) {
 			unsafe.putByte(object, offset, input.readByte());
 		}
 
+		@Override
 		public void copy (Object original, Object copy) {
 			unsafe.putByte(copy, offset, unsafe.getByte(original, offset));
 		}
@@ -147,14 +162,17 @@ class UnsafeField extends ReflectField {
 			offset = unsafe.objectFieldOffset(field);
 		}
 
+		@Override
 		public void write (Output output, Object object) {
 			output.writeBoolean(unsafe.getBoolean(object, offset));
 		}
 
+		@Override
 		public void read (Input input, Object object) {
 			unsafe.putBoolean(object, offset, input.readBoolean());
 		}
 
+		@Override
 		public void copy (Object original, Object copy) {
 			unsafe.putBoolean(copy, offset, unsafe.getBoolean(original, offset));
 		}
@@ -166,14 +184,17 @@ class UnsafeField extends ReflectField {
 			offset = unsafe.objectFieldOffset(field);
 		}
 
+		@Override
 		public void write (Output output, Object object) {
 			output.writeChar(unsafe.getChar(object, offset));
 		}
 
+		@Override
 		public void read (Input input, Object object) {
 			unsafe.putChar(object, offset, input.readChar());
 		}
 
+		@Override
 		public void copy (Object original, Object copy) {
 			unsafe.putChar(copy, offset, unsafe.getChar(original, offset));
 		}
@@ -185,6 +206,7 @@ class UnsafeField extends ReflectField {
 			offset = unsafe.objectFieldOffset(field);
 		}
 
+		@Override
 		public void write (Output output, Object object) {
 			if (varEncoding)
 				output.writeVarLong(unsafe.getLong(object, offset), false);
@@ -192,6 +214,7 @@ class UnsafeField extends ReflectField {
 				output.writeLong(unsafe.getLong(object, offset));
 		}
 
+		@Override
 		public void read (Input input, Object object) {
 			if (varEncoding)
 				unsafe.putLong(object, offset, input.readVarLong(false));
@@ -199,6 +222,7 @@ class UnsafeField extends ReflectField {
 				unsafe.putLong(object, offset, input.readLong());
 		}
 
+		@Override
 		public void copy (Object original, Object copy) {
 			unsafe.putLong(copy, offset, unsafe.getLong(original, offset));
 		}
@@ -210,14 +234,17 @@ class UnsafeField extends ReflectField {
 			offset = unsafe.objectFieldOffset(field);
 		}
 
+		@Override
 		public void write (Output output, Object object) {
 			output.writeDouble(unsafe.getDouble(object, offset));
 		}
 
+		@Override
 		public void read (Input input, Object object) {
 			unsafe.putDouble(object, offset, input.readDouble());
 		}
 
+		@Override
 		public void copy (Object original, Object copy) {
 			unsafe.putDouble(copy, offset, unsafe.getDouble(original, offset));
 		}
@@ -229,14 +256,17 @@ class UnsafeField extends ReflectField {
 			offset = unsafe.objectFieldOffset(field);
 		}
 
+		@Override
 		public void write (Output output, Object object) {
 			output.writeString((String)unsafe.getObject(object, offset));
 		}
 
+		@Override
 		public void read (Input input, Object object) {
 			unsafe.putObject(object, offset, input.readString());
 		}
 
+		@Override
 		public void copy (Object original, Object copy) {
 			unsafe.putObject(copy, offset, unsafe.getObject(original, offset));
 		}

--- a/src/com/esotericsoftware/kryo/serializers/VersionFieldSerializer.java
+++ b/src/com/esotericsoftware/kryo/serializers/VersionFieldSerializer.java
@@ -61,6 +61,7 @@ public class VersionFieldSerializer<T> extends FieldSerializer<T> {
 		initializeCachedFields();
 	}
 
+	@Override
 	protected void initializeCachedFields () {
 		CachedField[] fields = cachedFields.fields;
 		fieldVersion = new int[fields.length];
@@ -78,16 +79,19 @@ public class VersionFieldSerializer<T> extends FieldSerializer<T> {
 		if (DEBUG) debug("Version for type " + getType().getName() + ": " + typeVersion);
 	}
 
+	@Override
 	public void removeField (String fieldName) {
 		super.removeField(fieldName);
 		initializeCachedFields();
 	}
 
+	@Override
 	public void removeField (CachedField field) {
 		super.removeField(field);
 		initializeCachedFields();
 	}
 
+	@Override
 	public void write (Kryo kryo, Output output, T object) {
 		if (object == null) {
 			output.writeByte(NULL);
@@ -108,6 +112,7 @@ public class VersionFieldSerializer<T> extends FieldSerializer<T> {
 		if (pop > 0) popTypeVariables(pop);
 	}
 
+	@Override
 	public T read (Kryo kryo, Input input, Class<? extends T> type) {
 		int version = input.readVarInt(true);
 		if (version == NULL) return null;
@@ -151,6 +156,7 @@ public class VersionFieldSerializer<T> extends FieldSerializer<T> {
 	static public class VersionFieldSerializerConfig extends FieldSerializerConfig {
 		boolean compatible = true;
 
+		@Override
 		public VersionFieldSerializerConfig clone () {
 			return (VersionFieldSerializerConfig)super.clone(); // Clone is ok as we have only primitive fields.
 		}

--- a/src/com/esotericsoftware/kryo/unsafe/UnsafeByteBufferInput.java
+++ b/src/com/esotericsoftware/kryo/unsafe/UnsafeByteBufferInput.java
@@ -93,6 +93,7 @@ public class UnsafeByteBufferInput extends ByteBufferInput {
 		updateBufferAddress();
 	}
 
+	@Override
 	public void setBuffer (ByteBuffer buffer) {
 		if (!(buffer instanceof DirectBuffer)) throw new IllegalArgumentException("buffer must be direct.");
 		if (buffer != byteBuffer) UnsafeUtil.dispose(byteBuffer);
@@ -108,6 +109,7 @@ public class UnsafeByteBufferInput extends ByteBufferInput {
 		buffer.position(position);
 	}
 
+	@Override
 	public int read () throws KryoException {
 		if (optional(1) <= 0) return -1;
 		int result = unsafe.getByte(bufferAddress + position++) & 0xFF;
@@ -115,6 +117,7 @@ public class UnsafeByteBufferInput extends ByteBufferInput {
 		return result;
 	}
 
+	@Override
 	public byte readByte () throws KryoException {
 		if (position == limit) require(1);
 		byte result = unsafe.getByte(bufferAddress + position++);
@@ -122,6 +125,7 @@ public class UnsafeByteBufferInput extends ByteBufferInput {
 		return result;
 	}
 
+	@Override
 	public int readByteUnsigned () throws KryoException {
 		if (position == limit) require(1);
 		int result = unsafe.getByte(bufferAddress + position++) & 0xFF;
@@ -129,6 +133,7 @@ public class UnsafeByteBufferInput extends ByteBufferInput {
 		return result;
 	}
 
+	@Override
 	public int readInt () throws KryoException {
 		require(4);
 		int result = unsafe.getInt(bufferAddress + position);
@@ -137,6 +142,7 @@ public class UnsafeByteBufferInput extends ByteBufferInput {
 		return result;
 	}
 
+	@Override
 	public long readLong () throws KryoException {
 		require(8);
 		long result = unsafe.getLong(bufferAddress + position);
@@ -145,6 +151,7 @@ public class UnsafeByteBufferInput extends ByteBufferInput {
 		return result;
 	}
 
+	@Override
 	public float readFloat () throws KryoException {
 		require(4);
 		float result = unsafe.getFloat(bufferAddress + position);
@@ -153,6 +160,7 @@ public class UnsafeByteBufferInput extends ByteBufferInput {
 		return result;
 	}
 
+	@Override
 	public double readDouble () throws KryoException {
 		require(8);
 		double result = unsafe.getDouble(bufferAddress + position);
@@ -161,6 +169,7 @@ public class UnsafeByteBufferInput extends ByteBufferInput {
 		return result;
 	}
 
+	@Override
 	public short readShort () throws KryoException {
 		require(2);
 		short result = unsafe.getShort(bufferAddress + position);
@@ -169,6 +178,7 @@ public class UnsafeByteBufferInput extends ByteBufferInput {
 		return result;
 	}
 
+	@Override
 	public char readChar () throws KryoException {
 		require(2);
 		char result = unsafe.getChar(bufferAddress + position);
@@ -177,6 +187,7 @@ public class UnsafeByteBufferInput extends ByteBufferInput {
 		return result;
 	}
 
+	@Override
 	public boolean readBoolean () throws KryoException {
 		if (position == limit) require(1);
 		boolean result = unsafe.getByte(bufferAddress + position++) != 0;
@@ -184,48 +195,56 @@ public class UnsafeByteBufferInput extends ByteBufferInput {
 		return result;
 	}
 
+	@Override
 	public int[] readInts (int length) throws KryoException {
 		int[] array = new int[length];
 		readBytes(array, intArrayBaseOffset, length << 2);
 		return array;
 	}
 
+	@Override
 	public long[] readLongs (int length) throws KryoException {
 		long[] array = new long[length];
 		readBytes(array, longArrayBaseOffset, length << 3);
 		return array;
 	}
 
+	@Override
 	public float[] readFloats (int length) throws KryoException {
 		float[] array = new float[length];
 		readBytes(array, floatArrayBaseOffset, length << 2);
 		return array;
 	}
 
+	@Override
 	public double[] readDoubles (int length) throws KryoException {
 		double[] array = new double[length];
 		readBytes(array, doubleArrayBaseOffset, length << 3);
 		return array;
 	}
 
+	@Override
 	public short[] readShorts (int length) throws KryoException {
 		short[] array = new short[length];
 		readBytes(array, shortArrayBaseOffset, length << 1);
 		return array;
 	}
 
+	@Override
 	public char[] readChars (int length) throws KryoException {
 		char[] array = new char[length];
 		readBytes(array, charArrayBaseOffset, length << 1);
 		return array;
 	}
 
+	@Override
 	public boolean[] readBooleans (int length) throws KryoException {
 		boolean[] array = new boolean[length];
 		readBytes(array, booleanArrayBaseOffset, length);
 		return array;
 	}
 
+	@Override
 	public void readBytes (byte[] bytes, int offset, int count) throws KryoException {
 		readBytes(bytes, byteArrayBaseOffset + offset, count);
 	}

--- a/src/com/esotericsoftware/kryo/unsafe/UnsafeByteBufferOutput.java
+++ b/src/com/esotericsoftware/kryo/unsafe/UnsafeByteBufferOutput.java
@@ -85,6 +85,7 @@ public class UnsafeByteBufferOutput extends ByteBufferOutput {
 		updateBufferAddress();
 	}
 
+	@Override
 	public void setBuffer (ByteBuffer buffer, int maxBufferSize) {
 		if (!(buffer instanceof DirectBuffer)) throw new IllegalArgumentException("buffer must be direct.");
 		if (buffer != byteBuffer) UnsafeUtil.dispose(byteBuffer);
@@ -96,6 +97,7 @@ public class UnsafeByteBufferOutput extends ByteBufferOutput {
 		bufferAddress = ((DirectBuffer)byteBuffer).address();
 	}
 
+	@Override
 	protected boolean require (int required) throws KryoException {
 		ByteBuffer oldBuffer = byteBuffer;
 		boolean result = super.require(required);
@@ -118,24 +120,28 @@ public class UnsafeByteBufferOutput extends ByteBufferOutput {
 		buffer.position(position);
 	}
 
+	@Override
 	public void write (int value) throws KryoException {
 		if (position == capacity) require(1);
 		unsafe.putByte(bufferAddress + position++, (byte)value);
 		setBufferPosition(byteBuffer, position);
 	}
 
+	@Override
 	public void writeByte (byte value) throws KryoException {
 		if (position == capacity) require(1);
 		unsafe.putByte(bufferAddress + position++, value);
 		setBufferPosition(byteBuffer, position);
 	}
 
+	@Override
 	public void writeByte (int value) throws KryoException {
 		if (position == capacity) require(1);
 		unsafe.putByte(bufferAddress + position++, (byte)value);
 		setBufferPosition(byteBuffer, position);
 	}
 
+	@Override
 	public void writeInt (int value) throws KryoException {
 		require(4);
 		unsafe.putInt(bufferAddress + position, value);
@@ -143,6 +149,7 @@ public class UnsafeByteBufferOutput extends ByteBufferOutput {
 		setBufferPosition(byteBuffer, position);
 	}
 
+	@Override
 	public void writeLong (long value) throws KryoException {
 		require(8);
 		unsafe.putLong(bufferAddress + position, value);
@@ -150,6 +157,7 @@ public class UnsafeByteBufferOutput extends ByteBufferOutput {
 		setBufferPosition(byteBuffer, position);
 	}
 
+	@Override
 	public void writeFloat (float value) throws KryoException {
 		require(4);
 		unsafe.putFloat(bufferAddress + position, value);
@@ -157,6 +165,7 @@ public class UnsafeByteBufferOutput extends ByteBufferOutput {
 		setBufferPosition(byteBuffer, position);
 	}
 
+	@Override
 	public void writeDouble (double value) throws KryoException {
 		require(8);
 		unsafe.putDouble(bufferAddress + position, value);
@@ -164,6 +173,7 @@ public class UnsafeByteBufferOutput extends ByteBufferOutput {
 		setBufferPosition(byteBuffer, position);
 	}
 
+	@Override
 	public void writeShort (int value) throws KryoException {
 		require(2);
 		unsafe.putShort(bufferAddress + position, (short)value);
@@ -171,6 +181,7 @@ public class UnsafeByteBufferOutput extends ByteBufferOutput {
 		setBufferPosition(byteBuffer, position);
 	}
 
+	@Override
 	public void writeChar (char value) throws KryoException {
 		require(2);
 		unsafe.putChar(bufferAddress + position, value);
@@ -178,40 +189,49 @@ public class UnsafeByteBufferOutput extends ByteBufferOutput {
 		setBufferPosition(byteBuffer, position);
 	}
 
+	@Override
 	public void writeBoolean (boolean value) throws KryoException {
 		if (position == capacity) require(1);
 		unsafe.putByte(bufferAddress + position++, value ? (byte)1 : 0);
 		setBufferPosition(byteBuffer, position);
 	}
 
+	@Override
 	public void writeInts (int[] array, int offset, int count) throws KryoException {
 		writeBytes(array, intArrayBaseOffset, array.length << 2);
 	}
 
+	@Override
 	public void writeLongs (long[] array, int offset, int count) throws KryoException {
 		writeBytes(array, longArrayBaseOffset, array.length << 3);
 	}
 
+	@Override
 	public void writeFloats (float[] array, int offset, int count) throws KryoException {
 		writeBytes(array, floatArrayBaseOffset, array.length << 2);
 	}
 
+	@Override
 	public void writeDoubles (double[] array, int offset, int count) throws KryoException {
 		writeBytes(array, doubleArrayBaseOffset, array.length << 3);
 	}
 
+	@Override
 	public void writeShorts (short[] array, int offset, int count) throws KryoException {
 		writeBytes(array, shortArrayBaseOffset, array.length << 1);
 	}
 
+	@Override
 	public void writeChars (char[] array, int offset, int count) throws KryoException {
 		writeBytes(array, charArrayBaseOffset, array.length << 1);
 	}
 
+	@Override
 	public void writeBooleans (boolean[] array, int offset, int count) throws KryoException {
 		writeBytes(array, booleanArrayBaseOffset, array.length);
 	}
 
+	@Override
 	public void writeBytes (byte[] array, int offset, int count) throws KryoException {
 		writeBytes(array, byteArrayBaseOffset + offset, count);
 	}

--- a/src/com/esotericsoftware/kryo/unsafe/UnsafeInput.java
+++ b/src/com/esotericsoftware/kryo/unsafe/UnsafeInput.java
@@ -72,21 +72,25 @@ public class UnsafeInput extends Input {
 		super(inputStream, bufferSize);
 	}
 
+	@Override
 	public int read () throws KryoException {
 		if (optional(1) <= 0) return -1;
 		return unsafe.getByte(buffer, byteArrayBaseOffset + position++) & 0xFF;
 	}
 
+	@Override
 	public byte readByte () throws KryoException {
 		if (position == limit) require(1);
 		return unsafe.getByte(buffer, byteArrayBaseOffset + position++);
 	}
 
+	@Override
 	public int readByteUnsigned () throws KryoException {
 		if (position == limit) require(1);
 		return unsafe.getByte(buffer, byteArrayBaseOffset + position++) & 0xFF;
 	}
 
+	@Override
 	public int readInt () throws KryoException {
 		require(4);
 		int result = unsafe.getInt(buffer, byteArrayBaseOffset + position);
@@ -94,6 +98,7 @@ public class UnsafeInput extends Input {
 		return result;
 	}
 
+	@Override
 	public long readLong () throws KryoException {
 		require(8);
 		long result = unsafe.getLong(buffer, byteArrayBaseOffset + position);
@@ -101,6 +106,7 @@ public class UnsafeInput extends Input {
 		return result;
 	}
 
+	@Override
 	public float readFloat () throws KryoException {
 		require(4);
 		float result = unsafe.getFloat(buffer, byteArrayBaseOffset + position);
@@ -108,6 +114,7 @@ public class UnsafeInput extends Input {
 		return result;
 	}
 
+	@Override
 	public double readDouble () throws KryoException {
 		require(8);
 		double result = unsafe.getDouble(buffer, byteArrayBaseOffset + position);
@@ -115,6 +122,7 @@ public class UnsafeInput extends Input {
 		return result;
 	}
 
+	@Override
 	public short readShort () throws KryoException {
 		require(2);
 		short result = unsafe.getShort(buffer, byteArrayBaseOffset + position);
@@ -122,6 +130,7 @@ public class UnsafeInput extends Input {
 		return result;
 	}
 
+	@Override
 	public char readChar () throws KryoException {
 		require(2);
 		char result = unsafe.getChar(buffer, byteArrayBaseOffset + position);
@@ -129,54 +138,63 @@ public class UnsafeInput extends Input {
 		return result;
 	}
 
+	@Override
 	public boolean readBoolean () throws KryoException {
 		if (position == limit) require(1);
 		boolean result = unsafe.getByte(buffer, byteArrayBaseOffset + position++) != 0;
 		return result;
 	}
 
+	@Override
 	public int[] readInts (int length) throws KryoException {
 		int[] array = new int[length];
 		readBytes(array, intArrayBaseOffset, length << 2);
 		return array;
 	}
 
+	@Override
 	public long[] readLongs (int length) throws KryoException {
 		long[] array = new long[length];
 		readBytes(array, longArrayBaseOffset, length << 3);
 		return array;
 	}
 
+	@Override
 	public float[] readFloats (int length) throws KryoException {
 		float[] array = new float[length];
 		readBytes(array, floatArrayBaseOffset, length << 2);
 		return array;
 	}
 
+	@Override
 	public double[] readDoubles (int length) throws KryoException {
 		double[] array = new double[length];
 		readBytes(array, doubleArrayBaseOffset, length << 3);
 		return array;
 	}
 
+	@Override
 	public short[] readShorts (int length) throws KryoException {
 		short[] array = new short[length];
 		readBytes(array, shortArrayBaseOffset, length << 1);
 		return array;
 	}
 
+	@Override
 	public char[] readChars (int length) throws KryoException {
 		char[] array = new char[length];
 		readBytes(array, charArrayBaseOffset, length << 1);
 		return array;
 	}
 
+	@Override
 	public boolean[] readBooleans (int length) throws KryoException {
 		boolean[] array = new boolean[length];
 		readBytes(array, booleanArrayBaseOffset, length);
 		return array;
 	}
 
+	@Override
 	public void readBytes (byte[] bytes, int offset, int count) throws KryoException {
 		readBytes(bytes, byteArrayBaseOffset + offset, count);
 	}

--- a/src/com/esotericsoftware/kryo/unsafe/UnsafeOutput.java
+++ b/src/com/esotericsoftware/kryo/unsafe/UnsafeOutput.java
@@ -78,90 +78,108 @@ public class UnsafeOutput extends Output {
 		super(outputStream, bufferSize);
 	}
 
+	@Override
 	public void write (int value) throws KryoException {
 		if (position == capacity) require(1);
 		unsafe.putByte(buffer, byteArrayBaseOffset + position++, (byte)value);
 	}
 
+	@Override
 	public void writeByte (byte value) throws KryoException {
 		if (position == capacity) require(1);
 		unsafe.putByte(buffer, byteArrayBaseOffset + position++, value);
 	}
 
+	@Override
 	public void writeByte (int value) throws KryoException {
 		if (position == capacity) require(1);
 		unsafe.putByte(buffer, byteArrayBaseOffset + position++, (byte)value);
 	}
 
+	@Override
 	public void writeInt (int value) throws KryoException {
 		require(4);
 		unsafe.putInt(buffer, byteArrayBaseOffset + position, value);
 		position += 4;
 	}
 
+	@Override
 	public void writeLong (long value) throws KryoException {
 		require(8);
 		unsafe.putLong(buffer, byteArrayBaseOffset + position, value);
 		position += 8;
 	}
 
+	@Override
 	public void writeFloat (float value) throws KryoException {
 		require(4);
 		unsafe.putFloat(buffer, byteArrayBaseOffset + position, value);
 		position += 4;
 	}
 
+	@Override
 	public void writeDouble (double value) throws KryoException {
 		require(8);
 		unsafe.putDouble(buffer, byteArrayBaseOffset + position, value);
 		position += 8;
 	}
 
+	@Override
 	public void writeShort (int value) throws KryoException {
 		require(2);
 		unsafe.putShort(buffer, byteArrayBaseOffset + position, (short)value);
 		position += 2;
 	}
 
+	@Override
 	public void writeChar (char value) throws KryoException {
 		require(2);
 		unsafe.putChar(buffer, byteArrayBaseOffset + position, value);
 		position += 2;
 	}
 
+	@Override
 	public void writeBoolean (boolean value) throws KryoException {
 		if (position == capacity) require(1);
 		unsafe.putByte(buffer, byteArrayBaseOffset + position++, value ? (byte)1 : 0);
 	}
 
+	@Override
 	public void writeInts (int[] array, int offset, int count) throws KryoException {
 		writeBytes(array, intArrayBaseOffset, array.length << 2);
 	}
 
+	@Override
 	public void writeLongs (long[] array, int offset, int count) throws KryoException {
 		writeBytes(array, longArrayBaseOffset, array.length << 3);
 	}
 
+	@Override
 	public void writeFloats (float[] array, int offset, int count) throws KryoException {
 		writeBytes(array, floatArrayBaseOffset, array.length << 2);
 	}
 
+	@Override
 	public void writeDoubles (double[] array, int offset, int count) throws KryoException {
 		writeBytes(array, doubleArrayBaseOffset, array.length << 3);
 	}
 
+	@Override
 	public void writeShorts (short[] array, int offset, int count) throws KryoException {
 		writeBytes(array, shortArrayBaseOffset, array.length << 1);
 	}
 
+	@Override
 	public void writeChars (char[] array, int offset, int count) throws KryoException {
 		writeBytes(array, charArrayBaseOffset, array.length << 1);
 	}
 
+	@Override
 	public void writeBooleans (boolean[] array, int offset, int count) throws KryoException {
 		writeBytes(array, booleanArrayBaseOffset, array.length);
 	}
 
+	@Override
 	public void writeBytes (byte[] array, int offset, int count) throws KryoException {
 		writeBytes(array, byteArrayBaseOffset + offset, count);
 	}

--- a/src/com/esotericsoftware/kryo/util/DefaultClassResolver.java
+++ b/src/com/esotericsoftware/kryo/util/DefaultClassResolver.java
@@ -49,10 +49,12 @@ public class DefaultClassResolver implements ClassResolver {
 	private Class memoizedClass;
 	private Registration memoizedClassValue;
 
+	@Override
 	public void setKryo (Kryo kryo) {
 		this.kryo = kryo;
 	}
 
+	@Override
 	public Registration register (Registration registration) {
 		memoizedClassId = -1;
 		memoizedClass = null;
@@ -73,6 +75,7 @@ public class DefaultClassResolver implements ClassResolver {
 		return registration;
 	}
 
+	@Override
 	public Registration unregister (int classID) {
 		Registration registration = idToRegistration.remove(classID);
 		if (registration != null) {
@@ -85,10 +88,12 @@ public class DefaultClassResolver implements ClassResolver {
 		return registration;
 	}
 
+	@Override
 	public Registration registerImplicit (Class type) {
 		return register(new Registration(type, kryo.getDefaultSerializer(type), NAME));
 	}
 
+	@Override
 	public Registration getRegistration (Class type) {
 		if (type == memoizedClass) return memoizedClassValue;
 		Registration registration = classToRegistration.get(type);
@@ -99,10 +104,12 @@ public class DefaultClassResolver implements ClassResolver {
 		return registration;
 	}
 
+	@Override
 	public Registration getRegistration (int classID) {
 		return idToRegistration.get(classID);
 	}
 
+	@Override
 	public Registration writeClass (Output output, Class type) {
 		if (type == null) {
 			if (TRACE || (DEBUG && kryo.getDepth() == 1)) log("Write", null, output.position());
@@ -141,6 +148,7 @@ public class DefaultClassResolver implements ClassResolver {
 			output.writeString(type.getName());
 	}
 
+	@Override
 	public Registration readClass (Input input) {
 		int classID = input.readVarInt(true);
 		switch (classID) {
@@ -197,6 +205,7 @@ public class DefaultClassResolver implements ClassResolver {
 		return nameToClass != null ? nameToClass.get(className) : null;
 	}
 
+	@Override
 	public void reset () {
 		if (!kryo.isRegistrationRequired()) {
 			if (classToNameId != null) classToNameId.clear(2048);

--- a/src/com/esotericsoftware/kryo/util/DefaultInstantiatorStrategy.java
+++ b/src/com/esotericsoftware/kryo/util/DefaultInstantiatorStrategy.java
@@ -48,6 +48,7 @@ public class DefaultInstantiatorStrategy implements org.objenesis.strategy.Insta
 		return fallbackStrategy;
 	}
 
+	@Override
 	public ObjectInstantiator newInstantiatorOf (final Class type) {
 		if (!Util.isAndroid) {
 			// Use ReflectASM if the class is not a non-static member class.
@@ -58,6 +59,7 @@ public class DefaultInstantiatorStrategy implements org.objenesis.strategy.Insta
 				try {
 					final ConstructorAccess access = ConstructorAccess.get(type);
 					return new ObjectInstantiator() {
+						@Override
 						public Object newInstance () {
 							try {
 								return access.newInstance();
@@ -82,6 +84,7 @@ public class DefaultInstantiatorStrategy implements org.objenesis.strategy.Insta
 			}
 			final Constructor constructor = ctor;
 			return new ObjectInstantiator() {
+				@Override
 				public Object newInstance () {
 					try {
 						return constructor.newInstance();

--- a/src/com/esotericsoftware/kryo/util/Generics.java
+++ b/src/com/esotericsoftware/kryo/util/Generics.java
@@ -124,6 +124,7 @@ public interface Generics {
 			this.parameters = parameters.toArray(new TypeVariable[parameters.size()]);
 		}
 
+		@Override
 		public String toString () {
 			StringBuilder buffer = new StringBuilder();
 			buffer.append("[");

--- a/src/com/esotericsoftware/kryo/util/HashMapReferenceResolver.java
+++ b/src/com/esotericsoftware/kryo/util/HashMapReferenceResolver.java
@@ -34,42 +34,50 @@ public class HashMapReferenceResolver implements ReferenceResolver {
 	protected final IdentityHashMap<Object, Integer> writtenObjects = new IdentityHashMap();
 	protected final ArrayList readObjects = new ArrayList();
 
+	@Override
 	public void setKryo (Kryo kryo) {
 		this.kryo = kryo;
 	}
 
+	@Override
 	public int addWrittenObject (Object object) {
 		int id = writtenObjects.size();
 		writtenObjects.put(object, id);
 		return id;
 	}
 
+	@Override
 	public int getWrittenId (Object object) {
 		Integer id = writtenObjects.get(object);
 		if (id == null) return -1;
 		return id;
 	}
 
+	@Override
 	public int nextReadId (Class type) {
 		int id = readObjects.size();
 		readObjects.add(null);
 		return id;
 	}
 
+	@Override
 	public void setReadObject (int id, Object object) {
 		readObjects.set(id, object);
 	}
 
+	@Override
 	public Object getReadObject (Class type, int id) {
 		return readObjects.get(id);
 	}
 
+	@Override
 	public void reset () {
 		readObjects.clear();
 		writtenObjects.clear();
 	}
 
 	/** Returns false for all primitive wrappers and enums. */
+	@Override
 	public boolean useReferences (Class type) {
 		return !Util.isWrapperClass(type) && !Util.isEnum(type);
 	}

--- a/src/com/esotericsoftware/kryo/util/IdentityMap.java
+++ b/src/com/esotericsoftware/kryo/util/IdentityMap.java
@@ -58,10 +58,12 @@ public class IdentityMap<K, V> extends ObjectMap<K, V> {
 		super(map);
 	}
 
+	@Override
 	protected int place (K item) {
 		return (int)(System.identityHashCode(item) * 0x9E3779B97F4A7C15L >>> shift);
 	}
 
+	@Override
 	int locateKey (K key) {
 		if (key == null) throw new IllegalArgumentException("key cannot be null.");
 		K[] keyTable = this.keyTable;
@@ -72,6 +74,7 @@ public class IdentityMap<K, V> extends ObjectMap<K, V> {
 		}
 	}
 
+	@Override
 	public int hashCode () {
 		int h = size;
 		K[] keyTable = this.keyTable;

--- a/src/com/esotericsoftware/kryo/util/IdentityObjectIntMap.java
+++ b/src/com/esotericsoftware/kryo/util/IdentityObjectIntMap.java
@@ -58,10 +58,12 @@ public class IdentityObjectIntMap<K> extends ObjectIntMap<K> {
 		super(map);
 	}
 
+	@Override
 	protected int place (K item) {
 		return (int)(System.identityHashCode(item) * 0x9E3779B97F4A7C15L >>> shift);
 	}
 
+	@Override
 	int locateKey (K key) {
 		if (key == null) throw new IllegalArgumentException("key cannot be null.");
 		K[] keyTable = this.keyTable;

--- a/src/com/esotericsoftware/kryo/util/IntMap.java
+++ b/src/com/esotericsoftware/kryo/util/IntMap.java
@@ -442,6 +442,7 @@ public class IntMap<V> implements Iterable<IntMap.Entry<V>> {
 		return buffer.toString();
 	}
 
+	@Override
 	public Iterator<Entry<V>> iterator () {
 		return entries();
 	}
@@ -540,6 +541,7 @@ public class IntMap<V> implements Iterable<IntMap.Entry<V>> {
 		}
 
 		/** Note the same entry instance is returned each time this method is called. */
+		@Override
 		public Entry<V> next () {
 			if (!hasNext) throw new NoSuchElementException();
 			if (!valid) throw new KryoException("#iterator() cannot be used nested.");
@@ -556,11 +558,13 @@ public class IntMap<V> implements Iterable<IntMap.Entry<V>> {
 			return entry;
 		}
 
+		@Override
 		public boolean hasNext () {
 			if (!valid) throw new KryoException("#iterator() cannot be used nested.");
 			return hasNext;
 		}
 
+		@Override
 		public Iterator<Entry<V>> iterator () {
 			return this;
 		}
@@ -571,10 +575,12 @@ public class IntMap<V> implements Iterable<IntMap.Entry<V>> {
 			super(map);
 		}
 
+		@Override
 		public boolean hasNext () {
 			return hasNext;
 		}
 
+		@Override
 		@Null
 		public V next () {
 			if (!hasNext) throw new NoSuchElementException();
@@ -588,6 +594,7 @@ public class IntMap<V> implements Iterable<IntMap.Entry<V>> {
 			return value;
 		}
 
+		@Override
 		public Iterator<V> iterator () {
 			return this;
 		}

--- a/src/com/esotericsoftware/kryo/util/ListReferenceResolver.java
+++ b/src/com/esotericsoftware/kryo/util/ListReferenceResolver.java
@@ -33,41 +33,49 @@ public class ListReferenceResolver implements ReferenceResolver {
 	protected Kryo kryo;
 	protected final ArrayList seenObjects = new ArrayList();
 
+	@Override
 	public void setKryo (Kryo kryo) {
 		this.kryo = kryo;
 	}
 
+	@Override
 	public int addWrittenObject (Object object) {
 		int id = seenObjects.size();
 		seenObjects.add(object);
 		return id;
 	}
 
+	@Override
 	public int getWrittenId (Object object) {
 		for (int i = 0, n = seenObjects.size(); i < n; i++)
 			if (seenObjects.get(i) == object) return i;
 		return -1;
 	}
 
+	@Override
 	public int nextReadId (Class type) {
 		int id = seenObjects.size();
 		seenObjects.add(null);
 		return id;
 	}
 
+	@Override
 	public void setReadObject (int id, Object object) {
 		seenObjects.set(id, object);
 	}
 
+	@Override
 	public Object getReadObject (Class type, int id) {
 		return seenObjects.get(id);
 	}
 
+	@Override
 	public void reset () {
 		seenObjects.clear();
 	}
 
 	/** Returns false for all primitive wrappers and enums. */
+	@Override
 	public boolean useReferences (Class type) {
 		return !Util.isWrapperClass(type) && !Util.isEnum(type);
 	}

--- a/src/com/esotericsoftware/kryo/util/MapReferenceResolver.java
+++ b/src/com/esotericsoftware/kryo/util/MapReferenceResolver.java
@@ -46,34 +46,41 @@ public class MapReferenceResolver implements ReferenceResolver {
 		this.maximumCapacity = maximumCapacity;
 	}
 
+	@Override
 	public void setKryo (Kryo kryo) {
 		this.kryo = kryo;
 	}
 
+	@Override
 	public int addWrittenObject (Object object) {
 		int id = writtenObjects.size;
 		writtenObjects.put(object, id);
 		return id;
 	}
 
+	@Override
 	public int getWrittenId (Object object) {
 		return writtenObjects.get(object, -1);
 	}
 
+	@Override
 	public int nextReadId (Class type) {
 		int id = readObjects.size();
 		readObjects.add(null);
 		return id;
 	}
 
+	@Override
 	public void setReadObject (int id, Object object) {
 		readObjects.set(id, object);
 	}
 
+	@Override
 	public Object getReadObject (Class type, int id) {
 		return readObjects.get(id);
 	}
 
+	@Override
 	public void reset () {
 		final int size = readObjects.size();
 		readObjects.clear();
@@ -85,6 +92,7 @@ public class MapReferenceResolver implements ReferenceResolver {
 	}
 
 	/** Returns false for all primitive wrappers and enums. */
+	@Override
 	public boolean useReferences (Class type) {
 		return !Util.isWrapperClass(type) && !Util.isEnum(type);
 	}

--- a/src/com/esotericsoftware/kryo/util/ObjectIntMap.java
+++ b/src/com/esotericsoftware/kryo/util/ObjectIntMap.java
@@ -350,6 +350,7 @@ public class ObjectIntMap<K> implements Iterable<ObjectIntMap.Entry<K>> {
 		return buffer.toString();
 	}
 
+	@Override
 	public Entries<K> iterator () {
 		return entries();
 	}
@@ -438,6 +439,7 @@ public class ObjectIntMap<K> implements Iterable<ObjectIntMap.Entry<K>> {
 		}
 
 		/** Note the same entry instance is returned each time this method is called. */
+		@Override
 		public Entry<K> next () {
 			if (!hasNext) throw new NoSuchElementException();
 			if (!valid) throw new KryoException("#iterator() cannot be used nested.");
@@ -449,11 +451,13 @@ public class ObjectIntMap<K> implements Iterable<ObjectIntMap.Entry<K>> {
 			return entry;
 		}
 
+		@Override
 		public boolean hasNext () {
 			if (!valid) throw new KryoException("#iterator() cannot be used nested.");
 			return hasNext;
 		}
 
+		@Override
 		public Entries<K> iterator () {
 			return this;
 		}
@@ -503,11 +507,13 @@ public class ObjectIntMap<K> implements Iterable<ObjectIntMap.Entry<K>> {
 			super(map);
 		}
 
+		@Override
 		public boolean hasNext () {
 			if (!valid) throw new KryoException("#iterator() cannot be used nested.");
 			return hasNext;
 		}
 
+		@Override
 		public K next () {
 			if (!hasNext) throw new NoSuchElementException();
 			if (!valid) throw new KryoException("#iterator() cannot be used nested.");
@@ -517,6 +523,7 @@ public class ObjectIntMap<K> implements Iterable<ObjectIntMap.Entry<K>> {
 			return key;
 		}
 
+		@Override
 		public Keys<K> iterator () {
 			return this;
 		}

--- a/src/com/esotericsoftware/kryo/util/ObjectMap.java
+++ b/src/com/esotericsoftware/kryo/util/ObjectMap.java
@@ -404,6 +404,7 @@ public class ObjectMap<K, V> implements Iterable<ObjectMap.Entry<K, V>> {
 		return buffer.toString();
 	}
 
+	@Override
 	public Entries<K, V> iterator () {
 		return entries();
 	}
@@ -479,6 +480,7 @@ public class ObjectMap<K, V> implements Iterable<ObjectMap.Entry<K, V>> {
 			hasNext = false;
 		}
 
+		@Override
 		public void remove () {
 			int i = currentIndex;
 			if (i < 0) throw new IllegalStateException("next must be called before remove.");
@@ -511,6 +513,7 @@ public class ObjectMap<K, V> implements Iterable<ObjectMap.Entry<K, V>> {
 		}
 
 		/** Note the same entry instance is returned each time this method is called. */
+		@Override
 		public Entry<K, V> next () {
 			if (!hasNext) throw new NoSuchElementException();
 			K[] keyTable = map.keyTable;
@@ -521,10 +524,12 @@ public class ObjectMap<K, V> implements Iterable<ObjectMap.Entry<K, V>> {
 			return entry;
 		}
 
+		@Override
 		public boolean hasNext () {
 			return hasNext;
 		}
 
+		@Override
 		public Entries<K, V> iterator () {
 			return this;
 		}
@@ -535,10 +540,12 @@ public class ObjectMap<K, V> implements Iterable<ObjectMap.Entry<K, V>> {
 			super((ObjectMap<Object, V>)map);
 		}
 
+		@Override
 		public boolean hasNext () {
 			return hasNext;
 		}
 
+		@Override
 		@Null
 		public V next () {
 			if (!hasNext) throw new NoSuchElementException();
@@ -548,6 +555,7 @@ public class ObjectMap<K, V> implements Iterable<ObjectMap.Entry<K, V>> {
 			return value;
 		}
 
+		@Override
 		public Values<V> iterator () {
 			return this;
 		}
@@ -570,10 +578,12 @@ public class ObjectMap<K, V> implements Iterable<ObjectMap.Entry<K, V>> {
 			super((ObjectMap<K, Object>)map);
 		}
 
+		@Override
 		public boolean hasNext () {
 			return hasNext;
 		}
 
+		@Override
 		public K next () {
 			if (!hasNext) throw new NoSuchElementException();
 			K key = map.keyTable[nextIndex];
@@ -582,6 +592,7 @@ public class ObjectMap<K, V> implements Iterable<ObjectMap.Entry<K, V>> {
 			return key;
 		}
 
+		@Override
 		public Keys<K> iterator () {
 			return this;
 		}

--- a/src/com/esotericsoftware/kryo/util/Pool.java
+++ b/src/com/esotericsoftware/kryo/util/Pool.java
@@ -48,6 +48,7 @@ abstract public class Pool<T> {
 			queue = new LinkedBlockingQueue(maximumCapacity);
 		else if (softReferences) {
 			queue = new LinkedList() { // More efficient clean() than ArrayDeque.
+				@Override
 				public boolean add (Object object) {
 					if (size() >= maximumCapacity) return false;
 					super.add(object);
@@ -56,6 +57,7 @@ abstract public class Pool<T> {
 			};
 		} else {
 			queue = new ArrayDeque() {
+				@Override
 				public boolean add (Object object) {
 					if (size() >= maximumCapacity) return false;
 					super.add(object);
@@ -144,6 +146,7 @@ abstract public class Pool<T> {
 			this.delegate = delegate;
 		}
 
+		@Override
 		public T poll () {
 			while (true) {
 				SoftReference<T> reference = (SoftReference<T>)delegate.poll();
@@ -153,14 +156,17 @@ abstract public class Pool<T> {
 			}
 		}
 
+		@Override
 		public boolean offer (T e) {
 			return delegate.add(new SoftReference(e));
 		}
 
+		@Override
 		public int size () {
 			return delegate.size();
 		}
 
+		@Override
 		public void clear () {
 			delegate.clear();
 		}
@@ -179,58 +185,72 @@ abstract public class Pool<T> {
 				if (((SoftReference)iter.next()).get() == null) iter.remove();
 		}
 
+		@Override
 		public boolean add (T e) {
 			return false;
 		}
 
+		@Override
 		public boolean isEmpty () {
 			return false;
 		}
 
+		@Override
 		public boolean contains (Object o) {
 			return false;
 		}
 
+		@Override
 		public Iterator<T> iterator () {
 			return null;
 		}
 
+		@Override
 		public T remove () {
 			return null;
 		}
 
+		@Override
 		public Object[] toArray () {
 			return null;
 		}
 
+		@Override
 		public T element () {
 			return null;
 		}
 
+		@Override
 		public T peek () {
 			return null;
 		}
 
+		@Override
 		public <E> E[] toArray (E[] a) {
 			return null;
 		}
 
+		@Override
 		public boolean remove (Object o) {
 			return false;
 		}
 
+		@Override
 		public boolean containsAll (Collection c) {
 			return false;
 		}
 
+		@Override
 		public boolean addAll (Collection<? extends T> c) {
 			return false;
 		}
 
+		@Override
 		public boolean removeAll (Collection c) {
 			return false;
 		}
 
+		@Override
 		public boolean retainAll (Collection c) {
 			return false;
 		}

--- a/test/com/esotericsoftware/kryo/CopyTest.java
+++ b/test/com/esotericsoftware/kryo/CopyTest.java
@@ -27,6 +27,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class CopyTest extends KryoTestCase {
+	@Override
 	@Before
 	public void setUp () throws Exception {
 		super.setUp();

--- a/test/com/esotericsoftware/kryo/KryoTestCase.java
+++ b/test/com/esotericsoftware/kryo/KryoTestCase.java
@@ -93,22 +93,27 @@ abstract public class KryoTestCase {
 	/** @param length Pass Integer.MIN_VALUE to disable checking the length. */
 	public <T> T roundTrip (int length, T object1) {
 		T object2 = roundTripWithBufferFactory(length, object1, new BufferFactory() {
+			@Override
 			public Output createOutput (OutputStream os) {
 				return new Output(os);
 			}
 
+			@Override
 			public Output createOutput (OutputStream os, int size) {
 				return new Output(os, size);
 			}
 
+			@Override
 			public Output createOutput (int size, int limit) {
 				return new Output(size, limit);
 			}
 
+			@Override
 			public Input createInput (InputStream os, int size) {
 				return new Input(os, size);
 			}
 
+			@Override
 			public Input createInput (byte[] buffer) {
 				return new Input(buffer);
 			}
@@ -117,22 +122,27 @@ abstract public class KryoTestCase {
 		if (debug) return object2;
 
 		roundTripWithBufferFactory(length, object1, new BufferFactory() {
+			@Override
 			public Output createOutput (OutputStream os) {
 				return new ByteBufferOutput(os);
 			}
 
+			@Override
 			public Output createOutput (OutputStream os, int size) {
 				return new ByteBufferOutput(os, size);
 			}
 
+			@Override
 			public Output createOutput (int size, int limit) {
 				return new ByteBufferOutput(size, limit);
 			}
 
+			@Override
 			public Input createInput (InputStream os, int size) {
 				return new ByteBufferInput(os, size);
 			}
 
+			@Override
 			public Input createInput (byte[] buffer) {
 				ByteBuffer byteBuffer = allocateByteBuffer(buffer);
 				return new ByteBufferInput(byteBuffer);
@@ -140,44 +150,54 @@ abstract public class KryoTestCase {
 		});
 
 		roundTripWithBufferFactory(length, object1, new BufferFactory() {
+			@Override
 			public Output createOutput (OutputStream os) {
 				return new UnsafeOutput(os);
 			}
 
+			@Override
 			public Output createOutput (OutputStream os, int size) {
 				return new UnsafeOutput(os, size);
 			}
 
+			@Override
 			public Output createOutput (int size, int limit) {
 				return new UnsafeOutput(size, limit);
 			}
 
+			@Override
 			public Input createInput (InputStream os, int size) {
 				return new UnsafeInput(os, size);
 			}
 
+			@Override
 			public Input createInput (byte[] buffer) {
 				return new UnsafeInput(buffer);
 			}
 		});
 
 		roundTripWithBufferFactory(length, object1, new BufferFactory() {
+			@Override
 			public Output createOutput (OutputStream os) {
 				return new UnsafeByteBufferOutput(os);
 			}
 
+			@Override
 			public Output createOutput (OutputStream os, int size) {
 				return new UnsafeByteBufferOutput(os, size);
 			}
 
+			@Override
 			public Output createOutput (int size, int limit) {
 				return new UnsafeByteBufferOutput(size, limit);
 			}
 
+			@Override
 			public Input createInput (InputStream os, int size) {
 				return new UnsafeByteBufferInput(os, size);
 			}
 
+			@Override
 			public Input createInput (byte[] buffer) {
 				ByteBuffer byteBuffer = allocateByteBuffer(buffer);
 				return new UnsafeByteBufferInput(byteBuffer);

--- a/test/com/esotericsoftware/kryo/ReferenceTest.java
+++ b/test/com/esotericsoftware/kryo/ReferenceTest.java
@@ -58,10 +58,12 @@ public class ReferenceTest extends KryoTestCase {
 		kryo.setRegistrationRequired(false);
 		kryo.setReferences(true);
 		kryo.addDefaultSerializer(Stuff.class, new MapSerializer<Stuff>() {
+			@Override
 			protected void writeHeader (Kryo kryo, Output output, Stuff map) {
 				kryo.writeObjectOrNull(output, map.ordering, Ordering.class);
 			}
 
+			@Override
 			protected Stuff create (Kryo kryo, Input input, Class<? extends Stuff> type, int size) {
 				Ordering ordering = kryo.readObjectOrNull(input, Ordering.class);
 				return new Stuff(ordering);
@@ -121,6 +123,7 @@ public class ReferenceTest extends KryoTestCase {
 			}
 		}
 
+		@Override
 		public void write (Kryo kryo, Output output, List list) {
 			try {
 				kryo.writeClassAndObject(output, listField.get(list));
@@ -133,6 +136,7 @@ public class ReferenceTest extends KryoTestCase {
 			}
 		}
 
+		@Override
 		public List read (Kryo kryo, Input input, Class<? extends List> type) {
 			List list = (List)kryo.readClassAndObject(input);
 			int fromIndex = input.readInt();
@@ -167,6 +171,7 @@ public class ReferenceTest extends KryoTestCase {
 			}
 		}
 
+		@Override
 		public void write (Kryo kryo, Output output, List list) {
 			try {
 				kryo.writeClassAndObject(output, parentField.get(list));
@@ -179,6 +184,7 @@ public class ReferenceTest extends KryoTestCase {
 			}
 		}
 
+		@Override
 		public List read (Kryo kryo, Input input, Class<? extends List> type) {
 			List list = (List)kryo.readClassAndObject(input);
 			int offset = input.readInt();

--- a/test/com/esotericsoftware/kryo/SerializationBenchmarkTest.java
+++ b/test/com/esotericsoftware/kryo/SerializationBenchmarkTest.java
@@ -193,6 +193,7 @@ public class SerializationBenchmarkTest extends KryoTestCase {
 		}
 	}
 
+	@Override
 	public void setUp () throws Exception {
 		super.setUp();
 		Log.WARN();
@@ -229,6 +230,7 @@ public class SerializationBenchmarkTest extends KryoTestCase {
 		}
 
 		// Required by Kryo serialization.
+		@Override
 		public void read (Kryo kryo, Input in) {
 			intValue = kryo.readObject(in, Integer.class);
 			floatValue = kryo.readObject(in, Float.class);
@@ -239,6 +241,7 @@ public class SerializationBenchmarkTest extends KryoTestCase {
 		}
 
 		// Required by Java Externalizable.
+		@Override
 		public void readExternal (ObjectInput in) throws IOException, ClassNotFoundException {
 			intValue = in.readInt();
 			floatValue = in.readFloat();
@@ -249,6 +252,7 @@ public class SerializationBenchmarkTest extends KryoTestCase {
 		}
 
 		// Required by Kryo serialization.
+		@Override
 		public void write (Kryo kryo, Output out) {
 			kryo.writeObject(out, intValue);
 			kryo.writeObject(out, floatValue);
@@ -259,6 +263,7 @@ public class SerializationBenchmarkTest extends KryoTestCase {
 		}
 
 		// Required by Java Externalizable.
+		@Override
 		public void writeExternal (ObjectOutput out) throws IOException {
 			out.writeInt(intValue);
 			out.writeFloat(floatValue);

--- a/test/com/esotericsoftware/kryo/SerializationCompatTest.java
+++ b/test/com/esotericsoftware/kryo/SerializationCompatTest.java
@@ -90,6 +90,7 @@ public class SerializationCompatTest extends KryoTestCase {
 		if (JAVA_VERSION >= 11) TEST_DATAS.add(new TestDataDescription<>(new TestDataJava11(), 2210, 2238));
 	};
 
+	@Override
 	@Before
 	public void setUp () throws Exception {
 		super.setUp();
@@ -119,10 +120,12 @@ public class SerializationCompatTest extends KryoTestCase {
 	@Test
 	public void testStandard () throws Exception {
 		runTests("standard", new Function1<File, Input>() {
+			@Override
 			public Input apply (File file) throws FileNotFoundException {
 				return new Input(new FileInputStream(file));
 			}
 		}, new Function1<File, Output>() {
+			@Override
 			public Output apply (File file) throws Exception {
 				return new Output(new FileOutputStream(file));
 			}
@@ -132,10 +135,12 @@ public class SerializationCompatTest extends KryoTestCase {
 	@Test
 	public void testByteBuffer () throws Exception {
 		runTests("bytebuffer", new Function1<File, Input>() {
+			@Override
 			public Input apply (File file) throws FileNotFoundException {
 				return new ByteBufferInput(new FileInputStream(file));
 			}
 		}, new Function1<File, Output>() {
+			@Override
 			public Output apply (File file) throws Exception {
 				return new ByteBufferOutput(new FileOutputStream(file));
 			}
@@ -204,6 +209,7 @@ public class SerializationCompatTest extends KryoTestCase {
 		kryo.writeObject(out, description.testData);
 	}
 
+	@Override
 	protected void doAssertEquals (final Object one, final Object another) {
 		try {
 			assertReflectionEquals(one, another);

--- a/test/com/esotericsoftware/kryo/WarnUnregisteredClassesTest.java
+++ b/test/com/esotericsoftware/kryo/WarnUnregisteredClassesTest.java
@@ -117,6 +117,7 @@ public class WarnUnregisteredClassesTest {
 		public List<Integer> levels = new ArrayList();
 		public List<String> messages = new ArrayList();
 
+		@Override
 		public void log (int level, String category, String message, Throwable ex) {
 			levels.add(level);
 			messages.add(message);

--- a/test/com/esotericsoftware/kryo/serializers/ClosureSerializerTest.java
+++ b/test/com/esotericsoftware/kryo/serializers/ClosureSerializerTest.java
@@ -33,6 +33,7 @@ import org.junit.Test;
 
 /** Test for java 8 closures. */
 public class ClosureSerializerTest extends KryoTestCase {
+	@Override
 	@Before
 	public void setUp () throws Exception {
 		super.setUp();
@@ -60,6 +61,7 @@ public class ClosureSerializerTest extends KryoTestCase {
 		doAssertEquals(closure1, closure2);
 	}
 
+	@Override
 	protected void doAssertEquals (Object object1, Object object2) {
 		try {
 			assertEquals(((Callable)object1).call(), ((Callable)object2).call());

--- a/test/com/esotericsoftware/kryo/serializers/CompatibleFieldSerializerTest.java
+++ b/test/com/esotericsoftware/kryo/serializers/CompatibleFieldSerializerTest.java
@@ -46,6 +46,7 @@ public class CompatibleFieldSerializerTest extends KryoTestCase {
 		kryo.setReferences(references);
 
 		CompatibleFieldSerializerFactory factory = new CompatibleFieldSerializerFactory() {
+			@Override
 			public CompatibleFieldSerializer newSerializer (Kryo kryo, Class type) {
 				CompatibleFieldSerializer serializer = super.newSerializer(kryo, type);
 				serializer.getCompatibleFieldSerializerConfig().setChunkedEncoding(chunked);

--- a/test/com/esotericsoftware/kryo/serializers/DefaultSerializersTest.java
+++ b/test/com/esotericsoftware/kryo/serializers/DefaultSerializersTest.java
@@ -329,6 +329,7 @@ public class DefaultSerializersTest extends KryoTestCase {
 	public void testPriorityQueueCopy () {
 		List<Integer> values = Arrays.asList(7, 0, 5, 123, 432);
 		PriorityQueue<Integer> queue = new PriorityQueue(3, new Comparator<Integer>() {
+			@Override
 			public int compare (Integer o1, Integer o2) {
 				return o2 - o1;
 			}

--- a/test/com/esotericsoftware/kryo/serializers/ExternalizableSerializerTest.java
+++ b/test/com/esotericsoftware/kryo/serializers/ExternalizableSerializerTest.java
@@ -135,11 +135,13 @@ public class ExternalizableSerializerTest extends KryoTestCase {
 			return true;
 		}
 
+		@Override
 		public void writeExternal (ObjectOutput out) throws IOException {
 			out.writeObject(stringField);
 			out.writeInt(intField);
 		}
 
+		@Override
 		public void readExternal (ObjectInput in) throws IOException, ClassNotFoundException {
 			stringField = (String)in.readObject();
 			intField = in.readInt();
@@ -174,11 +176,13 @@ public class ExternalizableSerializerTest extends KryoTestCase {
 			return true;
 		}
 
+		@Override
 		public void writeExternal (ObjectOutput out) throws IOException {
 			out.writeObject(dateField);
 			out.writeLong(longField);
 		}
 
+		@Override
 		public void readExternal (ObjectInput in) throws IOException, ClassNotFoundException {
 			dateField = (Date)in.readObject();
 			longField = in.readInt();
@@ -196,10 +200,12 @@ public class ExternalizableSerializerTest extends KryoTestCase {
 			this.value = value;
 		}
 
+		@Override
 		public void writeExternal (ObjectOutput out) throws IOException {
 			out.writeObject(value);
 		}
 
+		@Override
 		public void readExternal (ObjectInput in) throws IOException, ClassNotFoundException {
 			value = (String)in.readObject();
 		}

--- a/test/com/esotericsoftware/kryo/serializers/FieldSerializerInheritanceTest.java
+++ b/test/com/esotericsoftware/kryo/serializers/FieldSerializerInheritanceTest.java
@@ -125,10 +125,12 @@ public class FieldSerializerInheritanceTest extends KryoTestCase {
 	static public class TestExtended extends TestDefault {
 		String a;
 
+		@Override
 		public String getA () {
 			return a;
 		}
 
+		@Override
 		public void setA (String a) {
 			this.a = a;
 		}

--- a/test/com/esotericsoftware/kryo/serializers/FieldSerializerTest.java
+++ b/test/com/esotericsoftware/kryo/serializers/FieldSerializerTest.java
@@ -304,14 +304,17 @@ public class FieldSerializerTest extends KryoTestCase {
 	@Test
 	public void testNoDefaultConstructor () {
 		kryo.register(SimpleNoDefaultConstructor.class, new Serializer<SimpleNoDefaultConstructor>() {
+			@Override
 			public SimpleNoDefaultConstructor read (Kryo kryo, Input input, Class<? extends SimpleNoDefaultConstructor> type) {
 				return new SimpleNoDefaultConstructor(input.readVarInt(true));
 			}
 
+			@Override
 			public void write (Kryo kryo, Output output, SimpleNoDefaultConstructor object) {
 				output.writeVarInt(object.constructorValue, true);
 			}
 
+			@Override
 			public SimpleNoDefaultConstructor copy (Kryo kryo, SimpleNoDefaultConstructor original) {
 				return new SimpleNoDefaultConstructor(original.constructorValue);
 			}
@@ -321,16 +324,19 @@ public class FieldSerializerTest extends KryoTestCase {
 
 		kryo.register(ComplexNoDefaultConstructor.class,
 			new FieldSerializer<ComplexNoDefaultConstructor>(kryo, ComplexNoDefaultConstructor.class) {
+				@Override
 				public void write (Kryo kryo, Output output, ComplexNoDefaultConstructor object) {
 					output.writeString(object.name);
 					super.write(kryo, output, object);
 				}
 
+				@Override
 				protected ComplexNoDefaultConstructor create (Kryo kryo, Input input, Class type) {
 					String name = input.readString();
 					return new ComplexNoDefaultConstructor(name);
 				}
 
+				@Override
 				protected ComplexNoDefaultConstructor createCopy (Kryo kryo, ComplexNoDefaultConstructor original) {
 					return new ComplexNoDefaultConstructor(original.name);
 				}
@@ -1040,14 +1046,17 @@ public class FieldSerializerTest extends KryoTestCase {
 	}
 
 	static public class HasDefaultSerializerAnnotationSerializer extends Serializer<HasDefaultSerializerAnnotation> {
+		@Override
 		public void write (Kryo kryo, Output output, HasDefaultSerializerAnnotation object) {
 			output.writeVarLong(object.time, true);
 		}
 
+		@Override
 		public HasDefaultSerializerAnnotation read (Kryo kryo, Input input, Class<? extends HasDefaultSerializerAnnotation> type) {
 			return new HasDefaultSerializerAnnotation(input.readVarLong(true));
 		}
 
+		@Override
 		public HasDefaultSerializerAnnotation copy (Kryo kryo, HasDefaultSerializerAnnotation original) {
 			return new HasDefaultSerializerAnnotation(original.time);
 		}

--- a/test/com/esotericsoftware/kryo/serializers/GenericsTest.java
+++ b/test/com/esotericsoftware/kryo/serializers/GenericsTest.java
@@ -42,6 +42,7 @@ public class GenericsTest extends KryoTestCase {
 		supportsCopy = true;
 	}
 
+	@Override
 	@Before
 	public void setUp () throws Exception {
 		super.setUp();
@@ -197,6 +198,7 @@ public class GenericsTest extends KryoTestCase {
 			this.value = value;
 		}
 
+		@Override
 		public V getValue () {
 			return value;
 		}

--- a/test/com/esotericsoftware/kryo/serializers/MapSerializerTest.java
+++ b/test/com/esotericsoftware/kryo/serializers/MapSerializerTest.java
@@ -252,6 +252,7 @@ public class MapSerializerTest extends KryoTestCase {
 	}
 
 	static public class KeyComparator implements Comparator<KeyThatIsntComparable> {
+		@Override
 		public int compare (KeyThatIsntComparable o1, KeyThatIsntComparable o2) {
 			return o1.value.compareTo(o2.value);
 		}

--- a/test/com/esotericsoftware/kryo/serializers/OptionalSerializersTest.java
+++ b/test/com/esotericsoftware/kryo/serializers/OptionalSerializersTest.java
@@ -37,6 +37,7 @@ public class OptionalSerializersTest extends KryoTestCase {
 		supportsCopy = true;
 	}
 
+	@Override
 	@Before
 	public void setUp () throws Exception {
 		super.setUp();

--- a/test/com/esotericsoftware/kryo/serializers/TimeSerializersTest.java
+++ b/test/com/esotericsoftware/kryo/serializers/TimeSerializersTest.java
@@ -43,6 +43,7 @@ import org.junit.Test;
 /** Test for java 8 java.time.* serializers. */
 public class TimeSerializersTest extends KryoTestCase {
 
+	@Override
 	@Before
 	public void setUp () throws Exception {
 		super.setUp();

--- a/test/com/esotericsoftware/kryo/serializers/java11/ImmutableCollectionsSerializersTest.java
+++ b/test/com/esotericsoftware/kryo/serializers/java11/ImmutableCollectionsSerializersTest.java
@@ -32,6 +32,7 @@ public class ImmutableCollectionsSerializersTest extends KryoTestCase {
 		supportsCopy = true;
 	}
 
+	@Override
 	@Before
 	public void setUp () throws Exception {
 		super.setUp();

--- a/test/com/esotericsoftware/kryo/util/PoolTest.java
+++ b/test/com/esotericsoftware/kryo/util/PoolTest.java
@@ -38,10 +38,12 @@ public class PoolTest extends KryoTestCase {
 	@Parameters
 	static public Collection<Object[]> data () {
 		return Arrays.asList(new Object[][] {{new Pool<Kryo>(true, false, 16) {
+			@Override
 			protected Kryo create () {
 				return new Kryo();
 			}
 		}}, {new Pool<Kryo>(true, true, 16) {
+			@Override
 			protected Kryo create () {
 				return new Kryo();
 			}


### PR DESCRIPTION
#683 showed that it is difficult to maintain the current code style for contributors. Two issues with the code base are the most problematic:

1. Missing `@Override` annotations on overridden methods
2. Non-standard sorting of modifiers (`static public final` instead of the standard `public static final`)

Both issues will be highlighted as warnings in IDEs and are most likely fixed by default cleanup actions. 

When adding new methods and classes, contributors have to remember these idiosyncrasies and manually sort modifiers and remove override annotations to match the current style.

I suggest that we address both issues before releasing Kryo 5 to make future contributions easier.

This PR addresses the first issue and adds all missing `@Override` annotations. The second issue is addressed in #740.

@magro: Please take a look.