### PR TITLE
avoid flush repeatedly when has finished flushing

### DIFF
--- a/src/com/esotericsoftware/kryo/io/OutputChunked.java
+++ b/src/com/esotericsoftware/kryo/io/OutputChunked.java
@@ -1,15 +1,15 @@
 /* Copyright (c) 2008-2020, Nathan Sweet
  * All rights reserved.
- *
+ * 
  * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following
  * conditions are met:
- *
+ * 
  * - Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
  * - Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
  * disclaimer in the documentation and/or other materials provided with the distribution.
  * - Neither the name of Esoteric Software nor the names of its contributors may be used to endorse or promote products derived
  * from this software without specific prior written permission.
- *
+ * 
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
  * BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
  * SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
@@ -19,102 +19,89 @@
 
 package com.esotericsoftware.kryo.io;
 
+import static com.esotericsoftware.kryo.util.Util.*;
+import static com.esotericsoftware.minlog.Log.*;
+
 import com.esotericsoftware.kryo.KryoException;
 
 import java.io.IOException;
 import java.io.OutputStream;
 
-import static com.esotericsoftware.kryo.util.Util.pos;
-import static com.esotericsoftware.minlog.Log.*;
-
-/**
- * An {@link Output} that writes the length before each flush. The length allows the chunks to be skipped when reading.
- *
- * @author Nathan Sweet
- */
+/** An {@link Output} that writes the length before each flush. The length allows the chunks to be skipped when reading.
+ * @author Nathan Sweet */
 public class OutputChunked extends Output {
-    /**
-     * @see Output#Output()
-     */
-    public OutputChunked() {
-        super();
-    }
+	/** @see Output#Output() */
+	public OutputChunked () {
+		super();
+	}
 
-    /**
-     * @see Output#Output(int)
-     */
-    public OutputChunked(int bufferSize) {
-        super(bufferSize);
-    }
+	/** @see Output#Output(int) */
+	public OutputChunked (int bufferSize) {
+		super(bufferSize);
+	}
 
-    /**
-     * @see Output#Output(OutputStream)
-     */
-    public OutputChunked(OutputStream outputStream) {
-        super(outputStream);
-    }
+	/** @see Output#Output(OutputStream) */
+	public OutputChunked (OutputStream outputStream) {
+		super(outputStream);
+	}
 
-    /**
-     * @see Output#Output(OutputStream, int)
-     */
-    public OutputChunked(OutputStream outputStream, int bufferSize) {
-        super(outputStream, bufferSize);
-    }
+	/** @see Output#Output(OutputStream, int) */
+	public OutputChunked (OutputStream outputStream, int bufferSize) {
+		super(outputStream, bufferSize);
+	}
 
-    public void flush() throws KryoException {
-        if (position() > 0) {
-            try {
-                writeChunkSize();
-                super.flush();
-            } catch (IOException ex) {
-                throw new KryoException(ex);
-            }
-        } else {
-            super.flush();
-        }
-    }
+	public void flush () throws KryoException {
+		if (position() > 0) {
+			try {
+				writeChunkSize();
+				super.flush();
+			} catch (IOException ex) {
+				throw new KryoException(ex);
+			}
+		} else {
+			super.flush();
+		}
+	}
 
-    private void writeChunkSize() throws IOException {
-        int size = position();
-        if (TRACE) trace("kryo", "Write chunk: " + size + pos(size));
-        OutputStream outputStream = getOutputStream();
-        if ((size & ~0x7F) == 0) {
-            outputStream.write(size);
-            return;
-        }
-        outputStream.write((size & 0x7F) | 0x80);
-        size >>>= 7;
-        if ((size & ~0x7F) == 0) {
-            outputStream.write(size);
-            return;
-        }
-        outputStream.write((size & 0x7F) | 0x80);
-        size >>>= 7;
-        if ((size & ~0x7F) == 0) {
-            outputStream.write(size);
-            return;
-        }
-        outputStream.write((size & 0x7F) | 0x80);
-        size >>>= 7;
-        if ((size & ~0x7F) == 0) {
-            outputStream.write(size);
-            return;
-        }
-        outputStream.write((size & 0x7F) | 0x80);
-        size >>>= 7;
-        outputStream.write(size);
-    }
+	private void writeChunkSize () throws IOException {
+		int size = position();
+		if (TRACE) trace("kryo", "Write chunk: " + size + pos(size));
+		OutputStream outputStream = getOutputStream();
+		if ((size & ~0x7F) == 0) {
+			outputStream.write(size);
+			return;
+		}
+		outputStream.write((size & 0x7F) | 0x80);
+		size >>>= 7;
+		if ((size & ~0x7F) == 0) {
+			outputStream.write(size);
+			return;
+		}
+		outputStream.write((size & 0x7F) | 0x80);
+		size >>>= 7;
+		if ((size & ~0x7F) == 0) {
+			outputStream.write(size);
+			return;
+		}
+		outputStream.write((size & 0x7F) | 0x80);
+		size >>>= 7;
+		if ((size & ~0x7F) == 0) {
+			outputStream.write(size);
+			return;
+		}
+		outputStream.write((size & 0x7F) | 0x80);
+		size >>>= 7;
+		outputStream.write(size);
+	}
 
-    /**
-     * Marks the curent written data as the end of a chunk. This chunk can then be skipped when reading.
-     */
-    public void endChunk() {
-        flush();
-        if (TRACE) trace("kryo", "End chunk.");
-        try {
-            getOutputStream().write(0); // Zero length chunk.
-        } catch (IOException ex) {
-            throw new KryoException(ex);
-        }
-    }
+	/** Marks the curent written data as the end of a chunk. This chunk can then be skipped when reading. */
+	public void endChunk () {
+		flush();
+		if (TRACE) trace("kryo", "End chunk.");
+		try {
+			getOutputStream().write(0); // Zero length chunk.
+		} catch (IOException ex) {
+			throw new KryoException(ex);
+		}
+	}
 }

