### PR TITLE
#834 Support skipping input chunks after a buffer underflow

### DIFF
--- a/src/com/esotericsoftware/kryo/io/InputChunked.java
+++ b/src/com/esotericsoftware/kryo/io/InputChunked.java
@@ -99,6 +99,7 @@ public class InputChunked extends Input {
 
 	/** Advances the stream to the next chunk. InputChunked will appear to hit the end of the data until this method is called. */
 	public void nextChunk () {
+		position = limit; // Underflow resets the position to 0. Ensure we are at the end of the chunk.
 		if (chunkSize == -1) readChunkSize(); // No current chunk, expect a new chunk.
 		while (chunkSize > 0)
 			skip(chunkSize);

--- a/test/com/esotericsoftware/kryo/io/ChunkedTest.java
+++ b/test/com/esotericsoftware/kryo/io/ChunkedTest.java
@@ -21,6 +21,7 @@ package com.esotericsoftware.kryo.io;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import com.esotericsoftware.kryo.KryoException;
 import org.junit.jupiter.api.Test;
 
 /** @author Nathan Sweet */
@@ -54,6 +55,26 @@ class ChunkedTest {
 		inputChunked.nextChunk(); // skip 4
 		assertEquals(5, inputChunked.readInt());
 		assertEquals(5678, input.readInt());
+		input.close();
+	}
+
+	@Test
+	void testSkipAfterUnderFlow () {
+		Output output = new Output(512);
+		OutputChunked outputChunked = new OutputChunked(output);
+		outputChunked.writeInt(1);
+		outputChunked.endChunk();
+		outputChunked.writeInt(2);
+		outputChunked.endChunk();
+		output.close();
+
+		Input input = new Input(output.getBuffer());
+		InputChunked inputChunked = new InputChunked(input);
+		assertEquals(1, inputChunked.readInt());
+		// trigger buffer underflow
+		assertThrows(KryoException.class, inputChunked::readInt);
+		inputChunked.nextChunk();
+		assertEquals(2, inputChunked.readInt());
 		input.close();
 	}
 }


### PR DESCRIPTION
Buffer underflows set the buffer position to 0 while trying to resize the buffer. This prevents `InputChunked.nextChunk()` from advancing to the next chunk.

This PR ensures that that the buffer is at the final position of the chunk before advancing to the next chunk.

Resolves #834.