### PR TITLE
Add new link to session-compatible-fast-serializer project

### DIFF
--- a/README.md
+++ b/README.md
@@ -1307,6 +1307,7 @@ There are a number of projects using Kryo. A few are listed below. Please submit
 - [Mybatis Redis-Cache](https://github.com/mybatis/redis-cache) (MyBatis Redis Cache adapter)
 - [Apache Dubbo](https://github.com/apache/incubator-dubbo) (high performance, open source RPC framework)
 - [Spring Statemachine](https://spring.io/projects/spring-statemachine) (State machine concepts with Spring)
+- [session-compatible-fast-serializer](https://github.com/alibaba/session-compatible-fast-serializer) (A compatible field serializer with better performance)
 
 ### Scala
 


### PR DESCRIPTION
When using kryo in a large scale distribute systems, we must face the problem that the  same jar with different versions.If using the built-in CompatibleFieldSerializer will get a bad performance. So we want to improve the performance.This is the JMH(Java MicroBenchmark result): 
```
Benchmark                                                      Mode  Cnt        Score                Error  Units
SerializerBenchmark.Kryo_Upstream_Compatible_DiffLayout1.run  thrpt   15   370660.262 ±  2967.346           ops/s
SerializerBenchmark.SCFS_DiffLayout1.run                      thrpt   15  1237834.811 ± 14960.798           ops/s
```
So We want add a link to session-compatible-fast-serializer so that if anyone encounter the same problem ,maybe session-compatible-fast-serializer  is a choice.