### PR TITLE
Improve MapReferenceResolver for small object graphs

### DIFF
--- a/src/com/esotericsoftware/kryo/util/MapReferenceResolver.java
+++ b/src/com/esotericsoftware/kryo/util/MapReferenceResolver.java
@@ -34,8 +34,8 @@ public class MapReferenceResolver implements ReferenceResolver {
 	private static final int MAXIMUM_CAPACITY = 8192;
 
 	protected Kryo kryo;
-	protected final IdentityObjectIntMap<Object> writtenObjects = new IdentityObjectIntMap<>(CAPACITY);
-	protected final ArrayList<Object> readObjects = new ArrayList<>(CAPACITY);
+	protected final IdentityObjectIntMap<Object> writtenObjects = new IdentityObjectIntMap<>();
+	protected final ArrayList<Object> readObjects = new ArrayList<>();
 	private final int maximumCapacity;
 
 	public MapReferenceResolver () {


### PR DESCRIPTION
This PR reverts initializing `MapReferenceResolver` collections with large capacities originally pushed in #705. 

For smaller object graphs this *significantly* increases overhead because these large maps have to be cleared after each graph is (de)serialized. The only advantage of initializing them at high capacity is that the *very first time* a larger graph is serialized, less resizing happens.

**Kryo 4**

Benchmark  |                     (objectType)  | (references) |   Mode |  Cnt  |      Score   
------------ | ------------- | ------------- | ------------- | ------------- | --:
FieldSerializerBenchmark.field     |   sample  |        **true** |  thrpt  |  5 |  **1211713,059** 
FieldSerializerBenchmark.field     |    media   |       **true** | thrpt  |  5  | **752031,612**

**Kryo 5 Master**

Benchmark  |                     (objectType)  | (references) |   Mode |  Cnt  |      Score   
------------ | ------------- | ------------- | ------------- | ------------- | --:
FieldSerializerBenchmark.field     |    sample   |     **true**   | thrpt    | 5  |  **453076,359**
FieldSerializerBenchmark.field       |   media    |       **true**   | thrpt   |  5 |  **332960,442**

**Kryo 5 Without Initial Capacity**

Benchmark  |                     (objectType)  | (references) |   Mode |  Cnt  |      Score   
------------ | ------------- | ------------- | ------------- | ------------- | --:
FieldSerializerBenchmark.field    |     sample    |       **true**  | thrpt  |   5   | **1197619,699**
FieldSerializerBenchmark.field     |     media      |     **true**  | thrpt   |  5  |  **785907,114**

This PR is part of my ongoing effort to make sure that Kryo 5 performs at least as well as Kryo 4. This PR achieves just that for small object graphs with references.

