### PR TITLE
#847 Ensure that `RecordSerializer` can deal with subtypes

### DIFF
--- a/test-jdk14/com/esotericsoftware/kryo/TestDataJava14.java
+++ b/test-jdk14/com/esotericsoftware/kryo/TestDataJava14.java
@@ -26,11 +26,11 @@ import com.esotericsoftware.kryo.SerializationCompatTestData;
  * @author Chris Hegarty <chris.hegarty@oracle.com>
  */
 public class TestDataJava14 extends SerializationCompatTestData.TestData {
-    public record Rec (byte b, short s, int i, long l, float f, double d, boolean bool, char c, String str, Number[] n) { };
+    public record Rec (byte b, short s, int i, long l, float f, double d, boolean bool, char c, String str, Integer[] n) { };
 
     private Rec rec;
 
     public TestDataJava14() {
-        rec = new Rec("b".getBytes()[0], (short)1, 2, 3L, 4.0f, 5.0d, true, 'c', "foo", new Number[]{1,2,3});
+        rec = new Rec("b".getBytes()[0], (short)1, 2, 3L, 4.0f, 5.0d, true, 'c', "foo", new Integer[]{1,2,3});
     }
 }

--- a/test-jdk14/com/esotericsoftware/kryo/serializers/RecordSerializerTest.java
+++ b/test-jdk14/com/esotericsoftware/kryo/serializers/RecordSerializerTest.java
@@ -19,7 +19,7 @@
 
 package com.esotericsoftware.kryo.serializers;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 import com.esotericsoftware.kryo.KryoException;
 import com.esotericsoftware.kryo.KryoTestCase;
@@ -301,4 +301,21 @@ public class RecordSerializerTest extends KryoTestCase {
 
         roundTrip(6, r2);
     }
+
+    public static record RecordWithSuperType(Number n) {}
+
+    @Test
+    void testRecordWithSuperType() {
+        var rc = new RecordSerializer<RecordWithSuperType>();
+        kryo.register(RecordWithSuperType.class, rc);
+
+        final var r = new RecordWithSuperType(1L);
+        final var output = new Output(32);
+        kryo.writeObject(output, r);
+        final var input = new Input(output.getBuffer(), 0, output.position());
+        final var r2 = kryo.readObject(input, RecordWithSuperType.class);
+
+        roundTrip(3, r2);
+    }
+    
 }


### PR DESCRIPTION
The `RecordSerializer` currently fails to deserialize abstract/non-final component types, because it doesn't include concrete type information in the serialized bytes.

It would be possible to solve this in a backwards-compatible way, but that would force users to opt-in to the the correct behavior. I think we should make an exception in this case, break compatibility, and allow users who already have records serialized with the flawed implementation to selectively enable backwards-compatibility for existing records.

This will have to be documented clearly in the release notes for Kryo 5.2.0.

Resolves #847.