--- a/src/com/esotericsoftware/kryo/io/OutputChunked.java
+++ b/src/com/esotericsoftware/kryo/io/OutputChunked.java
@@ -58,8 +58,9 @@ public class OutputChunked extends Output {
 			} catch (IOException ex) {
 				throw new KryoException(ex);
 			}
+		}else{
+			super.flush();
 		}
-		super.flush();
 	}
 
 	private void writeChunkSize () throws IOException {

--- a/src/com/esotericsoftware/kryo/io/OutputChunked.java
+++ b/src/com/esotericsoftware/kryo/io/OutputChunked.java
@@ -1,15 +1,15 @@
 /* Copyright (c) 2008-2020, Nathan Sweet
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following
  * conditions are met:
- * 
+ *
  * - Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
  * - Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
  * disclaimer in the documentation and/or other materials provided with the distribution.
  * - Neither the name of Esoteric Software nor the names of its contributors may be used to endorse or promote products derived
  * from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
  * BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
  * SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
@@ -19,89 +19,102 @@
 
 package com.esotericsoftware.kryo.io;
 
-import static com.esotericsoftware.kryo.util.Util.*;
-import static com.esotericsoftware.minlog.Log.*;
-
 import com.esotericsoftware.kryo.KryoException;
 
 import java.io.IOException;
 import java.io.OutputStream;
 
-/** An {@link Output} that writes the length before each flush. The length allows the chunks to be skipped when reading.
- * @author Nathan Sweet */
+import static com.esotericsoftware.kryo.util.Util.pos;
+import static com.esotericsoftware.minlog.Log.*;
+
+/**
+ * An {@link Output} that writes the length before each flush. The length allows the chunks to be skipped when reading.
+ *
+ * @author Nathan Sweet
+ */
 public class OutputChunked extends Output {
-	/** @see Output#Output() */
-	public OutputChunked () {
-		super();
-	}
+    /**
+     * @see Output#Output()
+     */
+    public OutputChunked() {
+        super();
+    }
 
-	/** @see Output#Output(int) */
-	public OutputChunked (int bufferSize) {
-		super(bufferSize);
-	}
+    /**
+     * @see Output#Output(int)
+     */
+    public OutputChunked(int bufferSize) {
+        super(bufferSize);
+    }
 
-	/** @see Output#Output(OutputStream) */
-	public OutputChunked (OutputStream outputStream) {
-		super(outputStream);
-	}
+    /**
+     * @see Output#Output(OutputStream)
+     */
+    public OutputChunked(OutputStream outputStream) {
+        super(outputStream);
+    }
 
-	/** @see Output#Output(OutputStream, int) */
-	public OutputChunked (OutputStream outputStream, int bufferSize) {
-		super(outputStream, bufferSize);
-	}
+    /**
+     * @see Output#Output(OutputStream, int)
+     */
+    public OutputChunked(OutputStream outputStream, int bufferSize) {
+        super(outputStream, bufferSize);
+    }
 
-	public void flush () throws KryoException {
-		if (position() > 0) {
-			try {
-				writeChunkSize();
-				super.flush();
-			} catch (IOException ex) {
-				throw new KryoException(ex);
-			}
-		}else{
-			super.flush();
-		}
-	}
+    public void flush() throws KryoException {
+        if (position() > 0) {
+            try {
+                writeChunkSize();
+                super.flush();
+            } catch (IOException ex) {
+                throw new KryoException(ex);
+            }
+        } else {
+            super.flush();
+        }
+    }
 
-	private void writeChunkSize () throws IOException {
-		int size = position();
-		if (TRACE) trace("kryo", "Write chunk: " + size + pos(size));
-		OutputStream outputStream = getOutputStream();
-		if ((size & ~0x7F) == 0) {
-			outputStream.write(size);
-			return;
-		}
-		outputStream.write((size & 0x7F) | 0x80);
-		size >>>= 7;
-		if ((size & ~0x7F) == 0) {
-			outputStream.write(size);
-			return;
-		}
-		outputStream.write((size & 0x7F) | 0x80);
-		size >>>= 7;
-		if ((size & ~0x7F) == 0) {
-			outputStream.write(size);
-			return;
-		}
-		outputStream.write((size & 0x7F) | 0x80);
-		size >>>= 7;
-		if ((size & ~0x7F) == 0) {
-			outputStream.write(size);
-			return;
-		}
-		outputStream.write((size & 0x7F) | 0x80);
-		size >>>= 7;
-		outputStream.write(size);
-	}
+    private void writeChunkSize() throws IOException {
+        int size = position();
+        if (TRACE) trace("kryo", "Write chunk: " + size + pos(size));
+        OutputStream outputStream = getOutputStream();
+        if ((size & ~0x7F) == 0) {
+            outputStream.write(size);
+            return;
+        }
+        outputStream.write((size & 0x7F) | 0x80);
+        size >>>= 7;
+        if ((size & ~0x7F) == 0) {
+            outputStream.write(size);
+            return;
+        }
+        outputStream.write((size & 0x7F) | 0x80);
+        size >>>= 7;
+        if ((size & ~0x7F) == 0) {
+            outputStream.write(size);
+            return;
+        }
+        outputStream.write((size & 0x7F) | 0x80);
+        size >>>= 7;
+        if ((size & ~0x7F) == 0) {
+            outputStream.write(size);
+            return;
+        }
+        outputStream.write((size & 0x7F) | 0x80);
+        size >>>= 7;
+        outputStream.write(size);
+    }
 
-	/** Marks the curent written data as the end of a chunk. This chunk can then be skipped when reading. */
-	public void endChunk () {
-		flush();
-		if (TRACE) trace("kryo", "End chunk.");
-		try {
-			getOutputStream().write(0); // Zero length chunk.
-		} catch (IOException ex) {
-			throw new KryoException(ex);
-		}
-	}
+    /**
+     * Marks the curent written data as the end of a chunk. This chunk can then be skipped when reading.
+     */
+    public void endChunk() {
+        flush();
+        if (TRACE) trace("kryo", "End chunk.");
+        try {
+            getOutputStream().write(0); // Zero length chunk.
+        } catch (IOException ex) {
+            throw new KryoException(ex);
+        }
+    }
 }

--- a/src/com/esotericsoftware/kryo/io/OutputChunked.java
+++ b/src/com/esotericsoftware/kryo/io/OutputChunked.java
@@ -94,7 +94,7 @@ public class OutputChunked extends Output {
 		outputStream.write(size);
 	}
 
-	/** Marks the curent written data as the end of a chunk. This chunk can then be skipped when reading. */
+	/** Marks the current written data as the end of a chunk. This chunk can then be skipped when reading. */
 	public void endChunk () {
 		flush();
 		if (TRACE) trace("kryo", "End chunk.");


### PR DESCRIPTION
Modify content： avoid flush repeatedly when has finished flushing.  
After my testing ,this modification can save cpu usage in high concurrency service.