### PR TITLE
ArraysAsListSerializer should deep-copy

### DIFF
--- a/src/com/esotericsoftware/kryo/serializers/DefaultSerializers.java
+++ b/src/com/esotericsoftware/kryo/serializers/DefaultSerializers.java
@@ -904,7 +904,14 @@ public class DefaultSerializers {
 
 		@Override
 		public List copy (Kryo kryo, List original) {
-			return Arrays.asList(original.toArray());
+			Object[] copyArr = new Object[original.size()];
+			List<Object> copy = Arrays.asList(copyArr);
+			kryo.reference(copy);
+			for (int i = 0; i < original.size(); i++)
+			{
+				copyArr[i] = kryo.copy(original.get(i));
+			}
+			return copy;
 		}
 	}
 

--- a/test/com/esotericsoftware/kryo/serializers/DefaultSerializersTest.java
+++ b/test/com/esotericsoftware/kryo/serializers/DefaultSerializersTest.java
@@ -445,6 +445,21 @@ public class DefaultSerializersTest extends KryoTestCase {
 	}
 
 	@Test
+	public void testArraysAsListDeepCopy () throws Exception {
+		kryo.register(Arrays.asList().getClass());
+		kryo.register(Date.class);
+
+		List<Date> list = Arrays.asList(new Date(-1234567));
+		List<Date> copiedList = kryo.copy(list);
+
+		assertEquals("List copy should equal the original list", list, copiedList);
+		assertNotSame("List copy should be a different instance", list, copiedList);
+		assertEquals("Class of list copy should be the same as produced by Arrays.asList", copiedList.getClass(), list.getClass());
+		assertEquals("List copy content should equal the original list content", list.get(0), copiedList.get(0));
+		assertNotSame("List copy content should be a different instance", list.get(0), copiedList.get(0));
+	}
+
+	@Test
 	public void testURLSerializer () throws Exception {
 		kryo.setInstantiatorStrategy(new DefaultInstantiatorStrategy(new StdInstantiatorStrategy()));
 		kryo.register(URL.class);


### PR DESCRIPTION
The standard CollectionSerializer creates a deep copy of its structure, including children. The ArraysAsListSerializer surprisingly only created a shallow copy as it did not call kryo.copy(...) on its children. This has been fixed.