### PR TITLE
Return false if the buffer is not resized after flush.

### DIFF
--- a/src/com/esotericsoftware/kryo/io/ByteBufferOutput.java
+++ b/src/com/esotericsoftware/kryo/io/ByteBufferOutput.java
@@ -182,7 +182,7 @@ public class ByteBufferOutput extends Output {
 	protected boolean require (int required) throws KryoException {
 		if (capacity - position >= required) return false;
 		flush();
-		if (capacity - position >= required) return true;
+		if (capacity - position >= required) return false;
 		if (required > maxCapacity - position) {
 			if (required > maxCapacity)
 				throw new KryoBufferOverflowException("Buffer overflow. Max capacity: " + maxCapacity + ", required: " + required);

--- a/src/com/esotericsoftware/kryo/io/Output.java
+++ b/src/com/esotericsoftware/kryo/io/Output.java
@@ -180,7 +180,7 @@ public class Output extends OutputStream implements AutoCloseable, Poolable {
 	protected boolean require (int required) throws KryoException {
 		if (capacity - position >= required) return false;
 		flush();
-		if (capacity - position >= required) return true;
+		if (capacity - position >= required) return false;
 		if (required > maxCapacity - position) {
 			if (required > maxCapacity)
 				throw new KryoBufferOverflowException("Buffer overflow. Max capacity: " + maxCapacity + ", required: " + required);


### PR DESCRIPTION
According to the doc string, `Output.require()` should return true if the buffer is resized and false otherwise. However, current implementation returns true if the buffer is not resized after `flush()`.