### PR TITLE
#789 Catch StackOverflowError and add hint for enabling references

### DIFF
--- a/src/com/esotericsoftware/kryo/serializers/ReflectField.java
+++ b/src/com/esotericsoftware/kryo/serializers/ReflectField.java
@@ -92,6 +92,12 @@ class ReflectField extends CachedField {
 		} catch (KryoException ex) {
 			ex.addTrace(name + " (" + object.getClass().getName() + ")");
 			throw ex;
+		} catch (StackOverflowError ex) {
+			throw new KryoException(
+				"A StackOverflow occurred. The most likely cause is that your data has a circular reference resulting in " +
+					"infinite recursion. Try enabling references with Kryo.setReferences(true). If your data structure " +
+					"is really more than " + kryo.getDepth() + " levels deep then try increasing your Java stack size.",
+				ex);
 		} catch (Throwable t) {
 			KryoException ex = new KryoException(t);
 			ex.addTrace(name + " (" + object.getClass().getName() + ")");

--- a/test/com/esotericsoftware/kryo/serializers/FieldSerializerTest.java
+++ b/test/com/esotericsoftware/kryo/serializers/FieldSerializerTest.java
@@ -705,6 +705,22 @@ public class FieldSerializerTest extends KryoTestCase {
 		roundTrip(1440, root);
 	}
 
+	@Test
+	public void testCircularReference () {
+		kryo.register(CircularReference.class);
+		kryo.register(CircularReference.Inner.class);
+
+		CircularReference instance = new CircularReference();
+		try {
+			roundTrip(1, instance);
+		} catch (KryoException ex) {
+			assertTrue(ex.getMessage().contains("A StackOverflow occurred."));
+			return;
+		}
+
+		fail("Exception was expected");
+	}
+
 	public static class DefaultTypes {
 		// Primitives.
 		public boolean booleanField;
@@ -1279,4 +1295,17 @@ public class FieldSerializerTest extends KryoTestCase {
 			return true;
 		}
 	}
+
+	static class CircularReference {
+		Inner b = new Inner(this);
+
+		static class Inner {
+			CircularReference a;
+	
+			public Inner(CircularReference a) {
+				this.a = a;
+			}
+		}
+	}
+
 }


### PR DESCRIPTION
This PR catches `StackOverflowError` thrown by `FieldSerializer` and adds hint about enabling references to the error message.
 
Resolves #789.