### PR TITLE
Initialize HashSet with large enough capacity

### DIFF
--- a/src/com/esotericsoftware/kryo/serializers/CollectionSerializer.java
+++ b/src/com/esotericsoftware/kryo/serializers/CollectionSerializer.java
@@ -27,6 +27,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashSet;
 
 import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.Registration;
@@ -170,9 +171,10 @@ public class CollectionSerializer<T extends Collection> extends Serializer<T> {
 
 	/** Used by {@link #read(Kryo, Input, Class)} to create the new object. This can be overridden to customize object creation (eg
 	 * to call a constructor with arguments), optionally reading bytes written in {@link #writeHeader(Kryo, Output, Collection)}.
-	 * The default implementation uses {@link Kryo#newInstance(Class)} with special cases for ArrayList. */
+	 * The default implementation uses {@link Kryo#newInstance(Class)} with special cases for ArrayList and HashSet. */
 	protected T create (Kryo kryo, Input input, Class<? extends T> type, int size) {
-		if (type == ArrayList.class) return (T)new ArrayList(size);
+		if (type == ArrayList.class) return (T)new ArrayList<>(size);
+		if (type == HashSet.class) return (T)new HashSet<>(Math.max((int)(size / 0.75f) + 1, 16));
 		T collection = kryo.newInstance(type);
 		if (collection instanceof ArrayList) ((ArrayList)collection).ensureCapacity(size);
 		return collection;


### PR DESCRIPTION
This PR adds a special case for `HashSet` to `CollectionSerializer`. It creates the set with the known capacity to avoid any resizing. 

We already have such special cases for `HashMap` and `ArrayList`.

The implementation is taken directly from JDK 11:

```
    public HashSet(Collection<? extends E> c) {
        map = new HashMap<>(Math.max((int) (c.size()/.75f) + 1, 16));
        addAll(c);
    }
```

The idea for this came up in a discussion on the [mailing list](https://groups.google.com/g/kryo-users/c/YDVladPC1F8/m/5N4ZGYe-EQAJ).

This approach is significantly faster for larger sets:

Benchmark  |                     (numItems)  | (mode) |   Mode |  Cnt  |      Score   
------------ | ------------- | ------------- | ------------- | ------------- | --:
HashSetBenchmark.read    |       1 |    reflection  | thrpt  |  9 |  15253082,858 | ops/s
HashSetBenchmark.read    |       1 |   direct+size  | thrpt  |  9 |  **18653499,627** | ops/s
HashSetBenchmark.read    |       5 |    reflection  | thrpt  |  9 |   8135389,329 | ops/s
HashSetBenchmark.read    |       5 |   direct+size  | thrpt  |  9 |   **8707013,705** | ops/s
HashSetBenchmark.read    |      10 |    reflection  | thrpt  |  9 |   5145392,761 | ops/s
HashSetBenchmark.read    |      10 |   direct+size  | thrpt  |  9 |   **5247402,334** | ops/s
HashSetBenchmark.read    |      50 |    reflection  | thrpt  |  9 |    780452,766 | ops/s
HashSetBenchmark.read    |      50 |   direct+size  | thrpt  |  9 |   **1008412,118** | ops/s
HashSetBenchmark.read    |     100 |    reflection  | thrpt  |  9 |    413697,180 | ops/s
HashSetBenchmark.read    |     100 |   direct+size  | thrpt  |  9 |    **459713,824** | ops/s
HashSetBenchmark.read    |    1000 |    reflection  | thrpt  |  9 |     40575,950 | ops/s
HashSetBenchmark.read    |    1000 |   direct+size  | thrpt  |  9 |     **45918,865** | ops/s