### PR TITLE
Cache components, getters and constructors in `RecordSerializer`

### DIFF
--- a/src/com/esotericsoftware/kryo/serializers/RecordSerializer.java
+++ b/src/com/esotericsoftware/kryo/serializers/RecordSerializer.java
@@ -68,13 +68,13 @@ public class RecordSerializer<T> extends ImmutableSerializer<T> {
 		GET_TYPE = getType;
 	}
 
-	private static final ClassValue<Constructor<?>> CONSTRUCTOR = new ClassValue<>() {
+	private static final ClassValue<Constructor<?>> CONSTRUCTOR = new ClassValue<Constructor<?>>() {
 		protected Constructor<?> computeValue(Class<?> clazz) {
 			final RecordComponent[] components = recordComponents(clazz, Comparator.comparing(RecordComponent::index));
 			return getCanonicalConstructor(clazz, components);
 		}
 	};
-	private static final ClassValue<RecordComponent[]> RECORD_COMPONENTS = new ClassValue<>() {
+	private static final ClassValue<RecordComponent[]> RECORD_COMPONENTS = new ClassValue<RecordComponent[]>() {
 		protected RecordComponent[] computeValue(Class<?> type) {
 			return recordComponents(type, Comparator.comparing(RecordComponent::name));
 		}
@@ -203,7 +203,7 @@ public class RecordSerializer<T> extends ImmutableSerializer<T> {
 				return getter.invoke(recordObject);
 			} catch (Exception t) {
 				KryoException ex = new KryoException(t);
-				ex.addTrace("Could not retrieve record component value (" + recordType + ")");
+				ex.addTrace("Could not retrieve record component value (" + recordType.getName() + ")");
 				throw ex;
 			}
 		}

--- a/test-jdk14/com/esotericsoftware/kryo/serializers/RecordSerializerTest.java
+++ b/test-jdk14/com/esotericsoftware/kryo/serializers/RecordSerializerTest.java
@@ -306,7 +306,7 @@ public class RecordSerializerTest extends KryoTestCase {
 
     @Test
     void testRecordWithSuperType() {
-        var rc = new RecordSerializer<RecordWithSuperType>();
+        var rc = new RecordSerializer<>(RecordWithSuperType.class);
         kryo.register(RecordWithSuperType.class, rc);
 
         final var r = new RecordWithSuperType(1L);


### PR DESCRIPTION
This PR adjusts `RecordSerializer` to cache record components, component getters and the canonical constructor. Thew new implementation is about 20x faster than the current one.

The only downside is that I had to remove the existing no-args constructor. This shouldn't be a huge issue, because there was no need for any user to instantiate the `RecordSerializer` themselves.

| Benchmark                        |   Mode |   Cnt    |     Score |   Error  |  Units |
| ------------- | ------------- | ------------- | -------------: | -------------: | ------------- |
| RecordSerializerBenchmark.new   |    thrpt |    4  | 2215445,525 | ± 20885,922 |  ops/s | 
| RecordSerializerBenchmark.old   |    thrpt  |   4  |  105476,509 | ±    1699,820 |   ops/s | 

If we want to stay fully backwards compatible, we can use `ClassValue` for caching record components and constructors.