### PR TITLE
Prevent ISE Queue full #804

### DIFF
--- a/src/com/esotericsoftware/kryo/util/Pool.java
+++ b/src/com/esotericsoftware/kryo/util/Pool.java
@@ -48,9 +48,7 @@ public abstract class Pool<T> {
 			queue = new LinkedBlockingQueue<T>(maximumCapacity) {
 				@Override
 				public boolean add (T o) {
-					if (size() >= maximumCapacity) return false;
-					super.add(o);
-					return true;
+					return super.offer(o);
 				}
 			};
 		else if (softReferences) {


### PR DESCRIPTION
Prevent throwing exception on multi-threaded environment where two
concurrent threads can change state between these lines:
```
if (size() >= maximumCapacity) return false;
super.add(o);
```
what causes mentioned exception.