### PR TITLE
#754 Unimplement `Poolable` from Kryo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1236,7 +1236,7 @@ If `true` is passed as the second argument to the Pool constructor, the Pool sto
 
 The third Pool parameter is the maximum capacity. If an object is freed and the pool already contains the maximum number of free objects, the specified object is reset but not added to the pool. The maximum capacity may be omitted for no limit.
 
-If an object implements Pool.Poolable then Poolable `reset` is called when the object is freed. This gives the object a chance to reset its state for reuse in the future. Alternatively, Pool `reset` can be overridden to reset objects. Input and Output implement Poolable to set their `position` and `total` to 0. Kryo implements Poolable to reset its object graph state.
+If an object implements Pool.Poolable then Poolable `reset` is called when the object is freed. This gives the object a chance to reset its state for reuse in the future. Alternatively, Pool `reset` can be overridden to reset objects. Input and Output implement Poolable to set their `position` and `total` to 0.
 
 Pool `getFree` returns the number of objects available to be obtained. If using soft references, this number may include objects that have been garbage collected. `clean` may be used first to remove empty soft references.
 

--- a/src/com/esotericsoftware/kryo/Kryo.java
+++ b/src/com/esotericsoftware/kryo/Kryo.java
@@ -92,7 +92,6 @@ import com.esotericsoftware.kryo.util.IntArray;
 import com.esotericsoftware.kryo.util.MapReferenceResolver;
 import com.esotericsoftware.kryo.util.NoGenerics;
 import com.esotericsoftware.kryo.util.ObjectMap;
-import com.esotericsoftware.kryo.util.Pool.Poolable;
 import com.esotericsoftware.kryo.util.Util;
 
 import java.lang.reflect.InvocationHandler;
@@ -126,7 +125,7 @@ import org.objenesis.strategy.StdInstantiatorStrategy;
 
 /** Maps classes to serializers so object graphs can be serialized automatically.
  * @author Nathan Sweet */
-public class Kryo implements Poolable {
+public class Kryo {
 	public static final byte NULL = 0;
 	public static final byte NOT_NULL = 1;
 
@@ -875,7 +874,6 @@ public class Kryo implements Poolable {
 	 * {@link #getOriginalToCopyMap() original to copy map}, and the {@link #getGraphContext() graph context}. If
 	 * {@link #setAutoReset(boolean) auto reset} is true, this method is called automatically when an object graph has been
 	 * completely serialized or deserialized. If overridden, the super method must be called. */
-	@Override
 	public void reset () {
 		depth = 0;
 		if (graphContext != null) graphContext.clear(2048);


### PR DESCRIPTION
This PR removes `Poolable` from Kryo to prevent resetting the object graph state twice after each (de)serialization. 

`Poolable` is a good fit for `Input`/`Output`, but in the case of `Kryo` conflicts with the concept of `autoReset`.

Resolves #754.
