### PR TITLE
#889 Serializer for java.sql.Timestamp which preserves nanoseconds

### DIFF
--- a/src/com/esotericsoftware/kryo/serializers/DefaultSerializers.java
+++ b/src/com/esotericsoftware/kryo/serializers/DefaultSerializers.java
@@ -346,6 +346,32 @@ public class DefaultSerializers {
 		}
 	}
 
+	/** Serializer for {@link Timestamp} which preserves the nanoseconds field. */
+	public static class TimestampSerializer extends Serializer<Timestamp> {
+		public void write (Kryo kryo, Output output, Timestamp object) {
+			output.writeVarLong(integralTimeComponent(object), true);
+			output.writeVarInt(object.getNanos(), true);
+		}
+
+		public Timestamp read (Kryo kryo, Input input, Class<? extends Timestamp> type) {
+			return create(input.readVarLong(true), input.readVarInt(true));
+		}
+
+		public Timestamp copy (Kryo kryo, Timestamp original) {
+			return create(integralTimeComponent(original), original.getNanos());
+		}
+
+		private long integralTimeComponent (Timestamp object) {
+			return object.getTime() - (object.getNanos() / 1_000_000);
+		}
+
+		private Timestamp create (long time, int nanos) {
+			Timestamp t = new Timestamp(time);
+			t.setNanos(nanos);
+			return t;
+		}
+	}
+
 	public static class EnumSerializer extends ImmutableSerializer<Enum> {
 		{
 			setAcceptsNull(true);

--- a/test/com/esotericsoftware/kryo/serializers/DefaultSerializersTest.java
+++ b/test/com/esotericsoftware/kryo/serializers/DefaultSerializersTest.java
@@ -225,6 +225,28 @@ class DefaultSerializersTest extends KryoTestCase {
 	}
 
 	@Test
+	void testTimestampSerializer () {
+		kryo.addDefaultSerializer(java.sql.Timestamp.class, DefaultSerializers.TimestampSerializer.class);
+		kryo.register(java.sql.Timestamp.class);
+		roundTrip(11, newTimestamp(Long.MIN_VALUE+808, 0)); // Smallest valid size
+		roundTrip(15, newTimestamp(Long.MIN_VALUE+808, 999_999_999));
+		roundTrip(11, newTimestamp(Long.MAX_VALUE, 0));
+		roundTrip(14, newTimestamp(Long.MAX_VALUE, 268_435_455)); // Largest valid size
+		roundTrip(3, newTimestamp(0, 0));
+		roundTrip(7, newTimestamp(0, 999_999_999));
+		roundTrip(8, newTimestamp(1234567, 123_456_789));
+		roundTrip(11, newTimestamp(-1234567, 0));
+		roundTrip(11, newTimestamp(-1234567, 1));
+		roundTrip(14, newTimestamp(-1234567, 123_456_789));
+	}
+	
+	private java.sql.Timestamp newTimestamp(long time, int nanos) {
+		java.sql.Timestamp t = new java.sql.Timestamp(time);
+		t.setNanos(nanos);
+		return t;
+	}
+
+	@Test
 	void testBigDecimalSerializer () {
 		kryo.register(BigDecimal.class);
 		kryo.register(BigDecimalSubclass.class);


### PR DESCRIPTION
I've added the new serializer to DefaultSeriailzers (even though it won't be used by default in Kryo 5). Is this OK? If not, let me know where it belongs.