### PR TITLE
Ensure that record constructors are always accessible

### DIFF
--- a/src/com/esotericsoftware/kryo/serializers/RecordSerializer.java
+++ b/src/com/esotericsoftware/kryo/serializers/RecordSerializer.java
@@ -261,7 +261,10 @@ public class RecordSerializer<T> extends ImmutableSerializer<T> {
 		Constructor<T> canonicalConstructor;
 		try {
 			canonicalConstructor = recordType.getConstructor(paramTypes);
-		} catch (NoSuchMethodException e) {
+			if (!canonicalConstructor.canAccess(null)) {
+				canonicalConstructor.setAccessible(true);
+			}
+		} catch (Exception e) {
 			canonicalConstructor = recordType.getDeclaredConstructor(paramTypes);
 			canonicalConstructor.setAccessible(true);
 		}


### PR DESCRIPTION
I encountered a scenario in production where a record constructor is returned by `recordType.getConstructor()`, but is unusable. Trying to invoke it throws an `IllegalAccessException`. 

Unfortunately, I was unable to reproduce this in a test. It might have something to do with access across module boundaries.