### PR TITLE
#776 Downgrade maven-bundle-plugin

### DIFF
--- a/pom-main.xml
+++ b/pom-main.xml
@@ -48,7 +48,7 @@
 			<plugin>
 				<groupId>org.apache.felix</groupId>
 				<artifactId>maven-bundle-plugin</artifactId>
-				<version>5.1.1</version>
+				<version>4.2.1</version>
 				<extensions>true</extensions>
 				<configuration>
 					<instructions>


### PR DESCRIPTION
Downgrades the `maven-bundle-plugin`.

A bug in that plugin drops the Automatic-Module-Name set by the maven-jar-plugin:

https://issues.apache.org/jira/browse/FELIX-6312
https://issues.apache.org/jira/browse/FELIX-6337

Resolves #776