### PR TITLE
Support closures when validating types in CompatibleFieldSerializer

### DIFF
--- a/src/com/esotericsoftware/kryo/util/Util.java
+++ b/src/com/esotericsoftware/kryo/util/Util.java
@@ -23,6 +23,7 @@ import static com.esotericsoftware.minlog.Log.*;
 
 import com.esotericsoftware.kryo.Serializer;
 import com.esotericsoftware.kryo.SerializerFactory;
+import com.esotericsoftware.kryo.serializers.ClosureSerializer;
 import com.esotericsoftware.kryo.serializers.FieldSerializer;
 import com.esotericsoftware.kryo.util.Generics.GenericType;
 
@@ -232,8 +233,9 @@ public class Util {
 	public static boolean isAssignableTo (Class<?> from, Class<?> to) {
 		if (to == Object.class) return true;
 		if (to.isAssignableFrom(from)) return true;
-		if (from.isPrimitive()) return isPrimitiveWrapperOf(to, from);
 		if (to.isPrimitive()) return isPrimitiveWrapperOf(from, to);
+		if (from.isPrimitive()) return isPrimitiveWrapperOf(to, from);
+		if (from == ClosureSerializer.Closure.class) return to.isInterface();
 		return false;
 	}
 

--- a/src/com/esotericsoftware/kryo/util/Util.java
+++ b/src/com/esotericsoftware/kryo/util/Util.java
@@ -233,8 +233,8 @@ public class Util {
 	public static boolean isAssignableTo (Class<?> from, Class<?> to) {
 		if (to == Object.class) return true;
 		if (to.isAssignableFrom(from)) return true;
-		if (to.isPrimitive()) return isPrimitiveWrapperOf(from, to);
 		if (from.isPrimitive()) return isPrimitiveWrapperOf(to, from);
+		if (to.isPrimitive()) return isPrimitiveWrapperOf(from, to);
 		if (from == ClosureSerializer.Closure.class) return to.isInterface();
 		return false;
 	}


### PR DESCRIPTION
Add check for `Closure` marker class to `Util.isAssignableTo()`.

Resolves #821.