### PR TITLE
#744 CompatibleFieldSerializer and fields declared as super-types

### DIFF
--- a/src/com/esotericsoftware/kryo/serializers/CompatibleFieldSerializer.java
+++ b/src/com/esotericsoftware/kryo/serializers/CompatibleFieldSerializer.java
@@ -90,7 +90,13 @@ public class CompatibleFieldSerializer<T> extends FieldSerializer<T> {
 				try {
 					if (object != null) {
 						Object value = cachedField.field.get(object);
-						if (value != null) valueClass = cachedField.field.getType();
+						if (value != null) {
+							final Class<?> fieldType = cachedField.field.getType();
+							if (fieldType.isPrimitive())
+								valueClass = fieldType;
+							else
+								valueClass = value.getClass();
+						}
 					}
 				} catch (IllegalAccessException ex) {
 				}

--- a/src/com/esotericsoftware/kryo/serializers/CompatibleFieldSerializer.java
+++ b/src/com/esotericsoftware/kryo/serializers/CompatibleFieldSerializer.java
@@ -30,6 +30,7 @@ import com.esotericsoftware.kryo.io.InputChunked;
 import com.esotericsoftware.kryo.io.Output;
 import com.esotericsoftware.kryo.io.OutputChunked;
 import com.esotericsoftware.kryo.util.ObjectMap;
+import com.esotericsoftware.kryo.util.Util;
 
 /** Serializes objects using direct field assignment, providing both forward and backward compatibility. This means fields can be
  * added or removed without invalidating previously serialized bytes. Renaming or changing the type of a field is not supported.
@@ -90,13 +91,7 @@ public class CompatibleFieldSerializer<T> extends FieldSerializer<T> {
 				try {
 					if (object != null) {
 						Object value = cachedField.field.get(object);
-						if (value != null) {
-							final Class<?> fieldType = cachedField.field.getType();
-							if (fieldType.isPrimitive())
-								valueClass = fieldType;
-							else
-								valueClass = value.getClass();
-						}
+						if (value != null) valueClass = value.getClass();
 					}
 				} catch (IllegalAccessException ex) {
 				}
@@ -168,7 +163,7 @@ public class CompatibleFieldSerializer<T> extends FieldSerializer<T> {
 				}
 
 				// Ensure the type in the data is compatible with the field type.
-				if (cachedField.valueClass != null && !cachedField.valueClass.isAssignableFrom(valueClass)) {
+				if (cachedField.valueClass != null && !Util.isAssignableTo(valueClass, cachedField.valueClass)) {
 					String message = "Read type is incompatible with the field type: " + className(valueClass) + " -> "
 						+ className(cachedField.valueClass) + " (" + getType().getName() + "#" + cachedField + ")";
 					if (!chunked) throw new KryoException(message);

--- a/src/com/esotericsoftware/kryo/util/Util.java
+++ b/src/com/esotericsoftware/kryo/util/Util.java
@@ -27,6 +27,8 @@ import com.esotericsoftware.kryo.serializers.FieldSerializer;
 import com.esotericsoftware.kryo.util.Generics.GenericType;
 
 import java.lang.reflect.Type;
+import java.util.HashMap;
+import java.util.Map;
 
 /** A few utility methods, mostly for private use.
  * @author Nathan Sweet */
@@ -52,6 +54,18 @@ public class Util {
 
 	// Maximum reasonable array length. See: https://stackoverflow.com/questions/3038392/do-java-arrays-have-a-maximum-size
 	public static final int maxArraySize = Integer.MAX_VALUE - 8;
+
+	private static final Map<Class<?>, Class<?>> primitiveWrappers = new HashMap<>();
+	static {
+		primitiveWrappers.put(boolean.class, Boolean.class);
+		primitiveWrappers.put(byte.class, Byte.class);
+		primitiveWrappers.put(char.class, Character.class);
+		primitiveWrappers.put(double.class, Double.class);
+		primitiveWrappers.put(float.class, Float.class);
+		primitiveWrappers.put(int.class, Integer.class);
+		primitiveWrappers.put(long.class, Long.class);
+		primitiveWrappers.put(short.class, Short.class);
+	}
 
 	public static boolean isClassAvailable (String className) {
 		try {
@@ -205,6 +219,18 @@ public class Util {
 		while (elementClass.getComponentType() != null)
 			elementClass = elementClass.getComponentType();
 		return elementClass;
+	}
+
+	public static boolean isAssignableTo (Class<?> from, Class<?> to) {
+		if (to.isAssignableFrom(from)) return true;
+		if (from.isPrimitive()) return isPrimitiveWrapperOf(to, from);
+		if (to.isPrimitive()) return isPrimitiveWrapperOf(from, to);
+		return false;
+	}
+
+	private static boolean isPrimitiveWrapperOf (Class<?> targetClass, Class<?> primitive) {
+		if (!primitive.isPrimitive()) throw new IllegalArgumentException("First argument has to be primitive type");
+		return primitiveWrappers.get(primitive) == targetClass;
 	}
 
 	public static boolean isAscii (String value) {

--- a/test/com/esotericsoftware/kryo/util/UtilTest.java
+++ b/test/com/esotericsoftware/kryo/util/UtilTest.java
@@ -1,0 +1,17 @@
+package com.esotericsoftware.kryo.util;
+
+import junit.framework.TestCase;
+
+public class UtilTest extends TestCase {
+
+    public void testIsAssignableTo() {
+        assertTrue(Util.isAssignableTo(Long.class, long.class));
+        assertTrue(Util.isAssignableTo(long.class, Long.class));
+        assertTrue(Util.isAssignableTo(Long.class, Long.class));
+        assertTrue(Util.isAssignableTo(long.class, long.class));
+
+        assertFalse(Util.isAssignableTo(String.class, Long.class));
+        assertFalse(Util.isAssignableTo(String.class, long.class));
+    }
+
+}


### PR DESCRIPTION
This PR attempts to resolve #744.

The original fix pushed by @NathanSweet in https://github.com/EsotericSoftware/kryo/commit/fb10f37ffec43d461b10d0cf4f17b950d12b6752 only works for fields that have the same type as the object stored in it. It fails for fields declared as super-types and interfaces.

This PR adds a check for primitive types originally proposed by @isaki in #670 and uses the concrete value class in all other instances.