### PR TITLE
Allowing for a delta in floating point comparisons

### DIFF
--- a/test/com/esotericsoftware/kryo/KryoAssert.java
+++ b/test/com/esotericsoftware/kryo/KryoAssert.java
@@ -26,15 +26,18 @@ import static org.junit.jupiter.api.Assertions.*;
  */
 public class KryoAssert {
 
+    static final double EPS_D = 1.E-14;
+    static final float EPS_F = 5.E-7f;
+
     private KryoAssert() {
 
     }
 
     public static void assertDoubleEquals(double expected, double actual) {
-        assertEquals(expected, actual, 0.0);
+        assertEquals(expected, actual, EPS_D);
     }
 
     public static void assertFloatEquals(float expected, double actual) {
-        assertEquals(expected, actual, 0.0);
+        assertEquals(expected, actual, EPS_F);
     }
 }

--- a/test/com/esotericsoftware/kryo/serializers/CompatibleFieldSerializerTest.java
+++ b/test/com/esotericsoftware/kryo/serializers/CompatibleFieldSerializerTest.java
@@ -43,6 +43,8 @@ class CompatibleFieldSerializerTest extends KryoTestCase {
 		supportsCopy = true;
 	}
 
+        static final double EPS = 1.E-14;
+
 	@Test
 	void testCompatibleFieldSerializer () {
 		testCompatibleFieldSerializer(83, false, false);
@@ -264,7 +266,7 @@ class CompatibleFieldSerializerTest extends KryoTestCase {
 		otherKryo.register(ClassWithWrapperAndPrimitive.class, otherSerializer);
 
 		ClassWithWrapperAndPrimitive o = (ClassWithWrapperAndPrimitive) otherKryo.readClassAndObject(input);
-		assertEquals(1L, o.value1, 0);
+		assertEquals(1L, o.value1, EPS);
 		assertEquals(1, o.value2);
 	}
 

--- a/test/com/esotericsoftware/kryo/serializers/CompatibleFieldSerializerTest.java
+++ b/test/com/esotericsoftware/kryo/serializers/CompatibleFieldSerializerTest.java
@@ -43,8 +43,6 @@ class CompatibleFieldSerializerTest extends KryoTestCase {
 		supportsCopy = true;
 	}
 
-        static final double EPS = 1.E-14;
-
 	@Test
 	void testCompatibleFieldSerializer () {
 		testCompatibleFieldSerializer(83, false, false);
@@ -266,7 +264,7 @@ class CompatibleFieldSerializerTest extends KryoTestCase {
 		otherKryo.register(ClassWithWrapperAndPrimitive.class, otherSerializer);
 
 		ClassWithWrapperAndPrimitive o = (ClassWithWrapperAndPrimitive) otherKryo.readClassAndObject(input);
-		assertEquals(1L, o.value1, EPS);
+		assertEquals(1L, o.value1.longValue());
 		assertEquals(1, o.value2);
 	}
 


### PR DESCRIPTION
I got failing tests on my machine and thus had to allow for a tiny delta between float of double numbers.

If I get it well, the comparison in CompatibleFieldSerializerTest.java is between long numbers, so another fix could be to use
        assertEquals(1L, o.value1);
The assertEquals method with 2 arguments can be applied to long numbers. With 3 arguments it is only for float or double (so in the current code, there is an implicit conversion from long to a floating-point type).

Best,
Pierre