### PR TITLE
Improve tests for JDK 17

### DIFF
--- a/README.md
+++ b/README.md
@@ -618,12 +618,11 @@ Kryo `isFinal` is used to determine if a class is final. This method can be over
 
 Kryo can serialize Java 8+ closures that implement java.io.Serializable, with some caveats. Closures serialized on one JVM may fail to be deserialized on a different JVM.
 
-Kryo `isClosure` is used to determine if a class is a closure. If so, then ClosureSerializer.Closure is used to find the class registration instead of the closure's class. To serialize closures, the following classes must be registered: ClosureSerializer.Closure, SerializedLambda, Object[], and Class. Additionally, the closure's capturing class must be registered.
+Kryo `isClosure` is used to determine if a class is a closure. If so, then ClosureSerializer.Closure is used to find the class registration instead of the closure's class. To serialize closures, the following classes must be registered: ClosureSerializer.Closure, Object[], and Class. Additionally, the closure's capturing class must be registered.
 
 ```java
 kryo.register(Object[].class);
 kryo.register(Class.class);
-kryo.register(SerializedLambda.class);
 kryo.register(ClosureSerializer.Closure.class, new ClosureSerializer());
 kryo.register(CapturingClass.class);
 

--- a/pom.xml
+++ b/pom.xml
@@ -436,15 +436,9 @@
 							<configuration>
 									<argLine>
 										--enable-preview
-										--add-opens java.base/java.lang=ALL-UNNAMED
-										--add-opens java.base/java.lang.invoke=ALL-UNNAMED
-										--add-opens java.base/java.net=ALL-UNNAMED
-										--add-opens java.base/java.nio=ALL-UNNAMED
-										--add-opens java.base/java.time=ALL-UNNAMED
-										--add-opens java.base/java.util=ALL-UNNAMED
-										--add-opens java.base/java.util.concurrent.atomic=ALL-UNNAMED
 										--add-opens java.base/sun.nio.ch=ALL-UNNAMED
-										--add-opens java.base/sun.util.calendar=ALL-UNNAMED
+										--add-opens java.base/java.nio=ALL-UNNAMED
+										--add-opens java.base/java.util.concurrent.atomic=ALL-UNNAMED
 									</argLine>
 							</configuration>
 						</plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -438,13 +438,13 @@
 										--enable-preview
 										--add-opens java.base/java.lang=ALL-UNNAMED
 										--add-opens java.base/java.lang.invoke=ALL-UNNAMED
-										--add-opens=java.base/java.net=ALL-UNNAMED
-										--add-opens=java.base/java.nio=ALL-UNNAMED
-										--add-opens=java.base/java.time=ALL-UNNAMED
-										--add-opens=java.base/java.util=ALL-UNNAMED
+										--add-opens java.base/java.net=ALL-UNNAMED
+										--add-opens java.base/java.nio=ALL-UNNAMED
+										--add-opens java.base/java.time=ALL-UNNAMED
+										--add-opens java.base/java.util=ALL-UNNAMED
 										--add-opens java.base/java.util.concurrent.atomic=ALL-UNNAMED
-										--add-opens=java.base/sun.nio.ch=ALL-UNNAMED
-										--add-opens=java.base/sun.util.calendar=ALL-UNNAMED
+										--add-opens java.base/sun.nio.ch=ALL-UNNAMED
+										--add-opens java.base/sun.util.calendar=ALL-UNNAMED
 									</argLine>
 							</configuration>
 						</plugin>

--- a/src/com/esotericsoftware/kryo/serializers/ClosureSerializer.java
+++ b/src/com/esotericsoftware/kryo/serializers/ClosureSerializer.java
@@ -37,7 +37,6 @@ import java.lang.reflect.Method;
  * <p>
  * <code>kryo.register(Object[].class);
  * kryo.register(Class.class);
- * kryo.register(java.lang.invoke.SerializedLambda.class);<br>
  * kryo.register(ClosureSerializer.Closure.class, new ClosureSerializer());</code>
  * <p>
  * Also, the closure's capturing class must be registered.

--- a/src/com/esotericsoftware/kryo/serializers/ClosureSerializer.java
+++ b/src/com/esotericsoftware/kryo/serializers/ClosureSerializer.java
@@ -27,6 +27,7 @@ import com.esotericsoftware.kryo.Registration;
 import com.esotericsoftware.kryo.Serializer;
 import com.esotericsoftware.kryo.io.Input;
 import com.esotericsoftware.kryo.io.Output;
+import com.esotericsoftware.minlog.Log;
 
 import java.io.Serializable;
 import java.lang.invoke.SerializedLambda;
@@ -56,7 +57,9 @@ public class ClosureSerializer extends Serializer {
 				readResolve = SerializedLambda.class.getDeclaredMethod("readResolve");
 				readResolve.setAccessible(true);
 			} catch (Exception ex) {
-				throw new KryoException("Unable to obtain SerializedLambda#readResolve via reflection.", ex);
+				readResolve = null;
+				Log.warn("Unable to obtain SerializedLambda#readResolve via reflection. " +
+					"Falling back on resolving lambdas via capturing class.", ex);
 			}
 		}
 	}
@@ -87,11 +90,12 @@ public class ClosureSerializer extends Serializer {
 		Object[] capturedArgs = new Object[count];
 		for (int i = 0; i < count; i++)
 			capturedArgs[i] = kryo.readClassAndObject(input);
-		SerializedLambda serializedLambda = new SerializedLambda(kryo.readClass(input).getType(), input.readString(),
+		Class<?> capturingClass = kryo.readClass(input).getType();
+		SerializedLambda serializedLambda = new SerializedLambda(capturingClass, input.readString(),
 			input.readString(), input.readString(), input.readVarInt(true), input.readString(), input.readString(),
 			input.readString(), input.readString(), capturedArgs);
 		try {
-			return readResolve.invoke(serializedLambda);
+			return readResolve(capturingClass, serializedLambda);
 		} catch (Exception ex) {
 			throw new KryoException("Error reading closure.", ex);
 		}
@@ -99,10 +103,23 @@ public class ClosureSerializer extends Serializer {
 
 	public Object copy (Kryo kryo, Object original) {
 		try {
-			return readResolve.invoke(toSerializedLambda(original));
+			SerializedLambda lambda = toSerializedLambda(original);
+			Class<?> capturingClass = Class.forName(lambda.getCapturingClass().replace('/', '.'));
+			return readResolve(capturingClass, lambda);
 		} catch (Exception ex) {
 			throw new KryoException("Error copying closure.", ex);
 		}
+	}
+
+	private Object readResolve (Class<?> capturingClass, SerializedLambda lambda) throws Exception {
+		if (readResolve != null) {
+			return readResolve.invoke(lambda);
+		}
+
+		// See SerializedLambda#readResolve
+		Method m = capturingClass.getDeclaredMethod("$deserializeLambda$", SerializedLambda.class);
+		m.setAccessible(true);
+		return m.invoke(null, lambda);
 	}
 
 	private SerializedLambda toSerializedLambda (Object object) {
@@ -118,9 +135,7 @@ public class ClosureSerializer extends Serializer {
 		try {
 			return (SerializedLambda)replacement;
 		} catch (Exception ex) {
-			throw new KryoException(
-				"writeReplace must return a SerializedLambda: " + (replacement == null ? null : className(replacement.getClass())),
-				ex);
+			throw new KryoException("writeReplace must return a SerializedLambda: " + className(replacement.getClass()), ex);
 		}
 	}
 }

--- a/src/com/esotericsoftware/kryo/util/Util.java
+++ b/src/com/esotericsoftware/kryo/util/Util.java
@@ -68,6 +68,10 @@ public class Util {
 		primitiveWrappers.put(short.class, Short.class);
 	}
 
+	public static boolean isUnsafeAvailable () {
+		return unsafe;
+	}
+
 	public static boolean isClassAvailable (String className) {
 		try {
 			Class.forName(className);

--- a/test-jdk11/com/esotericsoftware/kryo/serializers/ImmutableCollectionsSerializersTest.java
+++ b/test-jdk11/com/esotericsoftware/kryo/serializers/ImmutableCollectionsSerializersTest.java
@@ -82,7 +82,7 @@ class ImmutableCollectionsSerializersTest extends KryoTestCase {
 		roundTrip(6, Set.of(1, 2, 3));
 	}
 
-	static class TestClass {
+	public static class TestClass {
 		List<Integer> list;
 		Map<Integer, Integer> map;
 		Set<Integer> set;

--- a/test-jdk14/com/esotericsoftware/kryo/TestDataJava14.java
+++ b/test-jdk14/com/esotericsoftware/kryo/TestDataJava14.java
@@ -19,14 +19,24 @@
 
 package com.esotericsoftware.kryo;
 
-import com.esotericsoftware.kryo.SerializationCompatTestData;
+import org.apache.commons.lang.builder.EqualsBuilder;
+import org.apache.commons.lang.builder.HashCodeBuilder;
 
 /** Test data for {@link com.esotericsoftware.kryo.serializers.RecordSerializerTest}.
  * @author Julia Boes <julia.boes@oracle.com>
  * @author Chris Hegarty <chris.hegarty@oracle.com>
  */
 public class TestDataJava14 extends SerializationCompatTestData.TestData {
-    public record Rec (byte b, short s, int i, long l, float f, double d, boolean bool, char c, String str, Integer[] n) { };
+    public record Rec (byte b, short s, int i, long l, float f, double d, boolean bool, char c, String str, Integer[] n) {
+        // Overriden because of https://stackoverflow.com/questions/61261226/java-14-records-and-arrays
+        public boolean equals(Object o) {
+            return EqualsBuilder.reflectionEquals(this, o);
+        }
+
+        public int hashCode() {
+            return HashCodeBuilder.reflectionHashCode(this);
+        }
+    };
 
     private Rec rec;
 

--- a/test/com/esotericsoftware/kryo/KryoTestCase.java
+++ b/test/com/esotericsoftware/kryo/KryoTestCase.java
@@ -30,6 +30,7 @@ import com.esotericsoftware.kryo.unsafe.UnsafeByteBufferInput;
 import com.esotericsoftware.kryo.unsafe.UnsafeByteBufferOutput;
 import com.esotericsoftware.kryo.unsafe.UnsafeInput;
 import com.esotericsoftware.kryo.unsafe.UnsafeOutput;
+import com.esotericsoftware.kryo.util.Util;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -139,50 +140,54 @@ public abstract class KryoTestCase {
 			}
 		});
 
-		roundTripWithBufferFactory(length, object1, new BufferFactory() {
-			public Output createOutput (OutputStream os) {
-				return new UnsafeOutput(os);
-			}
+		if (Util.isUnsafeAvailable()) {
+			roundTripWithBufferFactory(length, object1, new BufferFactory() {
+				public Output createOutput(OutputStream os) {
+					return new UnsafeOutput(os);
+				}
 
-			public Output createOutput (OutputStream os, int size) {
-				return new UnsafeOutput(os, size);
-			}
+				public Output createOutput(OutputStream os, int size) {
+					return new UnsafeOutput(os, size);
+				}
 
-			public Output createOutput (int size, int limit) {
-				return new UnsafeOutput(size, limit);
-			}
+				public Output createOutput(int size, int limit) {
+					return new UnsafeOutput(size, limit);
+				}
 
-			public Input createInput (InputStream os, int size) {
-				return new UnsafeInput(os, size);
-			}
+				public Input createInput(InputStream os, int size) {
+					return new UnsafeInput(os, size);
+				}
 
-			public Input createInput (byte[] buffer) {
-				return new UnsafeInput(buffer);
-			}
-		});
+				public Input createInput(byte[] buffer) {
+					return new UnsafeInput(buffer);
+				}
+			});
+		}
 
-		roundTripWithBufferFactory(length, object1, new BufferFactory() {
-			public Output createOutput (OutputStream os) {
-				return new UnsafeByteBufferOutput(os);
-			}
+		if (Util.isUnsafeAvailable()) {
+			roundTripWithBufferFactory(length, object1, new BufferFactory() {
+				public Output createOutput(OutputStream os) {
+					return new UnsafeByteBufferOutput(os);
+				}
 
-			public Output createOutput (OutputStream os, int size) {
-				return new UnsafeByteBufferOutput(os, size);
-			}
+				public Output createOutput(OutputStream os, int size) {
+					return new UnsafeByteBufferOutput(os, size);
+				}
 
-			public Output createOutput (int size, int limit) {
-				return new UnsafeByteBufferOutput(size, limit);
-			}
+				public Output createOutput(int size, int limit) {
+					return new UnsafeByteBufferOutput(size, limit);
+				}
 
-			public Input createInput (InputStream os, int size) {
-				return new UnsafeByteBufferInput(os, size);
-			}
+				public Input createInput(InputStream os, int size) {
+					return new UnsafeByteBufferInput(os, size);
+				}
 
-			public Input createInput (byte[] buffer) {
-				ByteBuffer byteBuffer = allocateByteBuffer(buffer);
-				return new UnsafeByteBufferInput(byteBuffer.asReadOnlyBuffer());
-			}
-		});
+				public Input createInput(byte[] buffer) {
+					ByteBuffer byteBuffer = allocateByteBuffer(buffer);
+					return new UnsafeByteBufferInput(byteBuffer.asReadOnlyBuffer());
+				}
+			});
+		}
 
 		return object2;
 	}

--- a/test/com/esotericsoftware/kryo/ReferenceTest.java
+++ b/test/com/esotericsoftware/kryo/ReferenceTest.java
@@ -25,9 +25,9 @@ import com.esotericsoftware.kryo.io.Input;
 import com.esotericsoftware.kryo.io.Output;
 import com.esotericsoftware.kryo.serializers.MapSerializer;
 
-import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.TreeMap;
 
 import org.junit.jupiter.api.Test;
@@ -89,19 +89,13 @@ class ReferenceTest extends KryoTestCase {
 		list.add("2");
 		list.add("1");
 		list.add("1");
-		List subList = list.subList(0, 5);
+		ArrayListHolder subList = new ArrayListHolder(list);
 
 		kryo.setRegistrationRequired(false);
 		kryo.register(ArrayList.class);
-		Class<List> subListClass = (Class<List>)subList.getClass();
-		if (subListClass.getName().equals("java.util.ArrayList$SubList")) {
-			// This is JDK > = 1.7
-			kryo.register(subList.getClass(), new ArraySubListSerializer());
-		} else {
-			kryo.register(subList.getClass(), new SubListSerializer());
+		kryo.register(ArrayListHolder.class);
 
-		}
-		roundTrip(23, subList);
+		roundTrip(15, subList);
 	}
 
 	@Test
@@ -118,86 +112,25 @@ class ReferenceTest extends KryoTestCase {
 		fail("Exception was expected");
 	}
 
-	public static class SubListSerializer extends Serializer<List> {
-		private Field listField, offsetField, sizeField;
+	public static class ArrayListHolder {
+		private List<Object> parent;
 
-		public SubListSerializer () {
-			try {
-				Class sublistClass = Class.forName("java.util.SubList");
-				listField = sublistClass.getDeclaredField("l");
-				offsetField = sublistClass.getDeclaredField("offset");
-				sizeField = sublistClass.getDeclaredField("size");
-				listField.setAccessible(true);
-				offsetField.setAccessible(true);
-				sizeField.setAccessible(true);
-			} catch (Exception ex) {
-				throw new RuntimeException(ex);
-			}
+		public ArrayListHolder () {
 		}
 
-		public void write (Kryo kryo, Output output, List list) {
-			try {
-				kryo.writeClassAndObject(output, listField.get(list));
-				int fromIndex = offsetField.getInt(list);
-				int count = sizeField.getInt(list);
-				output.writeInt(fromIndex);
-				output.writeInt(count);
-			} catch (Exception ex) {
-				throw new RuntimeException(ex);
-			}
+		public ArrayListHolder (List<Object> parent) {
+			this.parent = parent;
 		}
 
-		public List read (Kryo kryo, Input input, Class<? extends List> type) {
-			List list = (List)kryo.readClassAndObject(input);
-			int fromIndex = input.readInt();
-			int count = input.readInt();
-			return list.subList(fromIndex, fromIndex + count);
-		}
-	}
-
-	public static class ArraySubListSerializer extends Serializer<List> {
-		private Field parentField, offsetField, sizeField;
-
-		public ArraySubListSerializer () {
-			try {
-				Class sublistClass = Class.forName("java.util.ArrayList$SubList");
-				parentField = getParentField(sublistClass);
-				offsetField = sublistClass.getDeclaredField("offset");
-				sizeField = sublistClass.getDeclaredField("size");
-				parentField.setAccessible(true);
-				offsetField.setAccessible(true);
-				sizeField.setAccessible(true);
-			} catch (Exception ex) {
-				throw new RuntimeException(ex);
-			}
+		public boolean equals (Object o) {
+			if (this == o) return true;
+			if (o == null || getClass() != o.getClass()) return false;
+			ArrayListHolder that = (ArrayListHolder)o;
+			return Objects.equals(parent, that.parent);
 		}
 
-		private Field getParentField(Class sublistClass) throws NoSuchFieldException {
-			try {
-				// java 9+
-				return sublistClass.getDeclaredField("root");
-			} catch(NoSuchFieldException e) {
-				return sublistClass.getDeclaredField("parent");
-			}
-		}
-
-		public void write (Kryo kryo, Output output, List list) {
-			try {
-				kryo.writeClassAndObject(output, parentField.get(list));
-				int offset = offsetField.getInt(list);
-				int size = sizeField.getInt(list);
-				output.writeInt(offset);
-				output.writeInt(size);
-			} catch (Exception ex) {
-				throw new RuntimeException(ex);
-			}
-		}
-
-		public List read (Kryo kryo, Input input, Class<? extends List> type) {
-			List list = (List)kryo.readClassAndObject(input);
-			int offset = input.readInt();
-			int size = input.readInt();
-			return list.subList(offset, offset + size);
+		public int hashCode () {
+			return Objects.hash(parent);
 		}
 	}
 }

--- a/test/com/esotericsoftware/kryo/ReflectionAssert.java
+++ b/test/com/esotericsoftware/kryo/ReflectionAssert.java
@@ -194,8 +194,8 @@ class ReflectionAssert {
 	private static void assertEqualDeclaredFields (final Class<? extends Object> clazz, final Object one, final Object another,
 												   final boolean requireMatchingClasses, final Map<Object, Object> alreadyChecked, final String path) {
 		for (final Field field : clazz.getDeclaredFields()) {
-			field.setAccessible(true);
-			if (!Modifier.isTransient(field.getModifiers())) {
+			if (!Modifier.isTransient(field.getModifiers()) && !Modifier.isStatic(field.getModifiers()) && !field.isSynthetic()) {
+				field.setAccessible(true);
 				try {
 					assertReflectionEquals(field.get(one), field.get(another), requireMatchingClasses, alreadyChecked,
 						path + "." + field.getName());

--- a/test/com/esotericsoftware/kryo/SerializationBenchmarkTest.java
+++ b/test/com/esotericsoftware/kryo/SerializationBenchmarkTest.java
@@ -109,6 +109,7 @@ class SerializationBenchmarkTest extends KryoTestCase {
 	}
 
 	@Test
+	@Unsafe
 	void testUnsafeOutput () throws Exception {
 		UnsafeOutput output = new UnsafeOutput(OUTPUT_BUFFER_SIZE);
 		UnsafeInput input = new UnsafeInput(output.getBuffer());
@@ -117,6 +118,7 @@ class SerializationBenchmarkTest extends KryoTestCase {
 	}
 
 	@Test
+	@Unsafe
 	void testUnsafeOutputFixed () throws Exception {
 		UnsafeOutput output = new UnsafeOutput(OUTPUT_BUFFER_SIZE);
 		UnsafeInput input = new UnsafeInput(output.getBuffer());
@@ -127,6 +129,7 @@ class SerializationBenchmarkTest extends KryoTestCase {
 	}
 
 	@Test
+	@Unsafe
 	void testUnsafeByteBufferOutput () throws Exception {
 		UnsafeByteBufferOutput output = new UnsafeByteBufferOutput(OUTPUT_BUFFER_SIZE);
 		UnsafeByteBufferInput input = new UnsafeByteBufferInput(output.getByteBuffer());
@@ -135,6 +138,7 @@ class SerializationBenchmarkTest extends KryoTestCase {
 	}
 
 	@Test
+	@Unsafe
 	void testUnsafeByteBufferOutputFixed () throws Exception {
 		UnsafeByteBufferOutput output = new UnsafeByteBufferOutput(OUTPUT_BUFFER_SIZE);
 		UnsafeByteBufferInput input = new UnsafeByteBufferInput(output.getByteBuffer());
@@ -198,7 +202,7 @@ class SerializationBenchmarkTest extends KryoTestCase {
 		Log.WARN();
 	}
 
-	private static class SampleObject implements Externalizable, KryoSerializable {
+	public static class SampleObject implements Externalizable, KryoSerializable {
 		private int intValue;
 		public float floatValue;
 		protected Short shortValue;

--- a/test/com/esotericsoftware/kryo/SerializationCompatTestData.java
+++ b/test/com/esotericsoftware/kryo/SerializationCompatTestData.java
@@ -277,14 +277,6 @@ class SerializationCompatTestData {
 			_public = new PublicClass(new PrivateClass("foo"));
 		}
 
-		public int hashCode () {
-			return HashCodeBuilder.reflectionHashCode(this);
-		}
-
-		public boolean equals (Object obj) {
-			return EqualsBuilder.reflectionEquals(this, obj);
-		}
-
 	}
 
 	static class Generic<T> {

--- a/test/com/esotericsoftware/kryo/Unsafe.java
+++ b/test/com/esotericsoftware/kryo/Unsafe.java
@@ -1,0 +1,34 @@
+/* Copyright (c) 2008-2022, Nathan Sweet
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following
+ * conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the distribution.
+ * - Neither the name of Esoteric Software nor the names of its contributors may be used to endorse or promote products derived
+ * from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
+ * BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. */
+
+package com.esotericsoftware.kryo;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.junit.jupiter.api.condition.EnabledIf;
+
+/** Conditional annotation that runs a test only if Unsafe is available */
+@Target(value = {ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@EnabledIf("com.esotericsoftware.kryo.util.Util#isUnsafeAvailable")
+public @interface Unsafe {
+}

--- a/test/com/esotericsoftware/kryo/io/UnsafeByteBufferInputOutputTest.java
+++ b/test/com/esotericsoftware/kryo/io/UnsafeByteBufferInputOutputTest.java
@@ -22,6 +22,7 @@ package com.esotericsoftware.kryo.io;
 import static com.esotericsoftware.kryo.KryoAssert.*;
 import static org.junit.jupiter.api.Assertions.*;
 
+import com.esotericsoftware.kryo.Unsafe;
 import com.esotericsoftware.kryo.unsafe.UnsafeByteBufferInput;
 import com.esotericsoftware.kryo.unsafe.UnsafeByteBufferOutput;
 import com.esotericsoftware.kryo.unsafe.UnsafeUtil;
@@ -33,6 +34,7 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 
 /** @author Roman Levenstein <romixlev@gmail.com> */
+@Unsafe
 @SuppressWarnings("restriction")
 class UnsafeByteBufferInputOutputTest {
 

--- a/test/com/esotericsoftware/kryo/io/UnsafeInputOutputTest.java
+++ b/test/com/esotericsoftware/kryo/io/UnsafeInputOutputTest.java
@@ -22,6 +22,7 @@ package com.esotericsoftware.kryo.io;
 import static com.esotericsoftware.kryo.KryoAssert.*;
 import static org.junit.jupiter.api.Assertions.*;
 
+import com.esotericsoftware.kryo.Unsafe;
 import com.esotericsoftware.kryo.unsafe.UnsafeInput;
 import com.esotericsoftware.kryo.unsafe.UnsafeOutput;
 
@@ -32,6 +33,7 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 
 /** @author Nathan Sweet <misc@n4te.com> */
+@Unsafe
 class UnsafeInputOutputTest {
 	@Test
 	void testOutputStream () {

--- a/test/com/esotericsoftware/kryo/serializers/ClosureSerializerTest.java
+++ b/test/com/esotericsoftware/kryo/serializers/ClosureSerializerTest.java
@@ -25,7 +25,6 @@ import com.esotericsoftware.kryo.KryoTestCase;
 import com.esotericsoftware.kryo.io.Input;
 import com.esotericsoftware.kryo.io.Output;
 
-import java.lang.invoke.SerializedLambda;
 import java.util.concurrent.Callable;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -40,7 +39,6 @@ class ClosureSerializerTest extends KryoTestCase {
 		kryo.register(Object[].class);
 		kryo.register(Class.class);
 		kryo.register(getClass()); // The closure's capturing class must be registered.
-		kryo.register(SerializedLambda.class);
 		kryo.register(ClosureSerializer.Closure.class, new ClosureSerializer());
 	}
 
@@ -56,6 +54,15 @@ class ClosureSerializerTest extends KryoTestCase {
 
 		Input input = new Input(output.getBuffer(), 0, output.position());
 		Callable<Integer> closure2 = (Callable<Integer>)kryo.readObject(input, ClosureSerializer.Closure.class);
+
+		doAssertEquals(closure1, closure2);
+	}
+
+	@Test
+	void testCopyClosure() {
+		Callable<Integer> closure1 = (Callable<Integer> & java.io.Serializable)( () -> 72363);
+
+		final Callable<Integer> closure2 = kryo.copy(closure1);
 
 		doAssertEquals(closure1, closure2);
 	}

--- a/test/com/esotericsoftware/kryo/serializers/CompatibleFieldSerializerTest.java
+++ b/test/com/esotericsoftware/kryo/serializers/CompatibleFieldSerializerTest.java
@@ -29,7 +29,6 @@ import com.esotericsoftware.kryo.io.Input;
 import com.esotericsoftware.kryo.io.Output;
 
 import java.io.Serializable;
-import java.lang.invoke.SerializedLambda;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
@@ -499,7 +498,6 @@ class CompatibleFieldSerializerTest extends KryoTestCase {
 		CompatibleFieldSerializer.CompatibleFieldSerializerConfig config = new CompatibleFieldSerializer.CompatibleFieldSerializerConfig();
 		kryo.setDefaultSerializer(new CompatibleFieldSerializerFactory(config));
 		kryo.register(ClassWithLambdaField.class);
-		kryo.register(SerializedLambda.class);
 		kryo.register(ClosureSerializer.Closure.class, new ClosureSerializer());
 
 		roundTrip(236, new ClassWithLambdaField());

--- a/test/com/esotericsoftware/kryo/serializers/FieldSerializerTest.java
+++ b/test/com/esotericsoftware/kryo/serializers/FieldSerializerTest.java
@@ -38,6 +38,7 @@ import com.esotericsoftware.kryo.serializers.FieldSerializer.Bind;
 import com.esotericsoftware.kryo.serializers.FieldSerializer.NotNull;
 import com.esotericsoftware.kryo.serializers.FieldSerializer.Optional;
 import com.esotericsoftware.kryo.serializers.MapSerializer.BindMap;
+import com.esotericsoftware.kryo.util.Util;
 
 import java.io.ByteArrayOutputStream;
 import java.util.ArrayList;
@@ -402,7 +403,7 @@ class FieldSerializerTest extends KryoTestCase {
 
 		kryo.register(HasPrivateConstructor.class);
 		roundTrip(4, test);
-		assertEquals(20, HasPrivateConstructor.invocations, "Wrong number of constructor invocations");
+		assertEquals(Util.isUnsafeAvailable() ? 20 : 10, HasPrivateConstructor.invocations, "Wrong number of constructor invocations");
 	}
 
 	/** This test uses StdInstantiatorStrategy and should bypass invocation of no-arg constructor, even if it is provided. **/

--- a/test/com/esotericsoftware/kryo/serializers/GenericsTest.java
+++ b/test/com/esotericsoftware/kryo/serializers/GenericsTest.java
@@ -186,11 +186,11 @@ class GenericsTest extends KryoTestCase {
 		roundTrip(168, o);
 	}
 
-	private interface Holder<V> {
+	interface Holder<V> {
 		V getValue ();
 	}
 
-	private abstract static class AbstractValueHolder<V> implements Holder<V> {
+	abstract static class AbstractValueHolder<V> implements Holder<V> {
 		private final V value;
 
 		AbstractValueHolder (V value) {
@@ -210,13 +210,13 @@ class GenericsTest extends KryoTestCase {
 		}
 	}
 
-	private abstract static class AbstractValueListHolder<V> extends AbstractValueHolder<List<V>> {
+	abstract static class AbstractValueListHolder<V> extends AbstractValueHolder<List<V>> {
 		AbstractValueListHolder (List<V> value) {
 			super(value);
 		}
 	}
 
-	private static class LongHolder extends AbstractValueHolder<Long> {
+	static class LongHolder extends AbstractValueHolder<Long> {
 		/** Kryo Constructor */
 		LongHolder () {
 			super(null);
@@ -227,7 +227,7 @@ class GenericsTest extends KryoTestCase {
 		}
 	}
 
-	private static class LongListHolder extends AbstractValueListHolder<Long> {
+	static class LongListHolder extends AbstractValueListHolder<Long> {
 		/** Kryo Constructor */
 		LongListHolder () {
 			super(null);
@@ -272,7 +272,7 @@ class GenericsTest extends KryoTestCase {
 	}
 
 	// A simple serializable class.
-	private static class SerializableObjectFoo implements Serializable {
+	public static class SerializableObjectFoo implements Serializable {
 		String name;
 
 		SerializableObjectFoo (String name) {
@@ -295,18 +295,18 @@ class GenericsTest extends KryoTestCase {
 		}
 	}
 
-	private static class BaseGeneric<T extends Serializable> {
+	static class BaseGeneric<T extends Serializable> {
 		// The type of this field cannot be derived from the context.
 		// Therefore, Kryo should consider it to be Object.
 		private final List<T> listPayload;
 
 		/** Kryo Constructor */
-		protected BaseGeneric () {
+		BaseGeneric () {
 			super();
 			this.listPayload = null;
 		}
 
-		protected BaseGeneric (final List<T> listPayload) {
+		BaseGeneric (final List<T> listPayload) {
 			super();
 			// Defensive copy, listPayload is mutable
 			this.listPayload = new ArrayList(listPayload);
@@ -330,7 +330,7 @@ class GenericsTest extends KryoTestCase {
 	}
 
 	// This is a non-generic class with a generic superclass.
-	private static class ConcreteClass2 extends BaseGeneric<SerializableObjectFoo> {
+	static class ConcreteClass2 extends BaseGeneric<SerializableObjectFoo> {
 		/** Kryo Constructor */
 		ConcreteClass2 () {
 			super();
@@ -341,7 +341,7 @@ class GenericsTest extends KryoTestCase {
 		}
 	}
 
-	private static class ConcreteClass1 extends ConcreteClass2 {
+	static class ConcreteClass1 extends ConcreteClass2 {
 		/** Kryo Constructor */
 		ConcreteClass1 () {
 			super();
@@ -352,7 +352,7 @@ class GenericsTest extends KryoTestCase {
 		}
 	}
 
-	private static class ConcreteClass extends ConcreteClass1 {
+	static class ConcreteClass extends ConcreteClass1 {
 		/** Kryo Constructor */
 		ConcreteClass () {
 			super();
@@ -363,7 +363,7 @@ class GenericsTest extends KryoTestCase {
 		}
 	}
 
-	public static class SuperGenerics {
+	static class SuperGenerics {
 		public static class RootSuper<RS> {
 			public ValueSuper<RS> rootSuperField;
 
@@ -396,7 +396,7 @@ class GenericsTest extends KryoTestCase {
 		}
 	}
 
-	public static class ClassWithMap {
+	static class ClassWithMap {
 		public final Map<MapKey, Set<String>> values = new HashMap();
 
 		public boolean equals (Object obj) {
@@ -419,7 +419,7 @@ class GenericsTest extends KryoTestCase {
 		}
 	}
 
-	public static class A<X> {
+	static class A<X> {
 		public static class B<Y> extends A {
 		}
 

--- a/test/com/esotericsoftware/kryo/serializers/OptionalSerializersTest.java
+++ b/test/com/esotericsoftware/kryo/serializers/OptionalSerializersTest.java
@@ -75,7 +75,7 @@ class OptionalSerializersTest extends KryoTestCase {
 		roundTrip(10, OptionalDouble.of(Double.MAX_VALUE));
 	}
 
-	static class TestClass {
+	public static class TestClass {
 		Optional<String> maybe;
 
 		public TestClass () {


### PR DESCRIPTION
This PR attempts to fix as many tests as possible when running under JDK17 without any `add-opens` arguments.

Most tests work without opening up modules now. Only one tests still fails:

- `SerializationCompatTest` fails because of `AtomicInteger`. 

We need custom serializers for `Atomic*` JDK classes to fix this.