### PR TITLE
Make the ImmutableCollections serializers public and final.

### DIFF
--- a/src/com/esotericsoftware/kryo/serializers/ImmutableCollectionsSerializers.java
+++ b/src/com/esotericsoftware/kryo/serializers/ImmutableCollectionsSerializers.java
@@ -50,7 +50,7 @@ public final class ImmutableCollectionsSerializers {
 		JdkImmutableSetSerializer.registerSerializers(kryo);
 	}
 
-	static class JdkImmutableListSerializer extends CollectionSerializer<List<Object>> {
+	public static final class JdkImmutableListSerializer extends CollectionSerializer<List<Object>> {
 
 		private JdkImmutableListSerializer () {
 			setElementsCanBeNull(false);
@@ -98,7 +98,7 @@ public final class ImmutableCollectionsSerializers {
 		}
 	}
 
-	static class JdkImmutableMapSerializer extends MapSerializer<Map<Object, Object>> {
+	public static final class JdkImmutableMapSerializer extends MapSerializer<Map<Object, Object>> {
 
 		private JdkImmutableMapSerializer () {
 			setKeysCanBeNull(false);
@@ -145,7 +145,7 @@ public final class ImmutableCollectionsSerializers {
 		}
 	}
 
-	static class JdkImmutableSetSerializer extends CollectionSerializer<Set<Object>> {
+	public static final class JdkImmutableSetSerializer extends CollectionSerializer<Set<Object>> {
 
 		private JdkImmutableSetSerializer () {
 			setElementsCanBeNull(false);


### PR DESCRIPTION
Declare the built-in serializers for Java's `List.of()`, `Set.of()` and `Map.of()` types to be both `public` and `final`. This makes it easier for Kryo extensions to detect them.

See #943.