### PR TITLE
Use recommended sort order for modifiers

### DIFF
--- a/src/com/esotericsoftware/kryo/Kryo.java
+++ b/src/com/esotericsoftware/kryo/Kryo.java
@@ -127,11 +127,11 @@ import org.objenesis.strategy.StdInstantiatorStrategy;
 /** Maps classes to serializers so object graphs can be serialized automatically.
  * @author Nathan Sweet */
 public class Kryo implements Poolable {
-	static public final byte NULL = 0;
-	static public final byte NOT_NULL = 1;
+	public static final byte NULL = 0;
+	public static final byte NOT_NULL = 1;
 
-	static private final int REF = -1;
-	static private final int NO_REF = -2;
+	private static final int REF = -1;
+	private static final int NO_REF = -2;
 
 	private SerializerFactory defaultSerializer = new FieldSerializerFactory();
 	private final ArrayList<DefaultSerializerEntry> defaultSerializers = new ArrayList(67);

--- a/src/com/esotericsoftware/kryo/Serializer.java
+++ b/src/com/esotericsoftware/kryo/Serializer.java
@@ -47,7 +47,7 @@ public abstract class Serializer<T> {
 	 * This method should not be called directly, instead this serializer can be passed to {@link Kryo} write methods that accept a
 	 * serialier.
 	 * @param object May be null if {@link #getAcceptsNull()} is true. */
-	abstract public void write (Kryo kryo, Output output, T object);
+	public abstract void write (Kryo kryo, Output output, T object);
 
 	/** Reads bytes and returns a new object of the specified concrete type.
 	 * <p>
@@ -58,7 +58,7 @@ public abstract class Serializer<T> {
 	 * This method should not be called directly, instead this serializer can be passed to {@link Kryo} read methods that accept a
 	 * serialier.
 	 * @return May be null if {@link #getAcceptsNull()} is true. */
-	abstract public T read (Kryo kryo, Input input, Class<? extends T> type);
+	public abstract T read (Kryo kryo, Input input, Class<? extends T> type);
 
 	public boolean getAcceptsNull () {
 		return acceptsNull;

--- a/src/com/esotericsoftware/kryo/SerializerFactory.java
+++ b/src/com/esotericsoftware/kryo/SerializerFactory.java
@@ -42,7 +42,7 @@ public interface SerializerFactory<T extends Serializer> {
 	public boolean isSupported (Class type);
 
 	/** A serializer factory which always returns true for {@link #isSupported(Class)}. */
-	static public abstract class BaseSerializerFactory<T extends Serializer> implements SerializerFactory<T> {
+	public abstract static class BaseSerializerFactory<T extends Serializer> implements SerializerFactory<T> {
 		public boolean isSupported (Class type) {
 			return true;
 		}
@@ -53,7 +53,7 @@ public interface SerializerFactory<T extends Serializer> {
 	 * {@link Class} as its only argument, or take no arguments. If several of the described constructors are found, the first
 	 * found constructor is used, in the order they were just described.
 	 * @author Rafael Winterhalter <rafael.wth@web.de> */
-	static public class ReflectionSerializerFactory<T extends Serializer> extends BaseSerializerFactory<T> {
+	public static class ReflectionSerializerFactory<T extends Serializer> extends BaseSerializerFactory<T> {
 		private final Class<T> serializerClass;
 
 		public ReflectionSerializerFactory (Class<T> serializerClass) {
@@ -66,7 +66,7 @@ public interface SerializerFactory<T extends Serializer> {
 
 		/** Creates a new instance of the specified serializer for serializing the specified class. Serializers must have a zero
 		 * argument constructor or one that takes (Kryo), (Class), or (Kryo, Class). */
-		static public <T extends Serializer> T newSerializer (Kryo kryo, Class<T> serializerClass, Class type) {
+		public static <T extends Serializer> T newSerializer (Kryo kryo, Class<T> serializerClass, Class type) {
 			try {
 				try {
 					return serializerClass.getConstructor(Kryo.class, Class.class).newInstance(kryo, type);
@@ -91,7 +91,7 @@ public interface SerializerFactory<T extends Serializer> {
 	/** A serializer factory that always returns a given serializer instance rather than creating new serializer instances. It can
 	 * be used when multiple types should be serialized by the same serializer.
 	 * @author Rafael Winterhalter <rafael.wth@web.de> */
-	static public class SingletonSerializerFactory<T extends Serializer> extends BaseSerializerFactory<T> {
+	public static class SingletonSerializerFactory<T extends Serializer> extends BaseSerializerFactory<T> {
 		private final T serializer;
 
 		public SingletonSerializerFactory (T serializer) {
@@ -105,7 +105,7 @@ public interface SerializerFactory<T extends Serializer> {
 
 	/** A serializer factory that returns new, configured {@link FieldSerializer} instances.
 	 * @author Nathan Sweet */
-	static public class FieldSerializerFactory extends BaseSerializerFactory<FieldSerializer> {
+	public static class FieldSerializerFactory extends BaseSerializerFactory<FieldSerializer> {
 		private final FieldSerializerConfig config;
 
 		public FieldSerializerFactory () {
@@ -127,7 +127,7 @@ public interface SerializerFactory<T extends Serializer> {
 
 	/** A serializer factory that returns new, configured {@link TaggedFieldSerializer} instances.
 	 * @author Nathan Sweet */
-	static public class TaggedFieldSerializerFactory extends BaseSerializerFactory<TaggedFieldSerializer> {
+	public static class TaggedFieldSerializerFactory extends BaseSerializerFactory<TaggedFieldSerializer> {
 		private final TaggedFieldSerializerConfig config;
 
 		public TaggedFieldSerializerFactory () {
@@ -149,7 +149,7 @@ public interface SerializerFactory<T extends Serializer> {
 
 	/** A serializer factory that returns new, configured {@link VersionFieldSerializer} instances.
 	 * @author Nathan Sweet */
-	static public class VersionFieldSerializerFactory extends BaseSerializerFactory<VersionFieldSerializer> {
+	public static class VersionFieldSerializerFactory extends BaseSerializerFactory<VersionFieldSerializer> {
 		private final VersionFieldSerializerConfig config;
 
 		public VersionFieldSerializerFactory () {
@@ -171,7 +171,7 @@ public interface SerializerFactory<T extends Serializer> {
 
 	/** A serializer factory that returns new, configured {@link CompatibleFieldSerializer} instances.
 	 * @author Nathan Sweet */
-	static public class CompatibleFieldSerializerFactory extends BaseSerializerFactory<CompatibleFieldSerializer> {
+	public static class CompatibleFieldSerializerFactory extends BaseSerializerFactory<CompatibleFieldSerializer> {
 		private final CompatibleFieldSerializerConfig config;
 
 		public CompatibleFieldSerializerFactory () {

--- a/src/com/esotericsoftware/kryo/io/ByteBufferInput.java
+++ b/src/com/esotericsoftware/kryo/io/ByteBufferInput.java
@@ -35,7 +35,7 @@ import java.nio.ByteOrder;
  * @author Roman Levenstein <romixlev@gmail.com>
  * @author Nathan Sweet */
 public class ByteBufferInput extends Input {
-	static private final ByteOrder nativeOrder = ByteOrder.nativeOrder();
+	private static final ByteOrder nativeOrder = ByteOrder.nativeOrder();
 
 	protected ByteBuffer byteBuffer;
 	private byte[] tempBuffer;

--- a/src/com/esotericsoftware/kryo/io/ByteBufferOutput.java
+++ b/src/com/esotericsoftware/kryo/io/ByteBufferOutput.java
@@ -35,7 +35,7 @@ import java.nio.ByteOrder;
  * @author Roman Levenstein <romixlev@gmail.com>
  * @author Nathan Sweet */
 public class ByteBufferOutput extends Output {
-	static private final ByteOrder nativeOrder = ByteOrder.nativeOrder();
+	private static final ByteOrder nativeOrder = ByteOrder.nativeOrder();
 
 	protected ByteBuffer byteBuffer;
 

--- a/src/com/esotericsoftware/kryo/io/Output.java
+++ b/src/com/esotericsoftware/kryo/io/Output.java
@@ -915,7 +915,7 @@ public class Output extends OutputStream implements AutoCloseable, Poolable {
 	//
 
 	/** Returns the number of bytes that would be written with {@link #writeVarInt(int, boolean)}. */
-	static public int varIntLength (int value, boolean optimizePositive) {
+	public static int varIntLength (int value, boolean optimizePositive) {
 		if (!optimizePositive) value = (value << 1) ^ (value >> 31);
 		if (value >>> 7 == 0) return 1;
 		if (value >>> 14 == 0) return 2;
@@ -925,7 +925,7 @@ public class Output extends OutputStream implements AutoCloseable, Poolable {
 	}
 
 	/** Returns the number of bytes that would be written with {@link #writeVarLong(long, boolean)}. */
-	static public int varLongLength (long value, boolean optimizePositive) {
+	public static int varLongLength (long value, boolean optimizePositive) {
 		if (!optimizePositive) value = (value << 1) ^ (value >> 63);
 		if (value >>> 7 == 0) return 1;
 		if (value >>> 14 == 0) return 2;

--- a/src/com/esotericsoftware/kryo/serializers/AsmField.java
+++ b/src/com/esotericsoftware/kryo/serializers/AsmField.java
@@ -56,7 +56,7 @@ class AsmField extends ReflectField {
 		}
 	}
 
-	final static class IntAsmField extends CachedField {
+	static final class IntAsmField extends CachedField {
 		public IntAsmField (Field field) {
 			super(field);
 		}
@@ -80,7 +80,7 @@ class AsmField extends ReflectField {
 		}
 	}
 
-	final static class FloatAsmField extends CachedField {
+	static final class FloatAsmField extends CachedField {
 		public FloatAsmField (Field field) {
 			super(field);
 		}
@@ -98,7 +98,7 @@ class AsmField extends ReflectField {
 		}
 	}
 
-	final static class ShortAsmField extends CachedField {
+	static final class ShortAsmField extends CachedField {
 		public ShortAsmField (Field field) {
 			super(field);
 		}
@@ -116,7 +116,7 @@ class AsmField extends ReflectField {
 		}
 	}
 
-	final static class ByteAsmField extends CachedField {
+	static final class ByteAsmField extends CachedField {
 		public ByteAsmField (Field field) {
 			super(field);
 		}
@@ -134,7 +134,7 @@ class AsmField extends ReflectField {
 		}
 	}
 
-	final static class BooleanAsmField extends CachedField {
+	static final class BooleanAsmField extends CachedField {
 		public BooleanAsmField (Field field) {
 			super(field);
 		}
@@ -152,7 +152,7 @@ class AsmField extends ReflectField {
 		}
 	}
 
-	final static class CharAsmField extends CachedField {
+	static final class CharAsmField extends CachedField {
 		public CharAsmField (Field field) {
 			super(field);
 		}
@@ -170,7 +170,7 @@ class AsmField extends ReflectField {
 		}
 	}
 
-	final static class LongAsmField extends CachedField {
+	static final class LongAsmField extends CachedField {
 		public LongAsmField (Field field) {
 			super(field);
 		}
@@ -194,7 +194,7 @@ class AsmField extends ReflectField {
 		}
 	}
 
-	final static class DoubleAsmField extends CachedField {
+	static final class DoubleAsmField extends CachedField {
 		public DoubleAsmField (Field field) {
 			super(field);
 		}
@@ -212,7 +212,7 @@ class AsmField extends ReflectField {
 		}
 	}
 
-	final static class StringAsmField extends CachedField {
+	static final class StringAsmField extends CachedField {
 		public StringAsmField (Field field) {
 			super(field);
 		}

--- a/src/com/esotericsoftware/kryo/serializers/BlowfishSerializer.java
+++ b/src/com/esotericsoftware/kryo/serializers/BlowfishSerializer.java
@@ -36,7 +36,7 @@ import javax.crypto.spec.SecretKeySpec;
  * @author Nathan Sweet */
 public class BlowfishSerializer extends Serializer {
 	private final Serializer serializer;
-	static private SecretKeySpec keySpec;
+	private static SecretKeySpec keySpec;
 
 	public BlowfishSerializer (Serializer serializer, byte[] key) {
 		this.serializer = serializer;
@@ -70,7 +70,7 @@ public class BlowfishSerializer extends Serializer {
 		return serializer.copy(kryo, original);
 	}
 
-	static private Cipher getCipher (int mode) {
+	private static Cipher getCipher (int mode) {
 		try {
 			Cipher cipher = Cipher.getInstance("Blowfish");
 			cipher.init(mode, keySpec);

--- a/src/com/esotericsoftware/kryo/serializers/ClosureSerializer.java
+++ b/src/com/esotericsoftware/kryo/serializers/ClosureSerializer.java
@@ -45,10 +45,10 @@ import java.lang.reflect.Method;
 public class ClosureSerializer extends Serializer {
 	/** Marker class used to find the class {@link Registration} for closure instances.
 	 * @see Kryo#isClosure(Class) */
-	static public class Closure {
+	public static class Closure {
 	}
 
-	static private Method readResolve;
+	private static Method readResolve;
 
 	public ClosureSerializer () {
 		if (readResolve == null) {

--- a/src/com/esotericsoftware/kryo/serializers/CompatibleFieldSerializer.java
+++ b/src/com/esotericsoftware/kryo/serializers/CompatibleFieldSerializer.java
@@ -44,7 +44,7 @@ import com.esotericsoftware.kryo.util.ObjectMap;
  * {@link CompatibleFieldSerializerConfig#setExtendedFieldNames(boolean)} must be true.
  * @author Nathan Sweet */
 public class CompatibleFieldSerializer<T> extends FieldSerializer<T> {
-	static private final int binarySearchThreshold = 32;
+	private static final int binarySearchThreshold = 32;
 
 	private CompatibleFieldSerializerConfig config;
 
@@ -244,7 +244,7 @@ public class CompatibleFieldSerializer<T> extends FieldSerializer<T> {
 	}
 
 	/** Configuration for CompatibleFieldSerializer instances. */
-	static public class CompatibleFieldSerializerConfig extends FieldSerializerConfig {
+	public static class CompatibleFieldSerializerConfig extends FieldSerializerConfig {
 		boolean readUnknownFieldData = true, chunked;
 		int chunkSize = 1024;
 

--- a/src/com/esotericsoftware/kryo/serializers/DefaultArraySerializers.java
+++ b/src/com/esotericsoftware/kryo/serializers/DefaultArraySerializers.java
@@ -33,7 +33,7 @@ import java.lang.reflect.Modifier;
  * default}.
  * @author Nathan Sweet */
 public class DefaultArraySerializers {
-	static public class ByteArraySerializer extends Serializer<byte[]> {
+	public static class ByteArraySerializer extends Serializer<byte[]> {
 		{
 			setAcceptsNull(true);
 		}
@@ -60,7 +60,7 @@ public class DefaultArraySerializers {
 		}
 	}
 
-	static public class IntArraySerializer extends Serializer<int[]> {
+	public static class IntArraySerializer extends Serializer<int[]> {
 		{
 			setAcceptsNull(true);
 		}
@@ -87,7 +87,7 @@ public class DefaultArraySerializers {
 		}
 	}
 
-	static public class FloatArraySerializer extends Serializer<float[]> {
+	public static class FloatArraySerializer extends Serializer<float[]> {
 		{
 			setAcceptsNull(true);
 		}
@@ -114,7 +114,7 @@ public class DefaultArraySerializers {
 		}
 	}
 
-	static public class LongArraySerializer extends Serializer<long[]> {
+	public static class LongArraySerializer extends Serializer<long[]> {
 		{
 			setAcceptsNull(true);
 		}
@@ -141,7 +141,7 @@ public class DefaultArraySerializers {
 		}
 	}
 
-	static public class ShortArraySerializer extends Serializer<short[]> {
+	public static class ShortArraySerializer extends Serializer<short[]> {
 		{
 			setAcceptsNull(true);
 		}
@@ -168,7 +168,7 @@ public class DefaultArraySerializers {
 		}
 	}
 
-	static public class CharArraySerializer extends Serializer<char[]> {
+	public static class CharArraySerializer extends Serializer<char[]> {
 		{
 			setAcceptsNull(true);
 		}
@@ -195,7 +195,7 @@ public class DefaultArraySerializers {
 		}
 	}
 
-	static public class DoubleArraySerializer extends Serializer<double[]> {
+	public static class DoubleArraySerializer extends Serializer<double[]> {
 		{
 			setAcceptsNull(true);
 		}
@@ -222,7 +222,7 @@ public class DefaultArraySerializers {
 		}
 	}
 
-	static public class BooleanArraySerializer extends Serializer<boolean[]> {
+	public static class BooleanArraySerializer extends Serializer<boolean[]> {
 		{
 			setAcceptsNull(true);
 		}
@@ -253,7 +253,7 @@ public class DefaultArraySerializers {
 		}
 	}
 
-	static public class StringArraySerializer extends Serializer<String[]> {
+	public static class StringArraySerializer extends Serializer<String[]> {
 		{
 			setAcceptsNull(true);
 		}
@@ -296,7 +296,7 @@ public class DefaultArraySerializers {
 		}
 	}
 
-	static public class ObjectArraySerializer extends Serializer<Object[]> {
+	public static class ObjectArraySerializer extends Serializer<Object[]> {
 		private boolean elementsAreSameType;
 		private boolean elementsCanBeNull = true;
 		private final Class type;

--- a/src/com/esotericsoftware/kryo/serializers/DefaultSerializers.java
+++ b/src/com/esotericsoftware/kryo/serializers/DefaultSerializers.java
@@ -62,7 +62,7 @@ import java.util.TreeSet;
 /** Contains many serializer classes that are provided by {@link Kryo#addDefaultSerializer(Class, Class) default}.
  * @author Nathan Sweet */
 public class DefaultSerializers {
-	static public class VoidSerializer extends ImmutableSerializer {
+	public static class VoidSerializer extends ImmutableSerializer {
 		public void write (Kryo kryo, Output output, Object object) {
 		}
 
@@ -71,7 +71,7 @@ public class DefaultSerializers {
 		}
 	}
 
-	static public class BooleanSerializer extends ImmutableSerializer<Boolean> {
+	public static class BooleanSerializer extends ImmutableSerializer<Boolean> {
 		public void write (Kryo kryo, Output output, Boolean object) {
 			output.writeBoolean(object);
 		}
@@ -81,7 +81,7 @@ public class DefaultSerializers {
 		}
 	}
 
-	static public class ByteSerializer extends ImmutableSerializer<Byte> {
+	public static class ByteSerializer extends ImmutableSerializer<Byte> {
 		public void write (Kryo kryo, Output output, Byte object) {
 			output.writeByte(object);
 		}
@@ -91,7 +91,7 @@ public class DefaultSerializers {
 		}
 	}
 
-	static public class CharSerializer extends ImmutableSerializer<Character> {
+	public static class CharSerializer extends ImmutableSerializer<Character> {
 		public void write (Kryo kryo, Output output, Character object) {
 			output.writeChar(object);
 		}
@@ -101,7 +101,7 @@ public class DefaultSerializers {
 		}
 	}
 
-	static public class ShortSerializer extends ImmutableSerializer<Short> {
+	public static class ShortSerializer extends ImmutableSerializer<Short> {
 		public void write (Kryo kryo, Output output, Short object) {
 			output.writeShort(object);
 		}
@@ -111,7 +111,7 @@ public class DefaultSerializers {
 		}
 	}
 
-	static public class IntSerializer extends ImmutableSerializer<Integer> {
+	public static class IntSerializer extends ImmutableSerializer<Integer> {
 		public void write (Kryo kryo, Output output, Integer object) {
 			output.writeInt(object, false);
 		}
@@ -121,7 +121,7 @@ public class DefaultSerializers {
 		}
 	}
 
-	static public class LongSerializer extends ImmutableSerializer<Long> {
+	public static class LongSerializer extends ImmutableSerializer<Long> {
 		public void write (Kryo kryo, Output output, Long object) {
 			output.writeVarLong(object, false);
 		}
@@ -131,7 +131,7 @@ public class DefaultSerializers {
 		}
 	}
 
-	static public class FloatSerializer extends ImmutableSerializer<Float> {
+	public static class FloatSerializer extends ImmutableSerializer<Float> {
 		public void write (Kryo kryo, Output output, Float object) {
 			output.writeFloat(object);
 		}
@@ -141,7 +141,7 @@ public class DefaultSerializers {
 		}
 	}
 
-	static public class DoubleSerializer extends ImmutableSerializer<Double> {
+	public static class DoubleSerializer extends ImmutableSerializer<Double> {
 		public void write (Kryo kryo, Output output, Double object) {
 			output.writeDouble(object);
 		}
@@ -152,7 +152,7 @@ public class DefaultSerializers {
 	}
 
 	/** @see Output#writeString(String) */
-	static public class StringSerializer extends ImmutableSerializer<String> {
+	public static class StringSerializer extends ImmutableSerializer<String> {
 		{
 			setAcceptsNull(true);
 		}
@@ -168,7 +168,7 @@ public class DefaultSerializers {
 
 	/** Serializer for {@link BigInteger} and any subclass.
 	 * @author Tumi <serverperformance@gmail.com> (enhacements) */
-	static public class BigIntegerSerializer extends ImmutableSerializer<BigInteger> {
+	public static class BigIntegerSerializer extends ImmutableSerializer<BigInteger> {
 		{
 			setAcceptsNull(true);
 		}
@@ -226,7 +226,7 @@ public class DefaultSerializers {
 
 	/** Serializer for {@link BigDecimal} and any subclass.
 	 * @author Tumi <serverperformance@gmail.com> (enhacements) */
-	static public class BigDecimalSerializer extends ImmutableSerializer<BigDecimal> {
+	public static class BigDecimalSerializer extends ImmutableSerializer<BigDecimal> {
 		private final BigIntegerSerializer bigIntegerSerializer = new BigIntegerSerializer();
 
 		{
@@ -277,7 +277,7 @@ public class DefaultSerializers {
 		}
 	}
 
-	static public class ClassSerializer extends ImmutableSerializer<Class> {
+	public static class ClassSerializer extends ImmutableSerializer<Class> {
 		{
 			setAcceptsNull(true);
 		}
@@ -298,7 +298,7 @@ public class DefaultSerializers {
 
 	/** Serializer for {@link Date}, {@link java.sql.Date}, {@link Time}, {@link Timestamp} and any other subclass.
 	 * @author Tumi <serverperformance@gmail.com> */
-	static public class DateSerializer extends Serializer<Date> {
+	public static class DateSerializer extends Serializer<Date> {
 		private Date create (Kryo kryo, Class<? extends Date> type, long time) throws KryoException {
 			if (type == Date.class || type == null) {
 				return new Date(time);
@@ -345,7 +345,7 @@ public class DefaultSerializers {
 		}
 	}
 
-	static public class EnumSerializer extends ImmutableSerializer<Enum> {
+	public static class EnumSerializer extends ImmutableSerializer<Enum> {
 		{
 			setAcceptsNull(true);
 		}
@@ -382,7 +382,7 @@ public class DefaultSerializers {
 		}
 	}
 
-	static public class EnumSetSerializer extends Serializer<EnumSet> {
+	public static class EnumSetSerializer extends Serializer<EnumSet> {
 		public void write (Kryo kryo, Output output, EnumSet object) {
 			Serializer serializer;
 			if (object.isEmpty()) {
@@ -413,7 +413,7 @@ public class DefaultSerializers {
 	}
 
 	/** @author <a href="mailto:martin.grotzke@javakaffee.de">Martin Grotzke</a> */
-	static public class CurrencySerializer extends ImmutableSerializer<Currency> {
+	public static class CurrencySerializer extends ImmutableSerializer<Currency> {
 		{
 			setAcceptsNull(true);
 		}
@@ -430,7 +430,7 @@ public class DefaultSerializers {
 	}
 
 	/** @author <a href="mailto:martin.grotzke@javakaffee.de">Martin Grotzke</a> */
-	static public class StringBufferSerializer extends Serializer<StringBuffer> {
+	public static class StringBufferSerializer extends Serializer<StringBuffer> {
 		{
 			setAcceptsNull(true);
 		}
@@ -451,7 +451,7 @@ public class DefaultSerializers {
 	}
 
 	/** @author <a href="mailto:martin.grotzke@javakaffee.de">Martin Grotzke</a> */
-	static public class StringBuilderSerializer extends Serializer<StringBuilder> {
+	public static class StringBuilderSerializer extends Serializer<StringBuilder> {
 		{
 			setAcceptsNull(true);
 		}
@@ -469,7 +469,7 @@ public class DefaultSerializers {
 		}
 	}
 
-	static public class KryoSerializableSerializer extends Serializer<KryoSerializable> {
+	public static class KryoSerializableSerializer extends Serializer<KryoSerializable> {
 		public void write (Kryo kryo, Output output, KryoSerializable object) {
 			object.write(kryo, output);
 		}
@@ -485,7 +485,7 @@ public class DefaultSerializers {
 	/** Serializer for lists created via {@link Collections#emptyList()} or that were just assigned the
 	 * {@link Collections#EMPTY_LIST}.
 	 * @author <a href="mailto:martin.grotzke@javakaffee.de">Martin Grotzke</a> */
-	static public class CollectionsEmptyListSerializer extends ImmutableSerializer<Collection> {
+	public static class CollectionsEmptyListSerializer extends ImmutableSerializer<Collection> {
 		public void write (Kryo kryo, Output output, Collection object) {
 		}
 
@@ -497,7 +497,7 @@ public class DefaultSerializers {
 	/** Serializer for maps created via {@link Collections#emptyMap()} or that were just assigned the
 	 * {@link Collections#EMPTY_MAP}.
 	 * @author <a href="mailto:martin.grotzke@javakaffee.de">Martin Grotzke</a> */
-	static public class CollectionsEmptyMapSerializer extends ImmutableSerializer<Map> {
+	public static class CollectionsEmptyMapSerializer extends ImmutableSerializer<Map> {
 		public void write (Kryo kryo, Output output, Map object) {
 		}
 
@@ -509,7 +509,7 @@ public class DefaultSerializers {
 	/** Serializer for sets created via {@link Collections#emptySet()} or that were just assigned the
 	 * {@link Collections#EMPTY_SET}.
 	 * @author <a href="mailto:martin.grotzke@javakaffee.de">Martin Grotzke</a> */
-	static public class CollectionsEmptySetSerializer extends ImmutableSerializer<Set> {
+	public static class CollectionsEmptySetSerializer extends ImmutableSerializer<Set> {
 		public void write (Kryo kryo, Output output, Set object) {
 		}
 
@@ -520,7 +520,7 @@ public class DefaultSerializers {
 
 	/** Serializer for lists created via {@link Collections#singletonList(Object)}.
 	 * @author <a href="mailto:martin.grotzke@javakaffee.de">Martin Grotzke</a> */
-	static public class CollectionsSingletonListSerializer extends Serializer<List> {
+	public static class CollectionsSingletonListSerializer extends Serializer<List> {
 		public void write (Kryo kryo, Output output, List object) {
 			kryo.writeClassAndObject(output, object.get(0));
 		}
@@ -536,7 +536,7 @@ public class DefaultSerializers {
 
 	/** Serializer for maps created via {@link Collections#singletonMap(Object, Object)}.
 	 * @author <a href="mailto:martin.grotzke@javakaffee.de">Martin Grotzke</a> */
-	static public class CollectionsSingletonMapSerializer extends Serializer<Map> {
+	public static class CollectionsSingletonMapSerializer extends Serializer<Map> {
 		public void write (Kryo kryo, Output output, Map object) {
 			Entry entry = (Entry)object.entrySet().iterator().next();
 			kryo.writeClassAndObject(output, entry.getKey());
@@ -557,7 +557,7 @@ public class DefaultSerializers {
 
 	/** Serializer for sets created via {@link Collections#singleton(Object)}.
 	 * @author <a href="mailto:martin.grotzke@javakaffee.de">Martin Grotzke</a> */
-	static public class CollectionsSingletonSetSerializer extends Serializer<Set> {
+	public static class CollectionsSingletonSetSerializer extends Serializer<Set> {
 		public void write (Kryo kryo, Output output, Set object) {
 			kryo.writeClassAndObject(output, object.iterator().next());
 		}
@@ -573,7 +573,7 @@ public class DefaultSerializers {
 
 	/** Serializer for {@link TimeZone}. Assumes the timezones are immutable.
 	 * @author Tumi <serverperformance@gmail.com> */
-	static public class TimeZoneSerializer extends ImmutableSerializer<TimeZone> {
+	public static class TimeZoneSerializer extends ImmutableSerializer<TimeZone> {
 		public void write (Kryo kryo, Output output, TimeZone object) {
 			output.writeString(object.getID());
 		}
@@ -585,9 +585,9 @@ public class DefaultSerializers {
 
 	/** Serializer for {@link GregorianCalendar}, java.util.JapaneseImperialCalendar, and sun.util.BuddhistCalendar.
 	 * @author Tumi <serverperformance@gmail.com> */
-	static public class CalendarSerializer extends Serializer<Calendar> {
+	public static class CalendarSerializer extends Serializer<Calendar> {
 		// The default value of gregorianCutover.
-		static private final long DEFAULT_GREGORIAN_CUTOVER = -12219292800000L;
+		private static final long DEFAULT_GREGORIAN_CUTOVER = -12219292800000L;
 
 		TimeZoneSerializer timeZoneSerializer = new TimeZoneSerializer();
 
@@ -622,7 +622,7 @@ public class DefaultSerializers {
 
 	/** Serializer for {@link TreeMap} and any subclass.
 	 * @author Tumi <serverperformance@gmail.com> (enhacements) */
-	static public class TreeMapSerializer extends MapSerializer<TreeMap> {
+	public static class TreeMapSerializer extends MapSerializer<TreeMap> {
 		protected void writeHeader (Kryo kryo, Output output, TreeMap treeSet) {
 			kryo.writeClassAndObject(output, treeSet.comparator());
 		}
@@ -655,7 +655,7 @@ public class DefaultSerializers {
 
 	/** Serializer for {@link TreeMap} and any subclass.
 	 * @author Tumi <serverperformance@gmail.com> (enhacements) */
-	static public class TreeSetSerializer extends CollectionSerializer<TreeSet> {
+	public static class TreeSetSerializer extends CollectionSerializer<TreeSet> {
 		protected void writeHeader (Kryo kryo, Output output, TreeSet treeSet) {
 			kryo.writeClassAndObject(output, treeSet.comparator());
 		}
@@ -688,7 +688,7 @@ public class DefaultSerializers {
 
 	/** Serializer for {@link PriorityQueue} and any subclass.
 	 * @author Nathan Sweet */
-	static public class PriorityQueueSerializer extends CollectionSerializer<PriorityQueue> {
+	public static class PriorityQueueSerializer extends CollectionSerializer<PriorityQueue> {
 		protected void writeHeader (Kryo kryo, Output output, PriorityQueue queue) {
 			kryo.writeClassAndObject(output, queue.comparator());
 		}
@@ -721,10 +721,10 @@ public class DefaultSerializers {
 
 	/** Serializer for {@link Locale} (immutables).
 	 * @author Tumi <serverperformance@gmail.com> */
-	static public class LocaleSerializer extends ImmutableSerializer<Locale> {
+	public static class LocaleSerializer extends ImmutableSerializer<Locale> {
 		// Missing constants in j.u.Locale for common locale
-		static public final Locale SPANISH = new Locale("es", "", "");
-		static public final Locale SPAIN = new Locale("es", "ES", "");
+		public static final Locale SPANISH = new Locale("es", "", "");
+		public static final Locale SPAIN = new Locale("es", "ES", "");
 
 		protected Locale create (String language, String country, String variant) {
 			// Fast-path for default locale in this system (may not be in the Locale constants list)
@@ -784,7 +784,7 @@ public class DefaultSerializers {
 	}
 
 	/** Serializer for {@link Charset}. */
-	static public class CharsetSerializer extends ImmutableSerializer<Charset> {
+	public static class CharsetSerializer extends ImmutableSerializer<Charset> {
 		public void write (Kryo kryo, Output output, Charset object) {
 			output.writeString(object.name());
 		}
@@ -795,7 +795,7 @@ public class DefaultSerializers {
 	}
 
 	/** Serializer for {@link URL}. */
-	static public class URLSerializer extends ImmutableSerializer<URL> {
+	public static class URLSerializer extends ImmutableSerializer<URL> {
 		public void write (Kryo kryo, Output output, URL object) {
 			output.writeString(object.toExternalForm());
 		}
@@ -810,7 +810,7 @@ public class DefaultSerializers {
 	}
 
 	/** Serializer for {@link Arrays#asList(Object...)}. */
-	static public class ArraysAsListSerializer extends CollectionSerializer<List> {
+	public static class ArraysAsListSerializer extends CollectionSerializer<List> {
 		protected List create (Kryo kryo, Input input, Class type, int size) {
 			return new ArrayList(size);
 		}
@@ -826,7 +826,7 @@ public class DefaultSerializers {
 		}
 	}
 
-	static public class BitSetSerializer extends Serializer<BitSet> {
+	public static class BitSetSerializer extends Serializer<BitSet> {
 		public void write (Kryo kryo, Output output, BitSet set) {
 			long[] values = set.toLongArray();
 			output.writeVarInt(values.length, true);

--- a/src/com/esotericsoftware/kryo/serializers/ExternalizableSerializer.java
+++ b/src/com/esotericsoftware/kryo/serializers/ExternalizableSerializer.java
@@ -118,7 +118,7 @@ public class ExternalizableSerializer extends Serializer {
 	}
 
 	/* find out if there are any pesky serialization extras on this class */
-	static private boolean hasInheritableReplaceMethod (Class type, String methodName) {
+	private static boolean hasInheritableReplaceMethod (Class type, String methodName) {
 		Method method = null;
 		Class current = type;
 		while (current != null) {

--- a/src/com/esotericsoftware/kryo/serializers/FieldSerializer.java
+++ b/src/com/esotericsoftware/kryo/serializers/FieldSerializer.java
@@ -222,7 +222,7 @@ public class FieldSerializer<T> extends Serializer<T> {
 	}
 
 	/** Settings for serializing a field. */
-	static public abstract class CachedField {
+	public abstract static class CachedField {
 		final Field field;
 		String name;
 		Class valueClass;
@@ -320,11 +320,11 @@ public class FieldSerializer<T> extends Serializer<T> {
 			return name;
 		}
 
-		abstract public void write (Output output, Object object);
+		public abstract void write (Output output, Object object);
 
-		abstract public void read (Input input, Object object);
+		public abstract void read (Input input, Object object);
 
-		abstract public void copy (Object original, Object copy);
+		public abstract void copy (Object original, Object copy);
 	}
 
 	/** Indicates a field should be ignored when its declaring class is registered unless the {@link Kryo#getContext() context} has
@@ -373,7 +373,7 @@ public class FieldSerializer<T> extends Serializer<T> {
 	}
 
 	/** Configuration for FieldSerializer instances. */
-	static public class FieldSerializerConfig implements Cloneable {
+	public static class FieldSerializerConfig implements Cloneable {
 		boolean fieldsCanBeNull = true;
 		boolean setFieldsAsAccessible = true;
 		boolean ignoreSyntheticFields = true;

--- a/src/com/esotericsoftware/kryo/serializers/ImmutableCollectionsSerializers.java
+++ b/src/com/esotericsoftware/kryo/serializers/ImmutableCollectionsSerializers.java
@@ -33,7 +33,7 @@ import java.util.Set;
 
 /** Serializers for {@link java.util.ImmutableCollections}, Are added as default serializers for java >= 9. */
 public final class ImmutableCollectionsSerializers {
-	static public void addDefaultSerializers (Kryo kryo) {
+	public static void addDefaultSerializers (Kryo kryo) {
 		if (isClassAvailable("java.util.ImmutableCollections")) {
 			JdkImmutableListSerializer.addDefaultSerializers(kryo);
 			JdkImmutableMapSerializer.addDefaultSerializers(kryo);

--- a/src/com/esotericsoftware/kryo/serializers/ImmutableSerializer.java
+++ b/src/com/esotericsoftware/kryo/serializers/ImmutableSerializer.java
@@ -24,7 +24,7 @@ import com.esotericsoftware.kryo.Serializer;
 /** A serializer which has {@link #setImmutable(boolean)} set to true. This convenience class exists only to reduce the typing
  * needed to define a serializer which is immutable.
  * @author Nathan Sweet */
-abstract public class ImmutableSerializer<T> extends Serializer<T> {
+public abstract class ImmutableSerializer<T> extends Serializer<T> {
 	{
 		setImmutable(true);
 	}

--- a/src/com/esotericsoftware/kryo/serializers/JavaSerializer.java
+++ b/src/com/esotericsoftware/kryo/serializers/JavaSerializer.java
@@ -73,7 +73,7 @@ public class JavaSerializer extends Serializer {
 	 * Java issue and is often solved by using a specific class loader. See:
 	 * https://github.com/apache/spark/blob/v1.6.3/streaming/src/main/scala/org/apache/spark/streaming/Checkpoint.scala#L154
 	 * https://issues.apache.org/jira/browse/GROOVY-1627 */
-	static private class ObjectInputStreamWithKryoClassLoader extends ObjectInputStream {
+	private static class ObjectInputStreamWithKryoClassLoader extends ObjectInputStream {
 		private final Kryo kryo;
 
 		ObjectInputStreamWithKryoClassLoader (InputStream in, Kryo kryo) throws IOException {

--- a/src/com/esotericsoftware/kryo/serializers/OptionalSerializers.java
+++ b/src/com/esotericsoftware/kryo/serializers/OptionalSerializers.java
@@ -34,7 +34,7 @@ import java.util.OptionalLong;
 /** Serializers for {@link Optional}, {@link OptionalInt}, {@link OptionalLong} and {@link OptionalDouble}. Are added as default
  * serializers for java >= 1.8. */
 public final class OptionalSerializers {
-	static public void addDefaultSerializers (Kryo kryo) {
+	public static void addDefaultSerializers (Kryo kryo) {
 		if (isClassAvailable("java.util.Optional")) kryo.addDefaultSerializer(Optional.class, OptionalSerializer.class);
 		if (isClassAvailable("java.util.OptionalInt")) kryo.addDefaultSerializer(OptionalInt.class, OptionalIntSerializer.class);
 		if (isClassAvailable("java.util.OptionalLong")) kryo.addDefaultSerializer(OptionalLong.class, OptionalLongSerializer.class);
@@ -42,7 +42,7 @@ public final class OptionalSerializers {
 			kryo.addDefaultSerializer(OptionalDouble.class, OptionalDoubleSerializer.class);
 	}
 
-	static public class OptionalSerializer extends Serializer<Optional> {
+	public static class OptionalSerializer extends Serializer<Optional> {
 		{
 			setAcceptsNull(false);
 		}
@@ -64,7 +64,7 @@ public final class OptionalSerializers {
 		}
 	}
 
-	static public class OptionalIntSerializer extends ImmutableSerializer<OptionalInt> {
+	public static class OptionalIntSerializer extends ImmutableSerializer<OptionalInt> {
 		public void write (Kryo kryo, Output output, OptionalInt object) {
 			output.writeBoolean(object.isPresent());
 			if (object.isPresent()) output.writeInt(object.getAsInt());
@@ -76,7 +76,7 @@ public final class OptionalSerializers {
 		}
 	}
 
-	static public class OptionalLongSerializer extends ImmutableSerializer<OptionalLong> {
+	public static class OptionalLongSerializer extends ImmutableSerializer<OptionalLong> {
 		public void write (Kryo kryo, Output output, OptionalLong object) {
 			output.writeBoolean(object.isPresent());
 			if (object.isPresent()) output.writeLong(object.getAsLong());
@@ -88,7 +88,7 @@ public final class OptionalSerializers {
 		}
 	}
 
-	static public class OptionalDoubleSerializer extends ImmutableSerializer<OptionalDouble> {
+	public static class OptionalDoubleSerializer extends ImmutableSerializer<OptionalDouble> {
 		public void write (Kryo kryo, Output output, OptionalDouble object) {
 			output.writeBoolean(object.isPresent());
 			if (object.isPresent()) output.writeDouble(object.getAsDouble());

--- a/src/com/esotericsoftware/kryo/serializers/ReflectField.java
+++ b/src/com/esotericsoftware/kryo/serializers/ReflectField.java
@@ -159,7 +159,7 @@ class ReflectField extends CachedField {
 		}
 	}
 
-	final static class IntReflectField extends CachedField {
+	static final class IntReflectField extends CachedField {
 		public IntReflectField (Field field) {
 			super(field);
 		}
@@ -201,7 +201,7 @@ class ReflectField extends CachedField {
 		}
 	}
 
-	final static class FloatReflectField extends CachedField {
+	static final class FloatReflectField extends CachedField {
 		public FloatReflectField (Field field) {
 			super(field);
 		}
@@ -237,7 +237,7 @@ class ReflectField extends CachedField {
 		}
 	}
 
-	final static class ShortReflectField extends CachedField {
+	static final class ShortReflectField extends CachedField {
 		public ShortReflectField (Field field) {
 			super(field);
 		}
@@ -273,7 +273,7 @@ class ReflectField extends CachedField {
 		}
 	}
 
-	final static class ByteReflectField extends CachedField {
+	static final class ByteReflectField extends CachedField {
 		public ByteReflectField (Field field) {
 			super(field);
 		}
@@ -309,7 +309,7 @@ class ReflectField extends CachedField {
 		}
 	}
 
-	final static class BooleanReflectField extends CachedField {
+	static final class BooleanReflectField extends CachedField {
 		public BooleanReflectField (Field field) {
 			super(field);
 		}
@@ -345,7 +345,7 @@ class ReflectField extends CachedField {
 		}
 	}
 
-	final static class CharReflectField extends CachedField {
+	static final class CharReflectField extends CachedField {
 		public CharReflectField (Field field) {
 			super(field);
 		}
@@ -381,7 +381,7 @@ class ReflectField extends CachedField {
 		}
 	}
 
-	final static class LongReflectField extends CachedField {
+	static final class LongReflectField extends CachedField {
 		public LongReflectField (Field field) {
 			super(field);
 		}
@@ -423,7 +423,7 @@ class ReflectField extends CachedField {
 		}
 	}
 
-	final static class DoubleReflectField extends CachedField {
+	static final class DoubleReflectField extends CachedField {
 		public DoubleReflectField (Field field) {
 			super(field);
 		}

--- a/src/com/esotericsoftware/kryo/serializers/TaggedFieldSerializer.java
+++ b/src/com/esotericsoftware/kryo/serializers/TaggedFieldSerializer.java
@@ -249,7 +249,7 @@ public class TaggedFieldSerializer<T> extends FieldSerializer<T> {
 	}
 
 	/** Configuration for TaggedFieldSerializer instances. */
-	static public class TaggedFieldSerializerConfig extends FieldSerializerConfig {
+	public static class TaggedFieldSerializerConfig extends FieldSerializerConfig {
 		boolean readUnknownTagData, chunked;
 		int chunkSize = 1024;
 

--- a/src/com/esotericsoftware/kryo/serializers/TimeSerializers.java
+++ b/src/com/esotericsoftware/kryo/serializers/TimeSerializers.java
@@ -47,7 +47,7 @@ import java.time.ZonedDateTime;
  *
  * Implementation note: All serialization is inspired by oracles java.time.Ser. */
 public final class TimeSerializers {
-	static public void addDefaultSerializers (Kryo kryo) {
+	public static void addDefaultSerializers (Kryo kryo) {
 		if (isClassAvailable("java.time.Duration")) kryo.addDefaultSerializer(Duration.class, DurationSerializer.class);
 		if (isClassAvailable("java.time.Instant")) kryo.addDefaultSerializer(Instant.class, InstantSerializer.class);
 		if (isClassAvailable("java.time.LocalDate")) kryo.addDefaultSerializer(LocalDate.class, LocalDateSerializer.class);
@@ -67,7 +67,7 @@ public final class TimeSerializers {
 		if (isClassAvailable("java.time.Period")) kryo.addDefaultSerializer(Period.class, PeriodSerializer.class);
 	}
 
-	static public class DurationSerializer extends ImmutableSerializer<Duration> {
+	public static class DurationSerializer extends ImmutableSerializer<Duration> {
 		public void write (Kryo kryo, Output out, Duration duration) {
 			out.writeLong(duration.getSeconds());
 			out.writeInt(duration.getNano(), true);
@@ -80,7 +80,7 @@ public final class TimeSerializers {
 		}
 	}
 
-	static public class InstantSerializer extends ImmutableSerializer<Instant> {
+	public static class InstantSerializer extends ImmutableSerializer<Instant> {
 		public void write (Kryo kryo, Output out, Instant instant) {
 			out.writeVarLong(instant.getEpochSecond(), true);
 			out.writeInt(instant.getNano(), true);
@@ -93,7 +93,7 @@ public final class TimeSerializers {
 		}
 	}
 
-	static public class LocalDateSerializer extends ImmutableSerializer<LocalDate> {
+	public static class LocalDateSerializer extends ImmutableSerializer<LocalDate> {
 		public void write (Kryo kryo, Output out, LocalDate date) {
 			write(out, date);
 		}
@@ -116,7 +116,7 @@ public final class TimeSerializers {
 		}
 	}
 
-	static public class LocalDateTimeSerializer extends ImmutableSerializer<LocalDateTime> {
+	public static class LocalDateTimeSerializer extends ImmutableSerializer<LocalDateTime> {
 		public void write (Kryo kryo, Output out, LocalDateTime dateTime) {
 			LocalDateSerializer.write(out, dateTime.toLocalDate());
 			LocalTimeSerializer.write(out, dateTime.toLocalTime());
@@ -129,7 +129,7 @@ public final class TimeSerializers {
 		}
 	}
 
-	static public class LocalTimeSerializer extends ImmutableSerializer<LocalTime> {
+	public static class LocalTimeSerializer extends ImmutableSerializer<LocalTime> {
 		public void write (Kryo kryo, Output out, LocalTime time) {
 			write(out, time);
 		}
@@ -184,7 +184,7 @@ public final class TimeSerializers {
 		}
 	}
 
-	static public class ZoneOffsetSerializer extends ImmutableSerializer<ZoneOffset> {
+	public static class ZoneOffsetSerializer extends ImmutableSerializer<ZoneOffset> {
 		public void write (Kryo kryo, Output out, ZoneOffset obj) {
 			write(out, obj);
 		}
@@ -208,7 +208,7 @@ public final class TimeSerializers {
 		}
 	}
 
-	static public class ZoneIdSerializer extends ImmutableSerializer<ZoneId> {
+	public static class ZoneIdSerializer extends ImmutableSerializer<ZoneId> {
 		public void write (Kryo kryo, Output out, ZoneId obj) {
 			write(out, obj);
 		}
@@ -227,7 +227,7 @@ public final class TimeSerializers {
 		}
 	}
 
-	static public class OffsetTimeSerializer extends ImmutableSerializer<OffsetTime> {
+	public static class OffsetTimeSerializer extends ImmutableSerializer<OffsetTime> {
 		public void write (Kryo kryo, Output out, OffsetTime obj) {
 			LocalTimeSerializer.write(out, obj.toLocalTime());
 			ZoneOffsetSerializer.write(out, obj.getOffset());
@@ -240,7 +240,7 @@ public final class TimeSerializers {
 		}
 	}
 
-	static public class OffsetDateTimeSerializer extends ImmutableSerializer<OffsetDateTime> {
+	public static class OffsetDateTimeSerializer extends ImmutableSerializer<OffsetDateTime> {
 		public void write (Kryo kryo, Output out, OffsetDateTime obj) {
 			LocalDateSerializer.write(out, obj.toLocalDate());
 			LocalTimeSerializer.write(out, obj.toLocalTime());
@@ -255,7 +255,7 @@ public final class TimeSerializers {
 		}
 	}
 
-	static public class ZonedDateTimeSerializer extends ImmutableSerializer<ZonedDateTime> {
+	public static class ZonedDateTimeSerializer extends ImmutableSerializer<ZonedDateTime> {
 		public void write (Kryo kryo, Output out, ZonedDateTime obj) {
 			LocalDateSerializer.write(out, obj.toLocalDate());
 			LocalTimeSerializer.write(out, obj.toLocalTime());
@@ -270,7 +270,7 @@ public final class TimeSerializers {
 		}
 	}
 
-	static public class YearSerializer extends ImmutableSerializer<Year> {
+	public static class YearSerializer extends ImmutableSerializer<Year> {
 		public void write (Kryo kryo, Output out, Year obj) {
 			out.writeVarInt(obj.getValue(), true);
 		}
@@ -280,7 +280,7 @@ public final class TimeSerializers {
 		}
 	}
 
-	static public class YearMonthSerializer extends ImmutableSerializer<YearMonth> {
+	public static class YearMonthSerializer extends ImmutableSerializer<YearMonth> {
 		public void write (Kryo kryo, Output out, YearMonth obj) {
 			out.writeVarInt(obj.getYear(), true);
 			out.writeByte(obj.getMonthValue());
@@ -293,7 +293,7 @@ public final class TimeSerializers {
 		}
 	}
 
-	static public class MonthDaySerializer extends ImmutableSerializer<MonthDay> {
+	public static class MonthDaySerializer extends ImmutableSerializer<MonthDay> {
 		public void write (Kryo kryo, Output out, MonthDay obj) {
 			out.writeByte(obj.getMonthValue());
 			out.writeByte(obj.getDayOfMonth());
@@ -306,7 +306,7 @@ public final class TimeSerializers {
 		}
 	}
 
-	static public class PeriodSerializer extends ImmutableSerializer<Period> {
+	public static class PeriodSerializer extends ImmutableSerializer<Period> {
 		public void write (Kryo kryo, Output out, Period obj) {
 			out.writeVarInt(obj.getYears(), true);
 			out.writeVarInt(obj.getMonths(), true);

--- a/src/com/esotericsoftware/kryo/serializers/UnsafeField.java
+++ b/src/com/esotericsoftware/kryo/serializers/UnsafeField.java
@@ -59,7 +59,7 @@ class UnsafeField extends ReflectField {
 		}
 	}
 
-	final static class IntUnsafeField extends CachedField {
+	static final class IntUnsafeField extends CachedField {
 		public IntUnsafeField (Field field) {
 			super(field);
 			offset = unsafe.objectFieldOffset(field);
@@ -84,7 +84,7 @@ class UnsafeField extends ReflectField {
 		}
 	}
 
-	final static class FloatUnsafeField extends CachedField {
+	static final class FloatUnsafeField extends CachedField {
 		public FloatUnsafeField (Field field) {
 			super(field);
 			offset = unsafe.objectFieldOffset(field);
@@ -103,7 +103,7 @@ class UnsafeField extends ReflectField {
 		}
 	}
 
-	final static class ShortUnsafeField extends CachedField {
+	static final class ShortUnsafeField extends CachedField {
 		public ShortUnsafeField (Field field) {
 			super(field);
 			offset = unsafe.objectFieldOffset(field);
@@ -122,7 +122,7 @@ class UnsafeField extends ReflectField {
 		}
 	}
 
-	final static class ByteUnsafeField extends CachedField {
+	static final class ByteUnsafeField extends CachedField {
 		public ByteUnsafeField (Field field) {
 			super(field);
 			offset = unsafe.objectFieldOffset(field);
@@ -141,7 +141,7 @@ class UnsafeField extends ReflectField {
 		}
 	}
 
-	final static class BooleanUnsafeField extends CachedField {
+	static final class BooleanUnsafeField extends CachedField {
 		public BooleanUnsafeField (Field field) {
 			super(field);
 			offset = unsafe.objectFieldOffset(field);
@@ -160,7 +160,7 @@ class UnsafeField extends ReflectField {
 		}
 	}
 
-	final static class CharUnsafeField extends CachedField {
+	static final class CharUnsafeField extends CachedField {
 		public CharUnsafeField (Field field) {
 			super(field);
 			offset = unsafe.objectFieldOffset(field);
@@ -179,7 +179,7 @@ class UnsafeField extends ReflectField {
 		}
 	}
 
-	final static class LongUnsafeField extends CachedField {
+	static final class LongUnsafeField extends CachedField {
 		public LongUnsafeField (Field field) {
 			super(field);
 			offset = unsafe.objectFieldOffset(field);
@@ -204,7 +204,7 @@ class UnsafeField extends ReflectField {
 		}
 	}
 
-	final static class DoubleUnsafeField extends CachedField {
+	static final class DoubleUnsafeField extends CachedField {
 		public DoubleUnsafeField (Field field) {
 			super(field);
 			offset = unsafe.objectFieldOffset(field);
@@ -223,7 +223,7 @@ class UnsafeField extends ReflectField {
 		}
 	}
 
-	final static class StringUnsafeField extends CachedField {
+	static final class StringUnsafeField extends CachedField {
 		public StringUnsafeField (Field field) {
 			super(field);
 			offset = unsafe.objectFieldOffset(field);

--- a/src/com/esotericsoftware/kryo/serializers/VersionFieldSerializer.java
+++ b/src/com/esotericsoftware/kryo/serializers/VersionFieldSerializer.java
@@ -148,7 +148,7 @@ public class VersionFieldSerializer<T> extends FieldSerializer<T> {
 	}
 
 	/** Configuration for VersionFieldSerializer instances. */
-	static public class VersionFieldSerializerConfig extends FieldSerializerConfig {
+	public static class VersionFieldSerializerConfig extends FieldSerializerConfig {
 		boolean compatible = true;
 
 		public VersionFieldSerializerConfig clone () {

--- a/src/com/esotericsoftware/kryo/unsafe/UnsafeUtil.java
+++ b/src/com/esotericsoftware/kryo/unsafe/UnsafeUtil.java
@@ -39,16 +39,16 @@ import sun.nio.ch.DirectBuffer;
 @SuppressWarnings("restriction")
 public class UnsafeUtil {
 	/** The sun.misc.Unsafe instance, or null if Unsafe is unavailable. */
-	static public final Unsafe unsafe;
+	public static final Unsafe unsafe;
 
-	static public final long byteArrayBaseOffset;
-	static public final long floatArrayBaseOffset;
-	static public final long doubleArrayBaseOffset;
-	static public final long intArrayBaseOffset;
-	static public final long longArrayBaseOffset;
-	static public final long shortArrayBaseOffset;
-	static public final long charArrayBaseOffset;
-	static public final long booleanArrayBaseOffset;
+	public static final long byteArrayBaseOffset;
+	public static final long floatArrayBaseOffset;
+	public static final long doubleArrayBaseOffset;
+	public static final long intArrayBaseOffset;
+	public static final long longArrayBaseOffset;
+	public static final long shortArrayBaseOffset;
+	public static final long charArrayBaseOffset;
+	public static final long booleanArrayBaseOffset;
 	static {
 		Unsafe tempUnsafe = null;
 		long tempByteArrayBaseOffset = 0;
@@ -92,7 +92,7 @@ public class UnsafeUtil {
 	}
 
 	// Constructor to be used for creation of ByteBuffers that use preallocated memory regions.
-	static private Constructor<? extends ByteBuffer> directByteBufferConstructor;
+	private static Constructor<? extends ByteBuffer> directByteBufferConstructor;
 	static {
 		ByteBuffer buffer = ByteBuffer.allocateDirect(1);
 		try {
@@ -104,7 +104,7 @@ public class UnsafeUtil {
 		}
 	}
 
-	static private Method cleanerMethod, cleanMethod;
+	private static Method cleanerMethod, cleanMethod;
 	static {
 		try {
 			cleanerMethod = DirectBuffer.class.getMethod("cleaner");
@@ -120,7 +120,7 @@ public class UnsafeUtil {
 	 * @param address Address of the memory region to be used for a ByteBuffer.
 	 * @param size Size in bytes of the memory region.
 	 * @throws UnsupportedOperationException if creating a ByteBuffer this way is not available. */
-	static public ByteBuffer newDirectBuffer (long address, int size) {
+	public static ByteBuffer newDirectBuffer (long address, int size) {
 		if (directByteBufferConstructor == null)
 			throw new UnsupportedOperationException("No direct ByteBuffer constructor is available.");
 		try {
@@ -131,12 +131,12 @@ public class UnsafeUtil {
 	}
 
 	/** Returns true if {@link #newDirectBuffer(long, int)} can be called. */
-	static public boolean isNewDirectBufferAvailable () {
+	public static boolean isNewDirectBufferAvailable () {
 		return directByteBufferConstructor != null;
 	}
 
 	/** Release a direct buffer immediately rather than waiting for GC. */
-	static public void dispose (ByteBuffer buffer) {
+	public static void dispose (ByteBuffer buffer) {
 		if (!(buffer instanceof DirectBuffer)) return;
 		if (cleanerMethod != null) {
 			try {

--- a/src/com/esotericsoftware/kryo/util/DefaultClassResolver.java
+++ b/src/com/esotericsoftware/kryo/util/DefaultClassResolver.java
@@ -32,7 +32,7 @@ import com.esotericsoftware.kryo.io.Output;
 /** Resolves classes by ID or by fully qualified class name.
  * @author Nathan Sweet */
 public class DefaultClassResolver implements ClassResolver {
-	static public final byte NAME = -1;
+	public static final byte NAME = -1;
 
 	protected Kryo kryo;
 

--- a/src/com/esotericsoftware/kryo/util/GenericsUtil.java
+++ b/src/com/esotericsoftware/kryo/util/GenericsUtil.java
@@ -33,7 +33,7 @@ public class GenericsUtil {
 	/** Returns the class for the specified type after replacing any type variables using the class hierarchy between the specified
 	 * classes.
 	 * @param toClass Must be a sub class of fromClass. */
-	static public Type resolveType (Class fromClass, Class toClass, Type type) {
+	public static Type resolveType (Class fromClass, Class toClass, Type type) {
 		// Explicit type, eg String.
 		if (type instanceof Class) return type;
 
@@ -76,7 +76,7 @@ public class GenericsUtil {
 	 * @param current Must be a sub class of fromClass.
 	 * @return A Class if the type variable was resolved, else a TypeVariable to continue searching or if the type could not be
 	 *         resolved. */
-	static private Type resolveTypeVariable (Class fromClass, Class current, Type type, boolean first) {
+	private static Type resolveTypeVariable (Class fromClass, Class current, Type type, boolean first) {
 		Type genericSuper = current.getGenericSuperclass();
 		if (!(genericSuper instanceof ParameterizedType)) return type; // No type arguments passed to super class.
 
@@ -119,7 +119,7 @@ public class GenericsUtil {
 	 * @param toClass Must be a sub class of fromClass.
 	 * @return Null if the type has no type parameters, else contains Class entries for type parameters that were resolved and
 	 *         TypeVariable entries for type parameters that couldn't be resolved. */
-	static public Type[] resolveTypeParameters (Class fromClass, Class toClass, Type type) {
+	public static Type[] resolveTypeParameters (Class fromClass, Class toClass, Type type) {
 		// Type which has a type parameter, eg ArrayList<T>.
 		if (type instanceof ParameterizedType) {
 			Type[] actualArgs = ((ParameterizedType)type).getActualTypeArguments();

--- a/src/com/esotericsoftware/kryo/util/IntArray.java
+++ b/src/com/esotericsoftware/kryo/util/IntArray.java
@@ -381,7 +381,7 @@ public class IntArray {
 	}
 
 	/** @see #IntArray(int[]) */
-	static public IntArray with (int... array) {
+	public static IntArray with (int... array) {
 		return new IntArray(array);
 	}
 }

--- a/src/com/esotericsoftware/kryo/util/IntMap.java
+++ b/src/com/esotericsoftware/kryo/util/IntMap.java
@@ -461,7 +461,7 @@ public class IntMap<V> implements Iterable<IntMap.Entry<V>> {
 		return new Keys(this);
 	}
 
-	static public class Entry<V> {
+	public static class Entry<V> {
 		public int key;
 		public @Null V value;
 
@@ -470,8 +470,8 @@ public class IntMap<V> implements Iterable<IntMap.Entry<V>> {
 		}
 	}
 
-	static private class MapIterator<V> {
-		static private final int INDEX_ILLEGAL = -2;
+	private static class MapIterator<V> {
+		private static final int INDEX_ILLEGAL = -2;
 		static final int INDEX_ZERO = -1;
 
 		public boolean hasNext;
@@ -532,7 +532,7 @@ public class IntMap<V> implements Iterable<IntMap.Entry<V>> {
 		}
 	}
 
-	static public class Entries<V> extends MapIterator<V> implements Iterable<Entry<V>>, Iterator<Entry<V>> {
+	public static class Entries<V> extends MapIterator<V> implements Iterable<Entry<V>>, Iterator<Entry<V>> {
 		private final Entry<V> entry = new Entry();
 
 		public Entries (IntMap map) {
@@ -566,7 +566,7 @@ public class IntMap<V> implements Iterable<IntMap.Entry<V>> {
 		}
 	}
 
-	static public class Values<V> extends MapIterator<V> implements Iterable<V>, Iterator<V> {
+	public static class Values<V> extends MapIterator<V> implements Iterable<V>, Iterator<V> {
 		public Values (IntMap<V> map) {
 			super(map);
 		}
@@ -601,7 +601,7 @@ public class IntMap<V> implements Iterable<IntMap.Entry<V>> {
 		}
 	}
 
-	static public class Keys extends MapIterator {
+	public static class Keys extends MapIterator {
 		public Keys (IntMap map) {
 			super(map);
 		}

--- a/src/com/esotericsoftware/kryo/util/ObjectIntMap.java
+++ b/src/com/esotericsoftware/kryo/util/ObjectIntMap.java
@@ -369,7 +369,7 @@ public class ObjectIntMap<K> implements Iterable<ObjectIntMap.Entry<K>> {
 		return new Keys(this);
 	}
 
-	static public class Entry<K> {
+	public static class Entry<K> {
 		public K key;
 		public int value;
 
@@ -378,7 +378,7 @@ public class ObjectIntMap<K> implements Iterable<ObjectIntMap.Entry<K>> {
 		}
 	}
 
-	static private class MapIterator<K> {
+	private static class MapIterator<K> {
 		public boolean hasNext;
 
 		final ObjectIntMap<K> map;
@@ -430,7 +430,7 @@ public class ObjectIntMap<K> implements Iterable<ObjectIntMap.Entry<K>> {
 		}
 	}
 
-	static public class Entries<K> extends MapIterator<K> implements Iterable<Entry<K>>, Iterator<Entry<K>> {
+	public static class Entries<K> extends MapIterator<K> implements Iterable<Entry<K>>, Iterator<Entry<K>> {
 		Entry<K> entry = new Entry<K>();
 
 		public Entries (ObjectIntMap<K> map) {
@@ -459,7 +459,7 @@ public class ObjectIntMap<K> implements Iterable<ObjectIntMap.Entry<K>> {
 		}
 	}
 
-	static public class Values extends MapIterator<Object> {
+	public static class Values extends MapIterator<Object> {
 		public Values (ObjectIntMap<?> map) {
 			super((ObjectIntMap<Object>)map);
 		}
@@ -498,7 +498,7 @@ public class ObjectIntMap<K> implements Iterable<ObjectIntMap.Entry<K>> {
 		}
 	}
 
-	static public class Keys<K> extends MapIterator<K> implements Iterable<K>, Iterator<K> {
+	public static class Keys<K> extends MapIterator<K> implements Iterable<K>, Iterator<K> {
 		public Keys (ObjectIntMap<K> map) {
 			super(map);
 		}

--- a/src/com/esotericsoftware/kryo/util/ObjectMap.java
+++ b/src/com/esotericsoftware/kryo/util/ObjectMap.java
@@ -423,14 +423,14 @@ public class ObjectMap<K, V> implements Iterable<ObjectMap.Entry<K, V>> {
 		return new Keys(this);
 	}
 
-	static public int tableSize (int capacity, float loadFactor) {
+	public static int tableSize (int capacity, float loadFactor) {
 		if (capacity < 0) throw new IllegalArgumentException("capacity must be >= 0: " + capacity);
 		int tableSize = nextPowerOfTwo(Math.max(2, (int)Math.ceil(capacity / loadFactor)));
 		if (tableSize > 1 << 30) throw new IllegalArgumentException("The required capacity is too large: " + capacity);
 		return tableSize;
 	}
 
-	static public int nextPowerOfTwo (int value) {
+	public static int nextPowerOfTwo (int value) {
 		if (value == 0) return 1;
 		value--;
 		value |= value >> 1;
@@ -441,7 +441,7 @@ public class ObjectMap<K, V> implements Iterable<ObjectMap.Entry<K, V>> {
 		return value + 1;
 	}
 
-	static public class Entry<K, V> {
+	public static class Entry<K, V> {
 		public K key;
 		@Null public V value;
 
@@ -450,7 +450,7 @@ public class ObjectMap<K, V> implements Iterable<ObjectMap.Entry<K, V>> {
 		}
 	}
 
-	static private abstract class MapIterator<K, V, I> implements Iterable<I>, Iterator<I> {
+	private abstract static class MapIterator<K, V, I> implements Iterable<I>, Iterator<I> {
 		public boolean hasNext;
 
 		final ObjectMap<K, V> map;
@@ -503,7 +503,7 @@ public class ObjectMap<K, V> implements Iterable<ObjectMap.Entry<K, V>> {
 		}
 	}
 
-	static public class Entries<K, V> extends MapIterator<K, V, Entry<K, V>> {
+	public static class Entries<K, V> extends MapIterator<K, V, Entry<K, V>> {
 		Entry<K, V> entry = new Entry<K, V>();
 
 		public Entries (ObjectMap<K, V> map) {
@@ -530,7 +530,7 @@ public class ObjectMap<K, V> implements Iterable<ObjectMap.Entry<K, V>> {
 		}
 	}
 
-	static public class Values<V> extends MapIterator<Object, V, V> {
+	public static class Values<V> extends MapIterator<Object, V, V> {
 		public Values (ObjectMap<?, V> map) {
 			super((ObjectMap<Object, V>)map);
 		}
@@ -565,7 +565,7 @@ public class ObjectMap<K, V> implements Iterable<ObjectMap.Entry<K, V>> {
 		}
 	}
 
-	static public class Keys<K> extends MapIterator<K, Object, K> {
+	public static class Keys<K> extends MapIterator<K, Object, K> {
 		public Keys (ObjectMap<K, ?> map) {
 			super((ObjectMap<K, Object>)map);
 		}

--- a/src/com/esotericsoftware/kryo/util/Pool.java
+++ b/src/com/esotericsoftware/kryo/util/Pool.java
@@ -31,7 +31,7 @@ import java.util.concurrent.LinkedBlockingQueue;
  * soft references.
  * @author Nathan Sweet
  * @author Martin Grotzke */
-abstract public class Pool<T> {
+public abstract class Pool<T> {
 	private final Queue<T> freeObjects;
 	private int peak;
 
@@ -66,7 +66,7 @@ abstract public class Pool<T> {
 		freeObjects = softReferences ? new SoftReferenceQueue(queue) : queue;
 	}
 
-	abstract protected T create ();
+	protected abstract T create ();
 
 	/** Returns an object from this pool. The object may be new (from {@link #create()}) or reused (previously {@link #free(Object)
 	 * freed}). */
@@ -130,7 +130,7 @@ abstract public class Pool<T> {
 	}
 
 	/** Objects implementing this interface will have {@link #reset()} called when passed to {@link Pool#free(Object)}. */
-	static public interface Poolable {
+	public static interface Poolable {
 		/** Resets the object for reuse. Object references should be nulled and fields may be set to default values. */
 		public void reset ();
 	}

--- a/src/com/esotericsoftware/kryo/util/Util.java
+++ b/src/com/esotericsoftware/kryo/util/Util.java
@@ -31,10 +31,10 @@ import java.lang.reflect.Type;
 /** A few utility methods, mostly for private use.
  * @author Nathan Sweet */
 public class Util {
-	static public final boolean isAndroid = "Dalvik".equals(System.getProperty("java.vm.name"));
+	public static final boolean isAndroid = "Dalvik".equals(System.getProperty("java.vm.name"));
 
 	/** True if Unsafe is available. Unsafe can be disabled by setting the system property "kryo.unsafe" to "false". */
-	static public final boolean unsafe;
+	public static final boolean unsafe;
 	static {
 		boolean found = false;
 		if ("false".equals(System.getProperty("kryo.unsafe"))) {
@@ -51,9 +51,9 @@ public class Util {
 	}
 
 	// Maximum reasonable array length. See: https://stackoverflow.com/questions/3038392/do-java-arrays-have-a-maximum-size
-	static public final int maxArraySize = Integer.MAX_VALUE - 8;
+	public static final int maxArraySize = Integer.MAX_VALUE - 8;
 
-	static public boolean isClassAvailable (String className) {
+	public static boolean isClassAvailable (String className) {
 		try {
 			Class.forName(className);
 			return true;
@@ -64,7 +64,7 @@ public class Util {
 	}
 
 	/** Returns the primitive wrapper class for a primitive class, or the specified class if it is not primitive. */
-	static public Class getWrapperClass (Class type) {
+	public static Class getWrapperClass (Class type) {
 		if (type == int.class) return Integer.class;
 		if (type == float.class) return Float.class;
 		if (type == boolean.class) return Boolean.class;
@@ -78,7 +78,7 @@ public class Util {
 
 	/** Returns the primitive class for a primitive wrapper class. Otherwise returns the type parameter.
 	 * @param type Must be a wrapper class. */
-	static public Class getPrimitiveClass (Class type) {
+	public static Class getPrimitiveClass (Class type) {
 		if (type == Integer.class) return int.class;
 		if (type == Float.class) return float.class;
 		if (type == Boolean.class) return boolean.class;
@@ -91,18 +91,18 @@ public class Util {
 		return type;
 	}
 
-	static public boolean isWrapperClass (Class type) {
+	public static boolean isWrapperClass (Class type) {
 		return type == Integer.class || type == Float.class || type == Boolean.class || type == Byte.class || type == Long.class
 			|| type == Character.class || type == Double.class || type == Short.class;
 	}
 
-	static public boolean isEnum (Class type) {
+	public static boolean isEnum (Class type) {
 		// Use this rather than type.isEnum() to return true for an enum value that is an inner class, eg: enum A {b{}}
 		return Enum.class.isAssignableFrom(type) && type != Enum.class;
 	}
 
 	/** Logs a message about an object. The log level and the string format of the object depend on the object type. */
-	static public void log (String message, Object object, int position) {
+	public static void log (String message, Object object, int position) {
 		if (object == null) {
 			if (TRACE) trace("kryo", message + ": null" + pos(position));
 			return;
@@ -114,13 +114,13 @@ public class Util {
 			debug("kryo", message + ": " + string(object) + pos(position));
 	}
 
-	static public String pos (int position) {
+	public static String pos (int position) {
 		return position == -1 ? "" : " [" + position + "]";
 	}
 
 	/** Returns the object formatted as a string. The format depends on the object's type and whether {@link Object#toString()} has
 	 * been overridden. */
-	static public String string (Object object) {
+	public static String string (Object object) {
 		if (object == null) return "null";
 		Class type = object.getClass();
 		if (type.isArray()) return className(type);
@@ -138,7 +138,7 @@ public class Util {
 	}
 
 	/** Returns the class formatted as a string. The format varies depending on the type. */
-	static public String className (Class type) {
+	public static String className (Class type) {
 		if (type == null) return "null";
 		if (type.isArray()) {
 			Class elementClass = getElementClass(type);
@@ -156,7 +156,7 @@ public class Util {
 	}
 
 	/** Returns the classes formatted as a string. The format varies depending on the type. */
-	static public String classNames (Class[] types) {
+	public static String classNames (Class[] types) {
 		StringBuilder buffer = new StringBuilder(32);
 		for (int i = 0, n = types.length; i < n; i++) {
 			if (i > 0) buffer.append(", ");
@@ -165,12 +165,12 @@ public class Util {
 		return buffer.toString();
 	}
 
-	static public String simpleName (Type type) {
+	public static String simpleName (Type type) {
 		if (type instanceof Class) return ((Class)type).getSimpleName();
 		return type.toString(); // Java 8: getTypeName
 	}
 
-	static public String simpleName (Class type, GenericType genericType) {
+	public static String simpleName (Class type, GenericType genericType) {
 		StringBuilder buffer = new StringBuilder(32);
 		buffer.append((type.isArray() ? getElementClass(type) : type).getSimpleName());
 		if (genericType.arguments != null) {
@@ -189,7 +189,7 @@ public class Util {
 	}
 
 	/** Returns the number of dimensions of an array. */
-	static public int getDimensionCount (Class arrayClass) {
+	public static int getDimensionCount (Class arrayClass) {
 		int depth = 0;
 		Class nextClass = arrayClass.getComponentType();
 		while (nextClass != null) {
@@ -200,14 +200,14 @@ public class Util {
 	}
 
 	/** Returns the base element type of an n-dimensional array class. */
-	static public Class getElementClass (Class arrayClass) {
+	public static Class getElementClass (Class arrayClass) {
 		Class elementClass = arrayClass;
 		while (elementClass.getComponentType() != null)
 			elementClass = elementClass.getComponentType();
 		return elementClass;
 	}
 
-	static public boolean isAscii (String value) {
+	public static boolean isAscii (String value) {
 		for (int i = 0, n = value.length(); i < n; i++)
 			if (value.charAt(i) > 127) return false;
 		return true;
@@ -215,7 +215,7 @@ public class Util {
 
 	/** @param factoryClass Must have a constructor that takes a serializer class, or a zero argument constructor.
 	 * @param serializerClass May be null if the factory already knows the serializer class to create. */
-	static public <T extends SerializerFactory> T newFactory (Class<T> factoryClass, Class<? extends Serializer> serializerClass) {
+	public static <T extends SerializerFactory> T newFactory (Class<T> factoryClass, Class<? extends Serializer> serializerClass) {
 		try {
 			if (serializerClass != null) {
 				try {

--- a/test/com/esotericsoftware/kryo/CopyTest.java
+++ b/test/com/esotericsoftware/kryo/CopyTest.java
@@ -159,7 +159,7 @@ public class CopyTest extends KryoTestCase {
 		assertEquals(test, copy);
 	}
 
-	static public class Moo {
+	public static class Moo {
 		Moo moo;
 	}
 }

--- a/test/com/esotericsoftware/kryo/KryoTestCase.java
+++ b/test/com/esotericsoftware/kryo/KryoTestCase.java
@@ -44,9 +44,9 @@ import org.junit.Before;
 
 /** Convenience methods for round tripping objects.
  * @author Nathan Sweet */
-abstract public class KryoTestCase {
+public abstract class KryoTestCase {
 	// When true, roundTrip will only do a single write/read to make debugging easier (breaks some tests).
-	static private final boolean debug = false;
+	private static final boolean debug = false;
 
 	protected Kryo kryo;
 	protected Output output;
@@ -277,7 +277,7 @@ abstract public class KryoTestCase {
 		assertEquals(arrayToList(object1), arrayToList(object2));
 	}
 
-	static public Object arrayToList (Object array) {
+	public static Object arrayToList (Object array) {
 		if (array == null || !array.getClass().isArray()) return array;
 		ArrayList list = new ArrayList(Array.getLength(array));
 		for (int i = 0, n = Array.getLength(array); i < n; i++)
@@ -285,7 +285,7 @@ abstract public class KryoTestCase {
 		return list;
 	}
 
-	static public ArrayList list (Object... items) {
+	public static ArrayList list (Object... items) {
 		ArrayList list = new ArrayList();
 		for (Object item : items)
 			list.add(item);

--- a/test/com/esotericsoftware/kryo/ReferenceTest.java
+++ b/test/com/esotericsoftware/kryo/ReferenceTest.java
@@ -33,11 +33,11 @@ import java.util.TreeMap;
 import org.junit.Test;
 
 public class ReferenceTest extends KryoTestCase {
-	static public class Ordering {
+	public static class Ordering {
 		public String order;
 	}
 
-	static public class Stuff extends TreeMap {
+	public static class Stuff extends TreeMap {
 		public Ordering ordering;
 
 		public Stuff (Ordering ordering) {
@@ -104,7 +104,7 @@ public class ReferenceTest extends KryoTestCase {
 		roundTrip(23, subList);
 	}
 
-	static public class SubListSerializer extends Serializer<List> {
+	public static class SubListSerializer extends Serializer<List> {
 		private Field listField, offsetField, sizeField;
 
 		public SubListSerializer () {
@@ -141,7 +141,7 @@ public class ReferenceTest extends KryoTestCase {
 		}
 	}
 
-	static public class ArraySubListSerializer extends Serializer<List> {
+	public static class ArraySubListSerializer extends Serializer<List> {
 		private Field parentField, offsetField, sizeField;
 
 		public ArraySubListSerializer () {

--- a/test/com/esotericsoftware/kryo/ReflectionAssert.java
+++ b/test/com/esotericsoftware/kryo/ReflectionAssert.java
@@ -69,7 +69,7 @@ class ReflectionAssert {
 	}
 
 	// CHECKSTYLE:OFF
-	static private void assertReflectionEquals (final Object one, final Object another,
+	private static void assertReflectionEquals (final Object one, final Object another,
 		final boolean requireMatchingCollectionClasses, final Map<Object, Object> alreadyChecked, final String path) {
 		if (one == another) {
 			return;
@@ -150,12 +150,12 @@ class ReflectionAssert {
 
 	} // CHECKSTYLE:ON
 
-	static private boolean isOnlyOneAssignable (final Class checkedClazz, final Object one, final Object another) {
+	private static boolean isOnlyOneAssignable (final Class checkedClazz, final Object one, final Object another) {
 		return checkedClazz.isAssignableFrom(one.getClass()) && !checkedClazz.isAssignableFrom(another.getClass())
 			|| checkedClazz.isAssignableFrom(another.getClass()) && !checkedClazz.isAssignableFrom(one.getClass());
 	}
 
-	static private boolean oneIsAssignable (final Object one, final Object another, final Class... checkedClazzes) {
+	private static boolean oneIsAssignable (final Object one, final Object another, final Class... checkedClazzes) {
 		for (final Class checkedClazz : checkedClazzes) {
 			if (checkedClazz.isAssignableFrom(one.getClass()) || checkedClazz.isAssignableFrom(another.getClass())) {
 				return true;
@@ -168,7 +168,7 @@ class ReflectionAssert {
 	 * TODO (MG): this assumes same iteration order, which must not be given for sets. There could be a specialized implementation
 	 * for sets.
 	 */
-	static private void assertCollectionEquals (final Collection m1, final Collection m2, final boolean requireMatchingClasses,
+	private static void assertCollectionEquals (final Collection m1, final Collection m2, final boolean requireMatchingClasses,
 		final Map<Object, Object> alreadyChecked, final String path) {
 		assertEquals("Collection size does not match for path '" + (StringUtils.isEmpty(path) ? "." : path) + "' - ", m1.size(),
 			m2.size());
@@ -180,8 +180,8 @@ class ReflectionAssert {
 		}
 	}
 
-	static private void assertMapEquals (final Map<?, ?> m1, final Map<?, ?> m2, final boolean requireMatchingClasses,
-		final Map<Object, Object> alreadyChecked, final String path) {
+	private static void assertMapEquals (final Map<?, ?> m1, final Map<?, ?> m2, final boolean requireMatchingClasses,
+										 final Map<Object, Object> alreadyChecked, final String path) {
 		assertEquals("Map size does not match for path '" + (StringUtils.isEmpty(path) ? "." : path) + "', map contents:"
 			+ "\nmap1: " + m1 + "\nmap2: " + m2 + "\n", m1.size(), m2.size());
 		for (final Map.Entry<?, ?> entry : m1.entrySet()) {
@@ -190,8 +190,8 @@ class ReflectionAssert {
 		}
 	}
 
-	static private void assertEqualDeclaredFields (final Class<? extends Object> clazz, final Object one, final Object another,
-		final boolean requireMatchingClasses, final Map<Object, Object> alreadyChecked, final String path) {
+	private static void assertEqualDeclaredFields (final Class<? extends Object> clazz, final Object one, final Object another,
+												   final boolean requireMatchingClasses, final Map<Object, Object> alreadyChecked, final String path) {
 		for (final Field field : clazz.getDeclaredFields()) {
 			field.setAccessible(true);
 			if (!Modifier.isTransient(field.getModifiers())) {

--- a/test/com/esotericsoftware/kryo/RegistrationTest.java
+++ b/test/com/esotericsoftware/kryo/RegistrationTest.java
@@ -52,7 +52,7 @@ public class RegistrationTest {
 		}
 	}
 
-	static public class Some<T> {
+	public static class Some<T> {
 		public T value;
 
 		public Some () {
@@ -63,9 +63,9 @@ public class RegistrationTest {
 		}
 	}
 
-	static public class Fruit {
+	public static class Fruit {
 	}
 
-	static public class Apple extends Fruit {
+	public static class Apple extends Fruit {
 	}
 }

--- a/test/com/esotericsoftware/kryo/SerializationBenchmarkTest.java
+++ b/test/com/esotericsoftware/kryo/SerializationBenchmarkTest.java
@@ -45,22 +45,22 @@ import org.junit.runners.MethodSorters;
  * @author Nathan Sweet */
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class SerializationBenchmarkTest extends KryoTestCase {
-	static private final int WARMUP_ITERATIONS = 1000;
+	private static final int WARMUP_ITERATIONS = 1000;
 
 	/** Number of runs. */
-	static private final int RUN_CNT = 1;
+	private static final int RUN_CNT = 1;
 
 	/** Number of iterations. Set it to something rather big for obtaining meaningful results */
-	static private final int ITER_CNT = 100;
+	private static final int ITER_CNT = 100;
 	// static private final int ITER_CNT = 20000;
 
-	static private final int SLEEP_BETWEEN_RUNS = 100;
+	private static final int SLEEP_BETWEEN_RUNS = 100;
 
-	static private final int OUTPUT_BUFFER_SIZE = 4096 * 10 * 4;
+	private static final int OUTPUT_BUFFER_SIZE = 4096 * 10 * 4;
 
 	final SampleObject object = createObject();
 
-	static private SampleObject createObject () {
+	private static SampleObject createObject () {
 		long[] longArray = new long[3000];
 		for (int i = 0; i < longArray.length; i++)
 			longArray[i] = i;
@@ -198,7 +198,7 @@ public class SerializationBenchmarkTest extends KryoTestCase {
 		Log.WARN();
 	}
 
-	static private class SampleObject implements Externalizable, KryoSerializable {
+	private static class SampleObject implements Externalizable, KryoSerializable {
 		private int intValue;
 		public float floatValue;
 		protected Short shortValue;

--- a/test/com/esotericsoftware/kryo/SerializationCompatTest.java
+++ b/test/com/esotericsoftware/kryo/SerializationCompatTest.java
@@ -72,17 +72,17 @@ import org.objenesis.strategy.StdInstantiatorStrategy;
  * related tag and run the test (there's nothing here to automate creation of test files for a different version). */
 public class SerializationCompatTest extends KryoTestCase {
 	// Set to true to delete failed test files, then set back to false, set expected bytes, and run again to generate new files.
-	static private final boolean DELETE_FAILED_TEST_FILES = false;
+	private static final boolean DELETE_FAILED_TEST_FILES = false;
 
-	static private final int JAVA_VERSION;
+	private static final int JAVA_VERSION;
 	static {
 		// java.version is e.g. 1.8.0 or 9.0.4
 		String[] strVersions = System.getProperty("java.version").split("\\.");
 		int[] versions = new int[] {parseInt(strVersions[0]), parseInt(strVersions[1])};
 		JAVA_VERSION = versions[0] > 1 ? versions[0] : versions[1];
 	}
-	static private final int EXPECTED_DEFAULT_SERIALIZER_COUNT = JAVA_VERSION < 11 ? 57 : 67; // Also change Kryo#defaultSerializers.
-	static private final List<TestDataDescription> TEST_DATAS = new ArrayList<>();
+	private static final int EXPECTED_DEFAULT_SERIALIZER_COUNT = JAVA_VERSION < 11 ? 57 : 67; // Also change Kryo#defaultSerializers.
+	private static final List<TestDataDescription> TEST_DATAS = new ArrayList<>();
 
 	static {
 		TEST_DATAS.add(new TestDataDescription<>(new TestData(), 1940, 1958));
@@ -216,7 +216,7 @@ public class SerializationCompatTest extends KryoTestCase {
 		B apply (A input) throws Exception;
 	}
 
-	static private class TestDataDescription<T extends TestData> {
+	private static class TestDataDescription<T extends TestData> {
 		final T testData;
 		final int length;
 		final int noGenericsLength;

--- a/test/com/esotericsoftware/kryo/SerializationCompatTestData.java
+++ b/test/com/esotericsoftware/kryo/SerializationCompatTestData.java
@@ -139,7 +139,7 @@ public class SerializationCompatTestData {
 		}
 	}
 
-	static public class TestData implements Serializable {
+	public static class TestData implements Serializable {
 		private boolean _boolean;
 		private char _char;
 		private byte _byte;
@@ -377,7 +377,7 @@ public class SerializationCompatTestData {
 		return person;
 	}
 
-	static public class Person {
+	public static class Person {
 
 		static enum Gender {
 			MALE, FEMALE
@@ -500,9 +500,9 @@ public class SerializationCompatTestData {
 
 	}
 
-	static public class Email implements Serializable {
+	public static class Email implements Serializable {
 
-		static private final long serialVersionUID = 1L;
+		private static final long serialVersionUID = 1L;
 
 		private String _name;
 		private String _email;
@@ -574,7 +574,7 @@ public class SerializationCompatTestData {
 
 	}
 
-	static public class PublicClass {
+	public static class PublicClass {
 		PrivateClass privateClass;
 
 		public PublicClass () {
@@ -593,7 +593,7 @@ public class SerializationCompatTestData {
 		}
 	}
 
-	static private class PrivateClass {
+	private static class PrivateClass {
 		String foo;
 
 		public PrivateClass (String foo) {

--- a/test/com/esotericsoftware/kryo/serializers/BeanSerializerTest.java
+++ b/test/com/esotericsoftware/kryo/serializers/BeanSerializerTest.java
@@ -43,7 +43,7 @@ public class BeanSerializerTest extends KryoTestCase {
 		roundTrip(33, test);
 	}
 
-	static public class TestClass {
+	public static class TestClass {
 		private String text = "something";
 		private String nullField;
 		private TestClass child;

--- a/test/com/esotericsoftware/kryo/serializers/CollectionSerializerTest.java
+++ b/test/com/esotericsoftware/kryo/serializers/CollectionSerializerTest.java
@@ -112,7 +112,7 @@ public class CollectionSerializerTest extends KryoTestCase {
 		assertNotSame(objects1.get(0), objects2.get(0));
 	}
 
-	static public class TreeSetSubclass<E> extends TreeSet<E> {
+	public static class TreeSetSubclass<E> extends TreeSet<E> {
 		public TreeSetSubclass () {
 		}
 

--- a/test/com/esotericsoftware/kryo/serializers/CompatibleFieldSerializerTest.java
+++ b/test/com/esotericsoftware/kryo/serializers/CompatibleFieldSerializerTest.java
@@ -378,7 +378,7 @@ public class CompatibleFieldSerializerTest extends KryoTestCase {
 		assertEquals(extendedObject, object2);
 	}
 
-	static public class TestClass {
+	public static class TestClass {
 		public String text = "something";
 		public int moo = 120;
 		public long moo2 = 1234120;
@@ -404,7 +404,7 @@ public class CompatibleFieldSerializerTest extends KryoTestCase {
 		}
 	}
 
-	static public class ExtendedTestClass extends TestClass {
+	public static class ExtendedTestClass extends TestClass {
 		// keep the same names of attributes like TestClass
 		public String text = "extendedSomething";
 		public int moo = 127;
@@ -433,11 +433,11 @@ public class CompatibleFieldSerializerTest extends KryoTestCase {
 		}
 	}
 
-	static public class AnotherClass {
+	public static class AnotherClass {
 		String value;
 	}
 
-	static public class ClassWithManyFields {
+	public static class ClassWithManyFields {
 		public String aa;
 		public String bb;
 		public String bAdd;

--- a/test/com/esotericsoftware/kryo/serializers/DeflateSerializerTest.java
+++ b/test/com/esotericsoftware/kryo/serializers/DeflateSerializerTest.java
@@ -47,7 +47,7 @@ public class DeflateSerializerTest extends KryoTestCase {
 		roundTrip(8, message);
 	}
 
-	static public class ServerPhysicsUpdate {
+	public static class ServerPhysicsUpdate {
 		public int value;
 
 		public ServerPhysicsUpdate () {
@@ -70,11 +70,11 @@ public class DeflateSerializerTest extends KryoTestCase {
 		}
 	}
 
-	static public enum MessageType {
+	public static enum MessageType {
 		SERVER_UPDATE
 	}
 
-	static public class Message {
+	public static class Message {
 		public MessageType type;
 		public Object data;
 

--- a/test/com/esotericsoftware/kryo/serializers/ExternalizableSerializerTest.java
+++ b/test/com/esotericsoftware/kryo/serializers/ExternalizableSerializerTest.java
@@ -107,7 +107,7 @@ public class ExternalizableSerializerTest extends KryoTestCase {
 		assertEquals(result.get(1), test2);
 	}
 
-	static public class TestClass implements Externalizable {
+	public static class TestClass implements Externalizable {
 		String stringField;
 		int intField;
 
@@ -146,7 +146,7 @@ public class ExternalizableSerializerTest extends KryoTestCase {
 		}
 	}
 
-	static public class AnotherTestClass implements Externalizable {
+	public static class AnotherTestClass implements Externalizable {
 		private Date dateField;
 		private long longField;
 
@@ -185,7 +185,7 @@ public class ExternalizableSerializerTest extends KryoTestCase {
 		}
 	}
 
-	static public class ReadResolvable implements Externalizable {
+	public static class ReadResolvable implements Externalizable {
 		String value;
 		private Object makeSureNullWorks;
 

--- a/test/com/esotericsoftware/kryo/serializers/FieldSerializerGenericsTest.java
+++ b/test/com/esotericsoftware/kryo/serializers/FieldSerializerGenericsTest.java
@@ -201,7 +201,7 @@ public class FieldSerializerGenericsTest extends KryoTestCase {
 
 	// ---
 
-	static public final class Value<T> {
+	public static final class Value<T> {
 		public T value;
 		public ArrayList<T> list;
 
@@ -221,7 +221,7 @@ public class FieldSerializerGenericsTest extends KryoTestCase {
 		}
 	}
 
-	static public final class MultipleValues {
+	public static final class MultipleValues {
 		public Value<String> string;
 		public Value<Integer> integer;
 
@@ -232,7 +232,7 @@ public class FieldSerializerGenericsTest extends KryoTestCase {
 
 	// ---
 
-	static public class NestedLists {
+	public static class NestedLists {
 		public ArrayList<NestedListValue<Integer>> lists;
 
 		public boolean equals (Object obj) {
@@ -240,7 +240,7 @@ public class FieldSerializerGenericsTest extends KryoTestCase {
 		}
 	}
 
-	static public final class NestedListValue<T> {
+	public static final class NestedListValue<T> {
 		public T value;
 
 		public NestedListValue (T value) {
@@ -254,7 +254,7 @@ public class FieldSerializerGenericsTest extends KryoTestCase {
 
 	// ---
 
-	static public class Super<X> {
+	public static class Super<X> {
 		public ArrayList<X> list;
 		public X value;
 
@@ -263,13 +263,13 @@ public class FieldSerializerGenericsTest extends KryoTestCase {
 		}
 	}
 
-	static public class PassArgToSuper<T> extends Super<T> {
+	public static class PassArgToSuper<T> extends Super<T> {
 	}
 
-	static public final class PassArgToSupers<T> extends PassArgToSuper<T> {
+	public static final class PassArgToSupers<T> extends PassArgToSuper<T> {
 	}
 
-	static public final class SuperTest {
+	public static final class SuperTest {
 		public PassArgToSupers<Integer> integer;
 		public PassArgToSupers<String> string;
 

--- a/test/com/esotericsoftware/kryo/serializers/FieldSerializerInheritanceTest.java
+++ b/test/com/esotericsoftware/kryo/serializers/FieldSerializerInheritanceTest.java
@@ -96,7 +96,7 @@ public class FieldSerializerInheritanceTest extends KryoTestCase {
 		}
 	}
 
-	static public class TestDefault {
+	public static class TestDefault {
 		String a;
 
 		public String getA () {
@@ -122,7 +122,7 @@ public class FieldSerializerInheritanceTest extends KryoTestCase {
 		}
 	}
 
-	static public class TestExtended extends TestDefault {
+	public static class TestExtended extends TestDefault {
 		String a;
 
 		public String getA () {

--- a/test/com/esotericsoftware/kryo/serializers/FieldSerializerTest.java
+++ b/test/com/esotericsoftware/kryo/serializers/FieldSerializerTest.java
@@ -699,7 +699,7 @@ public class FieldSerializerTest extends KryoTestCase {
 		roundTrip(1440, root);
 	}
 
-	static public class DefaultTypes {
+	public static class DefaultTypes {
 		// Primitives.
 		public boolean booleanField;
 		public byte byteField;
@@ -782,7 +782,7 @@ public class FieldSerializerTest extends KryoTestCase {
 		}
 	}
 
-	static public final class A {
+	public static final class A {
 		public int value;
 		@Bind(valueClass = B.class, serializerFactory = FieldSerializerFactory.class) public B b;
 
@@ -799,7 +799,7 @@ public class FieldSerializerTest extends KryoTestCase {
 		}
 	}
 
-	static public final class B {
+	public static final class B {
 		public int value;
 		@Bind(valueClass = A.class) public A a;
 
@@ -816,7 +816,7 @@ public class FieldSerializerTest extends KryoTestCase {
 		}
 	}
 
-	static public final class C {
+	public static final class C {
 		public A a;
 		@Bind(serializer = FieldSerializer.class, valueClass = D.class) public D d;
 
@@ -835,7 +835,7 @@ public class FieldSerializerTest extends KryoTestCase {
 		}
 	}
 
-	static public final class D {
+	public static final class D {
 		public E e;
 
 		public boolean equals (Object obj) {
@@ -850,7 +850,7 @@ public class FieldSerializerTest extends KryoTestCase {
 		}
 	}
 
-	static public final class E {
+	public static final class E {
 		public F f;
 
 		public boolean equals (Object obj) {
@@ -865,7 +865,7 @@ public class FieldSerializerTest extends KryoTestCase {
 		}
 	}
 
-	static public final class F {
+	public static final class F {
 		public int value;
 		public final int finalValue = 12;
 		public D d;
@@ -881,7 +881,7 @@ public class FieldSerializerTest extends KryoTestCase {
 		}
 	}
 
-	static public class SimpleNoDefaultConstructor {
+	public static class SimpleNoDefaultConstructor {
 		int constructorValue;
 
 		public SimpleNoDefaultConstructor (int constructorValue) {
@@ -909,7 +909,7 @@ public class FieldSerializerTest extends KryoTestCase {
 		}
 	}
 
-	static public class HasTransients {
+	public static class HasTransients {
 		public transient String transientField1;
 		public int anotherField2;
 		public String anotherField3;
@@ -942,7 +942,7 @@ public class FieldSerializerTest extends KryoTestCase {
 		}
 	}
 
-	static public class ComplexNoDefaultConstructor {
+	public static class ComplexNoDefaultConstructor {
 		public transient String name;
 		public int anotherField1;
 		public String anotherField2;
@@ -977,7 +977,7 @@ public class FieldSerializerTest extends KryoTestCase {
 	}
 
 	@DefaultSerializer(FieldSerializer.class)
-	static public class HasNonNull {
+	public static class HasNonNull {
 		@NotNull public String nonNullText;
 
 		public boolean equals (Object obj) {
@@ -993,7 +993,7 @@ public class FieldSerializerTest extends KryoTestCase {
 	}
 
 	@DefaultSerializer(serializerFactory = FieldSerializerFactory.class)
-	static public class HasStringField {
+	public static class HasStringField {
 		public String text;
 
 		public boolean equals (Object obj) {
@@ -1008,7 +1008,7 @@ public class FieldSerializerTest extends KryoTestCase {
 		}
 	}
 
-	static public class HasOptionalAnnotation {
+	public static class HasOptionalAnnotation {
 		@Optional("smurf") int moo;
 
 		public boolean equals (Object obj) {
@@ -1022,7 +1022,7 @@ public class FieldSerializerTest extends KryoTestCase {
 	}
 
 	@DefaultSerializer(HasDefaultSerializerAnnotationSerializer.class)
-	static public class HasDefaultSerializerAnnotation {
+	public static class HasDefaultSerializerAnnotation {
 		long time;
 
 		public HasDefaultSerializerAnnotation (long time) {
@@ -1039,7 +1039,7 @@ public class FieldSerializerTest extends KryoTestCase {
 		}
 	}
 
-	static public class HasDefaultSerializerAnnotationSerializer extends Serializer<HasDefaultSerializerAnnotation> {
+	public static class HasDefaultSerializerAnnotationSerializer extends Serializer<HasDefaultSerializerAnnotation> {
 		public void write (Kryo kryo, Output output, HasDefaultSerializerAnnotation object) {
 			output.writeVarLong(object.time, true);
 		}
@@ -1053,7 +1053,7 @@ public class FieldSerializerTest extends KryoTestCase {
 		}
 	}
 
-	static public class HasArgumentConstructor {
+	public static class HasArgumentConstructor {
 		public String moo;
 
 		public HasArgumentConstructor (String moo) {
@@ -1072,7 +1072,7 @@ public class FieldSerializerTest extends KryoTestCase {
 		}
 	}
 
-	static public class HasPrivateConstructor extends HasArgumentConstructor {
+	public static class HasPrivateConstructor extends HasArgumentConstructor {
 		static int invocations;
 
 		private HasPrivateConstructor () {
@@ -1081,7 +1081,7 @@ public class FieldSerializerTest extends KryoTestCase {
 		}
 	}
 
-	static public class HasGenerics<T> {
+	public static class HasGenerics<T> {
 		public ArrayList<T> list1;
 		private List<List> list2 = new ArrayList();
 		public List list3 = new ArrayList();
@@ -1116,7 +1116,7 @@ public class FieldSerializerTest extends KryoTestCase {
 		}
 	}
 
-	static public class ListContainer<T> {
+	public static class ListContainer<T> {
 		public ArrayList<T> list;
 
 		public boolean equals (Object obj) {
@@ -1131,7 +1131,7 @@ public class FieldSerializerTest extends KryoTestCase {
 		}
 	}
 
-	static public class MultipleTimesAnnotatedCollectionFields {
+	public static class MultipleTimesAnnotatedCollectionFields {
 		// This annotation should result in an exception, because
 		// it is applied to a non-collection field
 		@BindCollection(elementSerializer = LongArraySerializer.class, //
@@ -1141,7 +1141,7 @@ public class FieldSerializerTest extends KryoTestCase {
 		Collection collection;
 	}
 
-	static public class WronglyAnnotatedCollectionFields {
+	public static class WronglyAnnotatedCollectionFields {
 		// This annotation should result in an exception, because
 		// it is applied to a non-collection field
 		@BindCollection(elementSerializer = LongArraySerializer.class, //
@@ -1150,7 +1150,7 @@ public class FieldSerializerTest extends KryoTestCase {
 		int collection;
 	}
 
-	static public class WronglyAnnotatedMapFields {
+	public static class WronglyAnnotatedMapFields {
 		// This annotation should result in an exception, because
 		// it is applied to a non-map field
 		@BindMap(valueSerializer = IntArraySerializer.class, //
@@ -1161,8 +1161,8 @@ public class FieldSerializerTest extends KryoTestCase {
 		Object map;
 	}
 
-	static public class AnnotatedFields {
-		static public class HasFields {
+	public static class AnnotatedFields {
+		public static class HasFields {
 			public int number;
 			public String text;
 
@@ -1232,7 +1232,7 @@ public class FieldSerializerTest extends KryoTestCase {
 		}
 	}
 
-	static public class IsGeneric<T> {
+	public static class IsGeneric<T> {
 		T item;
 		private int y;
 		private int z;
@@ -1250,7 +1250,7 @@ public class FieldSerializerTest extends KryoTestCase {
 		}
 	}
 
-	static public class Deep {
+	public static class Deep {
 		public int i;
 		public Deep deep;
 

--- a/test/com/esotericsoftware/kryo/serializers/GenericsTest.java
+++ b/test/com/esotericsoftware/kryo/serializers/GenericsTest.java
@@ -190,7 +190,7 @@ public class GenericsTest extends KryoTestCase {
 		V getValue ();
 	}
 
-	static private abstract class AbstractValueHolder<V> implements Holder<V> {
+	private abstract static class AbstractValueHolder<V> implements Holder<V> {
 		private final V value;
 
 		AbstractValueHolder (V value) {
@@ -210,13 +210,13 @@ public class GenericsTest extends KryoTestCase {
 		}
 	}
 
-	static private abstract class AbstractValueListHolder<V> extends AbstractValueHolder<List<V>> {
+	private abstract static class AbstractValueListHolder<V> extends AbstractValueHolder<List<V>> {
 		AbstractValueListHolder (List<V> value) {
 			super(value);
 		}
 	}
 
-	static private class LongHolder extends AbstractValueHolder<Long> {
+	private static class LongHolder extends AbstractValueHolder<Long> {
 		/** Kryo Constructor */
 		LongHolder () {
 			super(null);
@@ -227,7 +227,7 @@ public class GenericsTest extends KryoTestCase {
 		}
 	}
 
-	static private class LongListHolder extends AbstractValueListHolder<Long> {
+	private static class LongListHolder extends AbstractValueListHolder<Long> {
 		/** Kryo Constructor */
 		LongListHolder () {
 			super(null);
@@ -272,7 +272,7 @@ public class GenericsTest extends KryoTestCase {
 	}
 
 	// A simple serializable class.
-	static private class SerializableObjectFoo implements Serializable {
+	private static class SerializableObjectFoo implements Serializable {
 		String name;
 
 		SerializableObjectFoo (String name) {
@@ -295,7 +295,7 @@ public class GenericsTest extends KryoTestCase {
 		}
 	}
 
-	static private class BaseGeneric<T extends Serializable> {
+	private static class BaseGeneric<T extends Serializable> {
 		// The type of this field cannot be derived from the context.
 		// Therefore, Kryo should consider it to be Object.
 		private final List<T> listPayload;
@@ -330,7 +330,7 @@ public class GenericsTest extends KryoTestCase {
 	}
 
 	// This is a non-generic class with a generic superclass.
-	static private class ConcreteClass2 extends BaseGeneric<SerializableObjectFoo> {
+	private static class ConcreteClass2 extends BaseGeneric<SerializableObjectFoo> {
 		/** Kryo Constructor */
 		ConcreteClass2 () {
 			super();
@@ -341,7 +341,7 @@ public class GenericsTest extends KryoTestCase {
 		}
 	}
 
-	static private class ConcreteClass1 extends ConcreteClass2 {
+	private static class ConcreteClass1 extends ConcreteClass2 {
 		/** Kryo Constructor */
 		ConcreteClass1 () {
 			super();
@@ -352,7 +352,7 @@ public class GenericsTest extends KryoTestCase {
 		}
 	}
 
-	static private class ConcreteClass extends ConcreteClass1 {
+	private static class ConcreteClass extends ConcreteClass1 {
 		/** Kryo Constructor */
 		ConcreteClass () {
 			super();
@@ -363,8 +363,8 @@ public class GenericsTest extends KryoTestCase {
 		}
 	}
 
-	static public class SuperGenerics {
-		static public class RootSuper<RS> {
+	public static class SuperGenerics {
+		public static class RootSuper<RS> {
 			public ValueSuper<RS> rootSuperField;
 
 			@Override
@@ -376,18 +376,18 @@ public class GenericsTest extends KryoTestCase {
 			}
 		}
 
-		static public class Root extends RootSuper<String> {
+		public static class Root extends RootSuper<String> {
 		}
 
-		static public class ValueSuper<VS> extends ValueSuperSuper<Integer> {
+		public static class ValueSuper<VS> extends ValueSuperSuper<Integer> {
 			VS superField;
 		}
 
-		static public class ValueSuperSuper<VSS> {
+		public static class ValueSuperSuper<VSS> {
 			VSS superSuperField;
 		}
 
-		static public class Value extends ValueSuper<String> {
+		public static class Value extends ValueSuper<String> {
 			@Override
 			public boolean equals (Object o) {
 				if (this == o) return true;
@@ -396,7 +396,7 @@ public class GenericsTest extends KryoTestCase {
 		}
 	}
 
-	static public class ClassWithMap {
+	public static class ClassWithMap {
 		public final Map<MapKey, Set<String>> values = new HashMap();
 
 		public boolean equals (Object obj) {
@@ -410,7 +410,7 @@ public class GenericsTest extends KryoTestCase {
 			return true;
 		}
 
-		static public class MapKey {
+		public static class MapKey {
 			public String field1, field2;
 
 			public String toString () {
@@ -419,11 +419,11 @@ public class GenericsTest extends KryoTestCase {
 		}
 	}
 
-	static public class A<X> {
-		static public class B<Y> extends A {
+	public static class A<X> {
+		public static class B<Y> extends A {
 		}
 
-		static public class DontPassToSuper<Z> extends B {
+		public static class DontPassToSuper<Z> extends B {
 			B<Z> b;
 		}
 	}

--- a/test/com/esotericsoftware/kryo/serializers/JavaSerializerTest.java
+++ b/test/com/esotericsoftware/kryo/serializers/JavaSerializerTest.java
@@ -42,7 +42,7 @@ public class JavaSerializerTest extends KryoTestCase {
 		roundTrip(146, test);
 	}
 
-	static public class TestClass implements Serializable {
+	public static class TestClass implements Serializable {
 		String stringField;
 		int intField;
 

--- a/test/com/esotericsoftware/kryo/serializers/MapSerializerTest.java
+++ b/test/com/esotericsoftware/kryo/serializers/MapSerializerTest.java
@@ -246,18 +246,18 @@ public class MapSerializerTest extends KryoTestCase {
 		private Map<Integer, String> mapTwo = this.mapOne;
 	}
 
-	static public class HasGenerics {
+	public static class HasGenerics {
 		public HashMap<String, Integer[]> map = new HashMap();
 		public HashMap<String, ?> map2 = new HashMap();
 	}
 
-	static public class KeyComparator implements Comparator<KeyThatIsntComparable> {
+	public static class KeyComparator implements Comparator<KeyThatIsntComparable> {
 		public int compare (KeyThatIsntComparable o1, KeyThatIsntComparable o2) {
 			return o1.value.compareTo(o2.value);
 		}
 	}
 
-	static public class KeyThatIsntComparable {
+	public static class KeyThatIsntComparable {
 		public String value;
 
 		public KeyThatIsntComparable () {
@@ -268,7 +268,7 @@ public class MapSerializerTest extends KryoTestCase {
 		}
 	}
 
-	static public class TreeMapSubclass<K, V> extends TreeMap<K, V> {
+	public static class TreeMapSubclass<K, V> extends TreeMap<K, V> {
 		public TreeMapSubclass () {
 		}
 
@@ -277,7 +277,7 @@ public class MapSerializerTest extends KryoTestCase {
 		}
 	}
 
-	static public enum SomeEnum {
+	public static enum SomeEnum {
 		a, b, c
 	}
 }

--- a/test/com/esotericsoftware/kryo/serializers/TaggedFieldSerializerTest.java
+++ b/test/com/esotericsoftware/kryo/serializers/TaggedFieldSerializerTest.java
@@ -156,7 +156,7 @@ public class TaggedFieldSerializerTest extends KryoTestCase {
 		assertTrue(receivedIAE);
 	}
 
-	static public class TestClass {
+	public static class TestClass {
 		@Tag(0) public String text = "something";
 		@Tag(1) public int moo = 120;
 		@Tag(2) public long moo2 = 1234120;
@@ -183,15 +183,15 @@ public class TaggedFieldSerializerTest extends KryoTestCase {
 		}
 	}
 
-	static public class IncompatibleClass extends TestClass {
+	public static class IncompatibleClass extends TestClass {
 		@Tag(3) public int poorlyTaggedField = 5;
 	}
 
-	static public class AnotherClass {
+	public static class AnotherClass {
 		@Tag(1) String value;
 	}
 
-	static private class FutureClass {
+	private static class FutureClass {
 		@Tag(0) public Integer value;
 		@Tag(1) public FutureClass2 futureClass2;
 		@Tag(value = 2) public String futureString = "unchanged";
@@ -229,7 +229,7 @@ public class TaggedFieldSerializerTest extends KryoTestCase {
 		}
 	}
 
-	static private class FutureClass2 {
+	private static class FutureClass2 {
 		@Tag(0) public String text = "something";
 		@Tag(1) public int moo = 120;
 		@Tag(2) public long moo2 = 1234120;

--- a/test/com/esotericsoftware/kryo/serializers/VersionedFieldSerializerTest.java
+++ b/test/com/esotericsoftware/kryo/serializers/VersionedFieldSerializerTest.java
@@ -53,7 +53,7 @@ public class VersionedFieldSerializerTest extends KryoTestCase {
 		assertEquals(object2.other.value, object1.other.value);
 	}
 
-	static public class TestClass {
+	public static class TestClass {
 		@Since(1) public String text = "something";
 		@Since(1) public int moo = 120;
 		@Since(2) public long moo2 = 1234120;
@@ -79,11 +79,11 @@ public class VersionedFieldSerializerTest extends KryoTestCase {
 		}
 	}
 
-	static public class AnotherClass {
+	public static class AnotherClass {
 		@Since(1) String value;
 	}
 
-	static private class FutureClass {
+	private static class FutureClass {
 		@Since(0) public Integer value;
 		@Since(1) public FutureClass2 futureClass2;
 		@Since(2) public String futureString = "unchanged";
@@ -121,7 +121,7 @@ public class VersionedFieldSerializerTest extends KryoTestCase {
 		}
 	}
 
-	static private class FutureClass2 {
+	private static class FutureClass2 {
 		@Since(0) public String text = "something";
 		@Since(1) public int moo = 120;
 		@Since(2) public long moo2 = 1234120;

--- a/test/com/esotericsoftware/kryo/util/GenericsUtilTest.java
+++ b/test/com/esotericsoftware/kryo/util/GenericsUtilTest.java
@@ -108,7 +108,7 @@ public class GenericsUtilTest {
 		}
 	}
 
-	static public class Test1<FLOAT, STRING, NULL> {
+	public static class Test1<FLOAT, STRING, NULL> {
 		public ArrayList<String> fromField1;
 		public ArrayList<FLOAT> fromSubClass;
 		public ArrayList<STRING> fromSubSubClass;
@@ -118,7 +118,7 @@ public class GenericsUtilTest {
 		public STRING[] arrayFromSubSubClass;
 	}
 
-	static public class Test2<STRING, NULL, ARRAYLIST> extends Test1<Float, STRING, NULL> {
+	public static class Test2<STRING, NULL, ARRAYLIST> extends Test1<Float, STRING, NULL> {
 		public STRING known;
 		public STRING[] array1;
 		public STRING[][] array2;
@@ -131,7 +131,7 @@ public class GenericsUtilTest {
 		public ArrayList<ARRAYLIST>[] parameterizedArrayFromSubClass;
 	}
 
-	static public class Test3<DOUBLE extends Number & Comparable, NULL, LONG> extends Test2<String, NULL, ArrayList<LONG>> {
+	public static class Test3<DOUBLE extends Number & Comparable, NULL, LONG> extends Test2<String, NULL, ArrayList<LONG>> {
 		public ArrayList<String> fromField3;
 		public ArrayList raw;
 		public NULL unknown2;
@@ -142,10 +142,10 @@ public class GenericsUtilTest {
 		public ArrayList<DOUBLE> multipleUpperBounds;
 	}
 
-	static public class Test4<NULL> extends Test3<Double, NULL, Long> {
+	public static class Test4<NULL> extends Test3<Double, NULL, Long> {
 	}
 
-	static public void main (String[] args) throws Exception {
+	public static void main (String[] args) throws Exception {
 		new GenericsUtilTest().testGenerics();
 	}
 }

--- a/test/com/esotericsoftware/kryo/util/PoolTest.java
+++ b/test/com/esotericsoftware/kryo/util/PoolTest.java
@@ -36,7 +36,7 @@ import org.junit.runners.Parameterized.Parameters;
 @RunWith(Parameterized.class)
 public class PoolTest extends KryoTestCase {
 	@Parameters
-	static public Collection<Object[]> data () {
+	public static Collection<Object[]> data () {
 		return Arrays.asList(new Object[][] {{new Pool<Kryo>(true, false, 16) {
 			protected Kryo create () {
 				return new Kryo();


### PR DESCRIPTION
Addresses the second code style issue described in #739 by applying Java's recommended modifier order.

See https://stackoverflow.com/a/16732059/441266