### PR TITLE
Add a hook to intercept registration of all new serializers.

### DIFF
--- a/src/com/esotericsoftware/kryo/Kryo.java
+++ b/src/com/esotericsoftware/kryo/Kryo.java
@@ -437,6 +437,13 @@ public class Kryo {
 		return lowest;
 	}
 
+	/** A single point of contact for customising new serializer instances when they are registered.
+	 * Invoked by {@link DefaultClassResolver#register(Registration)}.
+	 */
+	public Serializer adaptNewSerializer (Serializer serializer) {
+		return serializer;
+	}
+
 	/** Returns the best matching serializer for a class. This method can be overridden to implement custom logic to choose a
 	 * serializer. */
 	public Serializer getDefaultSerializer (Class type) {
@@ -527,7 +534,7 @@ public class Kryo {
 	 * <p>
 	 * IDs must be the same at deserialization as they were for serialization.
 	 * <p>
-	 * Registration can be suclassed to efficiently store per type information, accessible in serializers via
+	 * Registration can be subclassed to efficiently store per type information, accessible in serializers via
 	 * {@link Kryo#getRegistration(Class)}. */
 	public Registration register (Registration registration) {
 		int id = registration.getId();

--- a/src/com/esotericsoftware/kryo/util/DefaultClassResolver.java
+++ b/src/com/esotericsoftware/kryo/util/DefaultClassResolver.java
@@ -26,6 +26,7 @@ import com.esotericsoftware.kryo.ClassResolver;
 import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.KryoException;
 import com.esotericsoftware.kryo.Registration;
+import com.esotericsoftware.kryo.Serializer;
 import com.esotericsoftware.kryo.io.Input;
 import com.esotericsoftware.kryo.io.Output;
 
@@ -57,6 +58,16 @@ public class DefaultClassResolver implements ClassResolver {
 		memoizedClassId = -1;
 		memoizedClass = null;
 		if (registration == null) throw new IllegalArgumentException("registration cannot be null.");
+
+		final Serializer oldSerializer = registration.getSerializer();
+		final Serializer newSerializer = kryo.adaptNewSerializer(oldSerializer);
+		if (oldSerializer != newSerializer) {
+			if (newSerializer == null) {
+				throw new IllegalArgumentException("serializer cannot be null.");
+			}
+			registration.setSerializer(newSerializer);
+		}
+
 		if (registration.getId() != NAME) {
 			if (TRACE) {
 				trace("kryo", "Register class ID " + registration.getId() + ": " + className(registration.getType()) + " ("


### PR DESCRIPTION
Create a mechanism for customising, configuring, or even replacing a serializer when it is registered.

See #943.