### PR TITLE
#786 Balance `pushGenericType` and `popGenericType` for field serializers

### DIFF
--- a/src/com/esotericsoftware/kryo/serializers/CompatibleFieldSerializer.java
+++ b/src/com/esotericsoftware/kryo/serializers/CompatibleFieldSerializer.java
@@ -108,7 +108,7 @@ public class CompatibleFieldSerializer<T> extends FieldSerializer<T> {
 			if (chunked) outputChunked.endChunk();
 		}
 
-		if (pop > 0) popTypeVariables(pop);
+		popTypeVariables(pop);
 	}
 
 	@Override
@@ -186,7 +186,7 @@ public class CompatibleFieldSerializer<T> extends FieldSerializer<T> {
 			if (chunked) inputChunked.nextChunk();
 		}
 
-		if (pop > 0) popTypeVariables(pop);
+		popTypeVariables(pop);
 		return object;
 	}
 

--- a/src/com/esotericsoftware/kryo/serializers/FieldSerializer.java
+++ b/src/com/esotericsoftware/kryo/serializers/FieldSerializer.java
@@ -108,7 +108,7 @@ public class FieldSerializer<T> extends Serializer<T> {
 			fields[i].write(output, object);
 		}
 
-		if (pop > 0) popTypeVariables(pop);
+		popTypeVariables(pop);
 	}
 
 	@Override
@@ -124,7 +124,7 @@ public class FieldSerializer<T> extends Serializer<T> {
 			fields[i].read(input, object);
 		}
 
-		if (pop > 0) popTypeVariables(pop);
+		popTypeVariables(pop);
 		return object;
 	}
 
@@ -141,7 +141,9 @@ public class FieldSerializer<T> extends Serializer<T> {
 
 	protected void popTypeVariables (int pop) {
 		Generics generics = kryo.getGenerics();
-		generics.popTypeVariables(pop);
+		if (pop > 0) {
+			generics.popTypeVariables(pop);
+		}
 		generics.popGenericType();
 	}
 

--- a/src/com/esotericsoftware/kryo/serializers/TaggedFieldSerializer.java
+++ b/src/com/esotericsoftware/kryo/serializers/TaggedFieldSerializer.java
@@ -163,7 +163,7 @@ public class TaggedFieldSerializer<T> extends FieldSerializer<T> {
 			if (chunked) outputChunked.endChunk();
 		}
 
-		if (pop > 0) popTypeVariables(pop);
+		popTypeVariables(pop);
 	}
 
 	/** Can be overidden to write data needed for {@link #create(Kryo, Input, Class)}. The default implementation does nothing. */
@@ -238,7 +238,7 @@ public class TaggedFieldSerializer<T> extends FieldSerializer<T> {
 			if (chunked) inputChunked.nextChunk();
 		}
 
-		if (pop > 0) popTypeVariables(pop);
+		popTypeVariables(pop);
 		return object;
 	}
 

--- a/src/com/esotericsoftware/kryo/serializers/VersionFieldSerializer.java
+++ b/src/com/esotericsoftware/kryo/serializers/VersionFieldSerializer.java
@@ -109,7 +109,7 @@ public class VersionFieldSerializer<T> extends FieldSerializer<T> {
 			fields[i].write(output, object);
 		}
 
-		if (pop > 0) popTypeVariables(pop);
+		popTypeVariables(pop);
 	}
 
 	@Override
@@ -136,7 +136,7 @@ public class VersionFieldSerializer<T> extends FieldSerializer<T> {
 			fields[i].read(input, object);
 		}
 
-		if (pop > 0) popTypeVariables(pop);
+		popTypeVariables(pop);
 		return object;
 	}
 

--- a/src/com/esotericsoftware/kryo/util/DefaultGenerics.java
+++ b/src/com/esotericsoftware/kryo/util/DefaultGenerics.java
@@ -143,7 +143,12 @@ public final class DefaultGenerics implements Generics {
 		return null;
 	}
 
-	public String toString () {
+    @Override
+    public int getGenericTypesSize() {
+        return genericTypesSize;
+    }
+
+    public String toString () {
 		StringBuilder buffer = new StringBuilder();
 		for (int i = 0; i < argumentsSize; i += 2) {
 			if (i != 0) buffer.append(", ");

--- a/src/com/esotericsoftware/kryo/util/Generics.java
+++ b/src/com/esotericsoftware/kryo/util/Generics.java
@@ -70,6 +70,9 @@ public interface Generics {
 	/** Returns the class for the specified type variable, or null if it is not known.
 	 * @return May be null. */
 	Class resolveTypeVariable (TypeVariable typeVariable);
+	
+	/** Returns the number of generic types currently tracked */
+	int getGenericTypesSize();
 
 	/** Stores the type parameters for a class and, for parameters passed to super classes, the corresponding super class type
 	 * parameters. */

--- a/src/com/esotericsoftware/kryo/util/NoGenerics.java
+++ b/src/com/esotericsoftware/kryo/util/NoGenerics.java
@@ -61,4 +61,9 @@ public final class NoGenerics implements Generics {
 	public Class resolveTypeVariable (TypeVariable typeVariable) {
 		return null;
 	}
+
+    @Override
+    public int getGenericTypesSize() {
+        return 0;
+    }
 }

--- a/test/com/esotericsoftware/kryo/KryoTestCase.java
+++ b/test/com/esotericsoftware/kryo/KryoTestCase.java
@@ -290,6 +290,9 @@ public abstract class KryoTestCase {
 			doAssertEquals(object1, copy);
 		}
 
+		// Ensure generic types are balanced after each round of serialization
+		assertEquals(0, kryo.getGenerics().getGenericTypesSize());
+
 		return (T)object2;
 	}
 


### PR DESCRIPTION
This PR resolves #786. 

FieldSerializers currently violate the contract of `pushGenericType/popGenericType`. Under certain circumstances, a type is pushed but never popped resulting in an ever increasing array of generic types.

This PR ensures that `popGenericType` is called in all cases and adds an assertion for all round-trip tests that verifies that the generic types are empty after serialization.