### PR TITLE
#746 Ensure pool maximum capacity is honored

### DIFF
--- a/eclipse/code-format.xml
+++ b/eclipse/code-format.xml
@@ -163,7 +163,7 @@
 <setting id="org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode" value="enabled"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_switch" value="do not insert"/>
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_method_declaration" value="0"/>
-<setting id="org.eclipse.jdt.core.formatter.join_wrapped_lines" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.join_wrapped_lines" value="false"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_constructor_declaration" value="do not insert"/>
 <setting id="org.eclipse.jdt.core.formatter.wrap_before_conditional_operator" value="true"/>
 <setting id="org.eclipse.jdt.core.formatter.indent_switchstatements_compare_to_cases" value="true"/>


### PR DESCRIPTION
This PR resolves #746.

Limiting a pools maximum capacity is currently broken for two cases:

1. threadSafe=true softReferences=true
2. threadSafe=false softReferences=false

In the first case, `LinkedBlockingQueue.add` isn't overridden, so an `IllegalStateException` is thrown when reaching maximum capacity.

In the second case, the wrong method was overridden. `ArrayDeck` is not wrapped in a `SoftReferenceQueue` so `ArrayDeck.offer` is called directly. Internally, it uses `addLast` instead of `add` so the overridden method is never called.

I also made a slight change to the code formatting settings that preserves explicit linebreaks. It greatly improves the readability of the test-cases.