### PR TITLE
Customizable value for maximum capacity in MapReferenceResolver

### DIFF
--- a/src/com/esotericsoftware/kryo/util/MapReferenceResolver.java
+++ b/src/com/esotericsoftware/kryo/util/MapReferenceResolver.java
@@ -30,18 +30,21 @@ import java.util.ArrayList;
  * for get or put.
  * @author Nathan Sweet */
 public class MapReferenceResolver implements ReferenceResolver {
-	private static final int CAPACITY = 2048;
-	private static final int MAXIMUM_CAPACITY = 8192;
+	private static final int DEFAULT_CAPACITY = 2048;
 
 	protected Kryo kryo;
 	protected final IdentityObjectIntMap<Object> writtenObjects = new IdentityObjectIntMap<>();
 	protected final ArrayList<Object> readObjects = new ArrayList<>();
 	private final int maximumCapacity;
 
+	/** Creates a reference resolver with a default maximum capacity of 2048 */
 	public MapReferenceResolver () {
-		this(MAXIMUM_CAPACITY);
+		this(DEFAULT_CAPACITY);
 	}
 
+	/** Creates a reference resolver with the specified maximum capacity. The default value of 2048 is good enough in most cases.
+	 * If the average object graph is larger than the default, increasing this value can provide better performance.
+	 * @param maximumCapacity the capacity to trim written and read objects to when {@link #reset()} is called */
 	public MapReferenceResolver (int maximumCapacity) {
 		this.maximumCapacity = maximumCapacity;
 	}
@@ -86,9 +89,9 @@ public class MapReferenceResolver implements ReferenceResolver {
 		readObjects.clear();
 		if (size > maximumCapacity) {
 			readObjects.trimToSize();
-			readObjects.ensureCapacity(CAPACITY);
+			readObjects.ensureCapacity(maximumCapacity);
 		}
-		writtenObjects.clear(CAPACITY);
+		writtenObjects.clear(maximumCapacity);
 	}
 
 	/** Returns false for all primitive wrappers and enums. */


### PR DESCRIPTION
This PR makes the maximum capacity for read and written references configurable.

The new map implementations in Kryo 5 are quite sensitive to resize operations. The map that tracks written objects in `MapReferenceResolver` is currently resized to a maximum capacity of 2048 after each serialization.

Serializing graphs with more than 2048 objects cause the map to grow and shrink constantly. Ideally, the maximum capacity for the reference resolver should be higher than the average size of the serialized graphs. This increases throughput by 15-20% for large graphs:

Benchmark  |  (maxCapacity) |   (numObjects) |     Mode |        Score   | Units
------------ | ------------- | ------------- |  ------------- |  --: | -------------
MapBenchmark.readWrite       |          2048     |     3000  | thrpt  |      2987,977 |   ops/s
MapBenchmark.readWrite       |          2048     |     5000  | thrpt  |      1587,943 |   ops/s
MapBenchmark.readWrite       |          2048     |     8500  | thrpt  |       **834,508** |   ops/s
MapBenchmark.readWrite       |          2048     |    15000  | thrpt  |       **445,304** |   ops/s

Benchmark  |  (maxCapacity) |   (numObjects) |     Mode |        Score   | Units
------------ | ------------- | ------------- |  ------------- |  --: | -------------
MapBenchmark.readWrite       |          4096     |     3000  | thrpt  |      3184,284 |   ops/s
MapBenchmark.readWrite       |          4096     |     5000  | thrpt  |      1878,396 |   ops/s
MapBenchmark.readWrite       |          4096     |     8500  | thrpt  |       **915,208** |   ops/s
MapBenchmark.readWrite       |          4096     |    15000  | thrpt  |       **450,174** |   ops/s

Benchmark  |  (maxCapacity) |   (numObjects) |     Mode |        Score   | Units
------------ | ------------- | ------------- |  ------------- |  --: | -------------
MapBenchmark.readWrite       |         8192     |     3000   | thrpt  |      3153,370 |   ops/s
MapBenchmark.readWrite       |         8192     |     5000   | thrpt  |      1853,255 |   ops/s
MapBenchmark.readWrite       |         8192     |     8500   | thrpt  |     **1020,657** |   ops/s
MapBenchmark.readWrite       |         8192     |    15000   | thrpt  |       **499,207** |   ops/s

Benchmark  |  (maxCapacity) |   (numObjects) |     Mode |        Score   | Units
------------ | ------------- | ------------- |  ------------- |  --: | -------------
MapBenchmark.readWrite       |         16384    |      3000  | thrpt  |      3146,643 |   ops/s
MapBenchmark.readWrite       |         16384    |      5000  | thrpt  |      1819,554 |   ops/s
MapBenchmark.readWrite       |         16384    |      8500  | thrpt  |      **1027,564** |   ops/s
MapBenchmark.readWrite       |         16384    |     15000  | thrpt  |      **540,213** |   ops/s

Benchmark implementation: The benchmark writes `numObjects` to a `MapReferenceResolver` with capacity `maxCapacity`. It then reads `numObjects * 2` random objects back from the resolver and resets the resolver. 