### PR TITLE
#882 Catch `LinkageError` when accessing fields via ReflectASM

### DIFF
--- a/src/com/esotericsoftware/kryo/serializers/CachedFields.java
+++ b/src/com/esotericsoftware/kryo/serializers/CachedFields.java
@@ -146,7 +146,7 @@ class CachedFields implements Comparator<CachedField> {
 			try {
 				if (access == null) access = FieldAccess.get(serializer.type);
 				accessIndex = ((FieldAccess)access).getIndex(field);
-			} catch (RuntimeException ex) {
+			} catch (RuntimeException | LinkageError ex) {
 				if (DEBUG) debug("kryo", "Unable to use ReflectASM.", ex);
 			}
 		}


### PR DESCRIPTION
Resolves #882 