### PR TITLE
#778 Use canonical class name for registration hint if available

### DIFF
--- a/src/com/esotericsoftware/kryo/Kryo.java
+++ b/src/com/esotericsoftware/kryo/Kryo.java
@@ -519,7 +519,7 @@ public class Kryo {
 
 	protected String unregisteredClassMessage (Class type) {
 		return "Class is not registered: " + className(type) + "\nNote: To register this class use: kryo.register("
-			+ className(type) + ".class);";
+			+ canonicalName(type) + ".class);";
 	}
 
 	/** @see ClassResolver#getRegistration(int) */

--- a/src/com/esotericsoftware/kryo/util/Util.java
+++ b/src/com/esotericsoftware/kryo/util/Util.java
@@ -179,6 +179,14 @@ public class Util {
 		return buffer.toString();
 	}
 
+	/** Returns the class formatted as a string. If the class has a canonical name, the canonical name is returned, 
+	 * otherwise it returns the result of {@link #className(Class)} */
+	public static String canonicalName(Class type) {
+		if (type == null) return "null";
+		final String canonicalName = type.getCanonicalName();
+		return canonicalName != null ? canonicalName : className(type);
+	}
+
 	public static String simpleName (Type type) {
 		if (type instanceof Class) return ((Class)type).getSimpleName();
 		return type.toString(); // Java 8: getTypeName

--- a/test/com/esotericsoftware/kryo/WarnUnregisteredClassesTest.java
+++ b/test/com/esotericsoftware/kryo/WarnUnregisteredClassesTest.java
@@ -97,13 +97,25 @@ public class WarnUnregisteredClassesTest {
 	}
 
 	@Test
-	public void testLogMessageShouldContainsClassName () {
+	public void testLogMessageShouldContainClassName () {
 		Kryo kryo = new Kryo();
 		kryo.setRegistrationRequired(false);
 		kryo.setWarnUnregisteredClasses(true);
 
 		write(kryo, new UnregisteredClass());
 		assertTrue(log.messages.get(0).contains(UnregisteredClass.class.getName()));
+	}
+
+	@Test
+	public void testLogMessageShouldContainRegistrationHintWithCanonicalName () {
+		Kryo kryo = new Kryo();
+		kryo.setRegistrationRequired(false);
+		kryo.setWarnUnregisteredClasses(true);
+
+		write(kryo, new UnregisteredClass());
+		assertTrue(log.messages.get(0).contains(
+				"kryo.register(com.esotericsoftware.kryo.WarnUnregisteredClassesTest.UnregisteredClass.class)"
+		));
 	}
 
 	public void write (Kryo kryo, Object object) {


### PR DESCRIPTION
This PR adjusts the registration hint for `warnUnregisteredClasses` to use the canonical class name if available.

See #778 