### PR TITLE
optimize unnecessary require operation in write_ascii_slow

### DIFF
--- a/benchmarks/src/main/java/com/esotericsoftware/kryo/benchmarks/io/HugeStringBenchmark.java
+++ b/benchmarks/src/main/java/com/esotericsoftware/kryo/benchmarks/io/HugeStringBenchmark.java
@@ -1,0 +1,52 @@
+/* Copyright (c) 2008-2020, Nathan Sweet
+ * All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following
+ * conditions are met:
+ * 
+ * - Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the distribution.
+ * - Neither the name of Esoteric Software nor the names of its contributors may be used to endorse or promote products derived
+ * from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
+ * BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. */
+
+package com.esotericsoftware.kryo.benchmarks.io;
+
+import com.esotericsoftware.kryo.io.Output;
+import org.openjdk.jmh.annotations.*;
+
+
+
+
+/*
+ * this benchmark is used to test serialize huge string when not reuse the buffer
+ * */
+@BenchmarkMode(Mode.SingleShotTime)
+@Measurement(batchSize = 120000)
+public class HugeStringBenchmark {
+	static String hugeString = "";
+	static {
+		for(int i = 0; i < 256; i++){
+			hugeString += "abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789";
+		}
+	}
+	
+	/**
+	 * 1. not reuse the output
+	 * 2. the initial bufferSize will be smaller than hugeString size
+	 * ***/
+	@Benchmark
+	public void writeAsciiHuge (InputOutputState state) {
+		Output output = new Output(1024, 1024 * 512);
+		output.writeAscii(hugeString);
+	}
+	
+}
+￿

--- a/src/com/esotericsoftware/kryo/io/ByteBufferOutput.java
+++ b/src/com/esotericsoftware/kryo/io/ByteBufferOutput.java
@@ -649,7 +649,7 @@ public class ByteBufferOutput extends Output {
 			buffer.put(tmp, 0, charsToWrite);
 			charIndex += charsToWrite;
 			position += charsToWrite;
-			charsToWrite = Math.min(charCount - charIndex, capacity);
+			charsToWrite = Math.min(charCount - charIndex, maxAvailableRequired());
 			if (require(charsToWrite)) buffer = this.byteBuffer;
 		}
 	}


### PR DESCRIPTION
you can see the [discussion](https://groups.google.com/g/kryo-users/c/TjZik6HfQls/m/dESWdK43AgAJ) here
This PR is to reduce the require operation when serialize huge ascii string
You can use  

> mvn -f benchmarks/pom.xml compile exec:java -Dexec.args="-f 4 -wi 5 -i 3 -t 2 -w 2s -r 2 HugeStringBenchmark.writeAsciiHuge"
to test the performance (with and without this optimization), I have show a short result in the discussion