### PR TITLE
[issues-912] optimize serialization size for primitive arrays - IntOnly for now

### DIFF
--- a/src/com/esotericsoftware/kryo/Kryo.java
+++ b/src/com/esotericsoftware/kryo/Kryo.java
@@ -162,6 +162,7 @@ public class Kryo {
 	private IdentityMap originalToCopy;
 	private Object needsCopyReference;
 	private Generics generics = new DefaultGenerics(this);
+	public boolean optimizePrimitiveArrays = false;
 
 	/** Creates a new Kryo with a {@link DefaultClassResolver} and references disabled. */
 	public Kryo () {
@@ -1292,6 +1293,14 @@ public class Kryo {
 	 * @param optimizedGenerics whether to optimize generics (default is true) */
 	public void setOptimizedGenerics (boolean optimizedGenerics) {
 		generics = optimizedGenerics ? new DefaultGenerics(this) : NoGenerics.INSTANCE;
+	}
+
+	public boolean isOptimizePrimitiveArrays() {
+		return optimizePrimitiveArrays;
+	}
+
+	public void setOptimizePrimitiveArrays(boolean optimizePrimitiveArraySize) {
+		this.optimizePrimitiveArrays = optimizePrimitiveArraySize;
 	}
 
 	static final class DefaultSerializerEntry {

--- a/src/com/esotericsoftware/kryo/io/Input.java
+++ b/src/com/esotericsoftware/kryo/io/Input.java
@@ -903,6 +903,22 @@ public class Input extends InputStream implements Poolable {
 	}
 
 	// Primitive arrays:
+	public int[] readInts (int length, boolean optimizePositive) throws KryoException {
+		return readInts(length, length, optimizePositive);
+	}
+
+	/** Reads an int array in bulk using fixed or variable length encoding, depending on
+	 * {@link #setVariableLengthEncoding(boolean)}. This may be more efficient than reading them individually.
+	 * It also takes optimizedLength when {@link Kryo#isOptimizePrimitiveArrays()} is set */
+	public int[] readInts (int length, int optimizedLength, boolean optimizePositive) throws KryoException {
+		if (varEncoding) {
+			int[] array = new int[length];
+			for (int i = 0; i < optimizedLength; i++)
+				array[i] = readVarInt(optimizePositive);
+			return array;
+		}
+		return readInts(length, optimizedLength);
+	}
 
 	/** Reads an int array in bulk. This may be more efficient than reading them individually. */
 	public int[] readInts (int length, int optimizedLength) throws KryoException {
@@ -922,29 +938,6 @@ public class Input extends InputStream implements Poolable {
 				array[i] = readInt();
 		}
 		return array;
-	}
-
-	/** Reads an int array in bulk using fixed or variable length encoding, depending on
-	 * {@link #setVariableLengthEncoding(boolean)}. This may be more efficient than reading them individually. */
-	public int[] readInts (int length, boolean optimizePositive) throws KryoException {
-		if (varEncoding) {
-			int[] array = new int[length];
-			for (int i = 0; i < length; i++)
-				array[i] = readVarInt(optimizePositive);
-			return array;
-		}
-		return readInts(length, length);
-	}
-
-	/** same as {@link #readInts(int, boolean)} except it also takes optimizedLength when {@link Kryo#isOptimizePrimitiveArrays()} is set */
-	public int[] readInts (int length, int optimizedLength, boolean optimizePositive) throws KryoException {
-		if (varEncoding) {
-			int[] array = new int[length];
-			for (int i = 0; i < optimizedLength; i++)
-				array[i] = readVarInt(optimizePositive);
-			return array;
-		}
-		return readInts(length, optimizedLength);
 	}
 
 	/** Reads a long array in bulk. This may be more efficient than reading them individually. */

--- a/src/com/esotericsoftware/kryo/io/Input.java
+++ b/src/com/esotericsoftware/kryo/io/Input.java
@@ -19,6 +19,7 @@
 
 package com.esotericsoftware.kryo.io;
 
+import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.KryoException;
 import com.esotericsoftware.kryo.io.KryoBufferUnderflowException;
 import com.esotericsoftware.kryo.util.Pool.Poolable;
@@ -904,12 +905,12 @@ public class Input extends InputStream implements Poolable {
 	// Primitive arrays:
 
 	/** Reads an int array in bulk. This may be more efficient than reading them individually. */
-	public int[] readInts (int length) throws KryoException {
+	public int[] readInts (int length, int optimizedLength) throws KryoException {
 		int[] array = new int[length];
-		if (optional(length << 2) == length << 2) {
+		if (optional(optimizedLength << 2) == optimizedLength << 2) {
 			byte[] buffer = this.buffer;
 			int p = this.position;
-			for (int i = 0; i < length; i++, p += 4) {
+			for (int i = 0; i < optimizedLength; i++, p += 4) {
 				array[i] = buffer[p] & 0xFF //
 					| (buffer[p + 1] & 0xFF) << 8 //
 					| (buffer[p + 2] & 0xFF) << 16 //
@@ -917,7 +918,7 @@ public class Input extends InputStream implements Poolable {
 			}
 			position = p;
 		} else {
-			for (int i = 0; i < length; i++)
+			for (int i = 0; i < optimizedLength; i++)
 				array[i] = readInt();
 		}
 		return array;
@@ -932,7 +933,18 @@ public class Input extends InputStream implements Poolable {
 				array[i] = readVarInt(optimizePositive);
 			return array;
 		}
-		return readInts(length);
+		return readInts(length, length);
+	}
+
+	/** same as {@link #readInts(int, boolean)} except it also takes optimizedLength when {@link Kryo#isOptimizePrimitiveArrays()} is set */
+	public int[] readInts (int length, int optimizedLength, boolean optimizePositive) throws KryoException {
+		if (varEncoding) {
+			int[] array = new int[length];
+			for (int i = 0; i < optimizedLength; i++)
+				array[i] = readVarInt(optimizePositive);
+			return array;
+		}
+		return readInts(length, optimizedLength);
 	}
 
 	/** Reads a long array in bulk. This may be more efficient than reading them individually. */

--- a/src/com/esotericsoftware/kryo/serializers/DefaultArraySerializers.java
+++ b/src/com/esotericsoftware/kryo/serializers/DefaultArraySerializers.java
@@ -76,12 +76,6 @@ public class DefaultArraySerializers {
 				while(object[optimizedSize-1]==0){
 					optimizedSize--;
 				}
-//				for (int i = object.length-1; i > 0; i--) {
-//					if(object[i]!=0){
-//						break;
-//					}
-//					optimizedSize--;
-//				}
 				output.writeVarInt(optimizedSize + 1, true);
 				output.writeInts(object, 0, optimizedSize, false);
 			}else{

--- a/src/com/esotericsoftware/kryo/serializers/DefaultArraySerializers.java
+++ b/src/com/esotericsoftware/kryo/serializers/DefaultArraySerializers.java
@@ -71,13 +71,33 @@ public class DefaultArraySerializers {
 				return;
 			}
 			output.writeVarInt(object.length + 1, true);
-			output.writeInts(object, 0, object.length, false);
+			if(kryo.isOptimizePrimitiveArrays()){
+				int optimizedSize = object.length;
+				while(object[optimizedSize-1]==0){
+					optimizedSize--;
+				}
+//				for (int i = object.length-1; i > 0; i--) {
+//					if(object[i]!=0){
+//						break;
+//					}
+//					optimizedSize--;
+//				}
+				output.writeVarInt(optimizedSize + 1, true);
+				output.writeInts(object, 0, optimizedSize, false);
+			}else{
+				output.writeInts(object, 0, object.length, false);
+			}
 		}
 
 		public int[] read (Kryo kryo, Input input, Class type) {
 			int length = input.readVarInt(true);
 			if (length == NULL) return null;
-			return input.readInts(length - 1, false);
+			if(kryo.isOptimizePrimitiveArrays()){
+				int optimizedSize = input.readVarInt(true);
+				return input.readInts(length-1, optimizedSize - 1, false);
+			}else{
+				return input.readInts(length - 1, false);
+			}
 		}
 
 		public int[] copy (Kryo kryo, int[] original) {

--- a/test/com/esotericsoftware/kryo/serializers/ArraySerializerTest.java
+++ b/test/com/esotericsoftware/kryo/serializers/ArraySerializerTest.java
@@ -33,6 +33,23 @@ class ArraySerializerTest extends KryoTestCase {
 	}
 
 	@Test
+	void testOptimizedIntArrays () {
+		kryo.register(int[].class);
+
+		// default case
+		roundTrip(6, new int[] {1, 2, 3, 4});
+		// case where lot of trailing values are default value
+		// case withbut any optimization, it would have length of 18
+		roundTrip(18, new int[] {1, 2, 3, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0});
+
+		// case with optimization, it would have length of 7, and also regardless of the size now.
+		kryo.setOptimizePrimitiveArrays(true);
+		roundTrip(7, new int[] {1, 2, 3, 4, 0, 0, 0, 0, 0});
+		roundTrip(7, new int[] {1, 2, 3, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0});
+
+	}
+
+	@Test
 	void testArrays () {
 		kryo.register(int[].class);
 		kryo.register(int[][].class);


### PR DESCRIPTION
PR for #912 ( Currently limited to showcase the feature for Int primitive arrays only based on the guidelines )

Motivation:
Many times, primitive array is used for optimized/efficient code (size and execution time), where the size of the primitive array is not always accurately decided beforehand. 
Serializing these primitive arrays can produce large serialized object with mostly blank character (NUL).
Kryo being focused in efficiency, should provide configuration to further optimize this behavior to store only the necessary values whenever there is an opportunity to do so.

pls refer to the description on #912 for more info on approach.

Thanks