### PR TITLE
Add a new ConcurrentSkipListMapSerializer

### DIFF
--- a/src/com/esotericsoftware/kryo/Kryo.java
+++ b/src/com/esotericsoftware/kryo/Kryo.java
@@ -74,6 +74,7 @@ import com.esotericsoftware.kryo.serializers.DefaultSerializers.StringSerializer
 import com.esotericsoftware.kryo.serializers.DefaultSerializers.TimeZoneSerializer;
 import com.esotericsoftware.kryo.serializers.DefaultSerializers.TreeMapSerializer;
 import com.esotericsoftware.kryo.serializers.DefaultSerializers.TreeSetSerializer;
+import com.esotericsoftware.kryo.serializers.DefaultSerializers.ConcurrentSkipListMapSerializer;
 import com.esotericsoftware.kryo.serializers.DefaultSerializers.URLSerializer;
 import com.esotericsoftware.kryo.serializers.DefaultSerializers.VoidSerializer;
 import com.esotericsoftware.kryo.serializers.FieldSerializer;
@@ -117,6 +118,7 @@ import java.util.PriorityQueue;
 import java.util.TimeZone;
 import java.util.TreeMap;
 import java.util.TreeSet;
+import java.util.concurrent.ConcurrentSkipListMap;
 
 import org.objenesis.instantiator.ObjectInstantiator;
 import org.objenesis.strategy.InstantiatorStrategy;
@@ -131,9 +133,10 @@ public class Kryo {
 
 	private static final int REF = -1;
 	private static final int NO_REF = -2;
+	private static final int DEFAULT_SERIALIZER_SIZE = 68;
 
 	private SerializerFactory defaultSerializer = new FieldSerializerFactory();
-	private final ArrayList<DefaultSerializerEntry> defaultSerializers = new ArrayList(67);
+	private final ArrayList<DefaultSerializerEntry> defaultSerializers = new ArrayList(DEFAULT_SERIALIZER_SIZE);
 	private final int lowPriorityDefaultSerializerCount;
 
 	private final ClassResolver classResolver;
@@ -211,6 +214,7 @@ public class Kryo {
 		addDefaultSerializer(Collections.singleton(null).getClass(), CollectionsSingletonSetSerializer.class);
 		addDefaultSerializer(TreeSet.class, TreeSetSerializer.class);
 		addDefaultSerializer(Collection.class, CollectionSerializer.class);
+		addDefaultSerializer(ConcurrentSkipListMap.class, ConcurrentSkipListMapSerializer.class);
 		addDefaultSerializer(TreeMap.class, TreeMapSerializer.class);
 		addDefaultSerializer(Map.class, MapSerializer.class);
 		addDefaultSerializer(TimeZone.class, TimeZoneSerializer.class);

--- a/src/com/esotericsoftware/kryo/serializers/DefaultSerializers.java
+++ b/src/com/esotericsoftware/kryo/serializers/DefaultSerializers.java
@@ -58,6 +58,7 @@ import java.util.Set;
 import java.util.TimeZone;
 import java.util.TreeMap;
 import java.util.TreeSet;
+import java.util.concurrent.ConcurrentSkipListMap;
 
 /** Contains many serializer classes that are provided by {@link Kryo#addDefaultSerializer(Class, Class) default}.
  * @author Nathan Sweet */
@@ -719,6 +720,46 @@ public class DefaultSerializers {
 			}
 		}
 	}
+
+    /** Serializer for {@link ConcurrentSkipListMap} and any subclass.
+     * @author Mr14huashao <mr11huashao@gmail.com> (enhacements)*/
+    public static class ConcurrentSkipListMapSerializer extends MapSerializer<ConcurrentSkipListMap> {
+        @Override
+        protected void writeHeader(Kryo kryo, Output output, ConcurrentSkipListMap concurrentSkipListMap) {
+            kryo.writeClassAndObject(output, concurrentSkipListMap.comparator());
+        }
+
+        @Override
+        protected ConcurrentSkipListMap create(Kryo kryo, Input input, Class<? extends ConcurrentSkipListMap> type,
+            int size) {
+            return createConcurrentSkipListMap(type, (Comparator)kryo.readClassAndObject(input));
+        }
+
+        @Override
+        protected ConcurrentSkipListMap createCopy(Kryo kryo, ConcurrentSkipListMap original) {
+            return createConcurrentSkipListMap(original.getClass(), original.comparator());
+        }
+
+        private ConcurrentSkipListMap createConcurrentSkipListMap(Class<? extends ConcurrentSkipListMap> type,
+            Comparator comparator) {
+            if (type == ConcurrentSkipListMap.class || type == null) {
+                return new ConcurrentSkipListMap(comparator);
+            }
+            // Use reflection for subclasses.
+            try {
+                Constructor constructor = type.getConstructor(Comparator.class);
+                if (!constructor.isAccessible()) {
+                    try {
+                        constructor.setAccessible(true);
+                    } catch (SecurityException ignored) {
+                    }
+                }
+                return (ConcurrentSkipListMap)constructor.newInstance(comparator);
+            } catch (Exception ex) {
+                throw new KryoException(ex);
+            }
+        }
+    }
 
 	/** Serializer for {@link TreeMap} and any subclass.
 	 * @author Tumi <serverperformance@gmail.com> (enhacements) */

--- a/test/com/esotericsoftware/kryo/SerializationCompatTest.java
+++ b/test/com/esotericsoftware/kryo/SerializationCompatTest.java
@@ -81,7 +81,7 @@ public class SerializationCompatTest extends KryoTestCase {
 		int[] versions = new int[] {parseInt(strVersions[0]), parseInt(strVersions[1])};
 		JAVA_VERSION = versions[0] > 1 ? versions[0] : versions[1];
 	}
-	private static final int EXPECTED_DEFAULT_SERIALIZER_COUNT = JAVA_VERSION < 11 ? 57 : 67; // Also change Kryo#defaultSerializers.
+	private static final int EXPECTED_DEFAULT_SERIALIZER_COUNT = JAVA_VERSION < 11 ? 58 : 68; // Also change Kryo#defaultSerializers.
 	private static final List<TestDataDescription> TEST_DATAS = new ArrayList<>();
 
 	static {


### PR DESCRIPTION
As the issue [#660 ] (https://github.com/EsotericSoftware/kryo/issues/660) mentioned, the kryo lacks of a default 'ConcurrentSKipListMap' serializer.

This is a fix for it.