### PR TITLE
Performance improvements for `Kryo.isClosure()`

### DIFF
--- a/src/com/esotericsoftware/kryo/Kryo.java
+++ b/src/com/esotericsoftware/kryo/Kryo.java
@@ -1257,10 +1257,10 @@ public class Kryo {
 	 * the class {@link Registration}.
 	 * <p>
 	 * This can be overridden to support alternative closure implementations. The default implementation returns true if the
-	 * specified type's name contains '/' (to detect a Java 8+ closure). */
+	 * specified type is synthetic and the type's simple name contains '/' (to detect a Java 8+ closure). */
 	public boolean isClosure (Class type) {
 		if (type == null) throw new IllegalArgumentException("type cannot be null.");
-		return type.getName().indexOf('/') >= 0;
+		return type.isSynthetic() && type.getSimpleName().indexOf('/') >= 0;
 	}
 
 	/** Returns true if the specified type is a proxy. When true, Kryo uses {@link InvocationHandler} instead of the specified type

--- a/test/com/esotericsoftware/kryo/serializers/ClosureSerializerTest.java
+++ b/test/com/esotericsoftware/kryo/serializers/ClosureSerializerTest.java
@@ -26,6 +26,7 @@ import com.esotericsoftware.kryo.io.Input;
 import com.esotericsoftware.kryo.io.Output;
 
 import java.util.concurrent.Callable;
+import java.util.function.Supplier;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -59,7 +60,40 @@ class ClosureSerializerTest extends KryoTestCase {
 	}
 
 	@Test
-	void testCopyClosure() {
+	void testCapturingClosure () {
+		final int number = 72363;
+		Supplier<Integer> closure1 = (Supplier<Integer> & java.io.Serializable) () -> number;
+
+		// The length cannot be checked reliable, as it can vary based on the JVM.
+		roundTrip(Integer.MIN_VALUE, closure1);
+
+		Output output = new Output(1024, -1);
+		kryo.writeObject(output, closure1);
+
+		Input input = new Input(output.getBuffer(), 0, output.position());
+		Supplier<Integer> closure2 = (Supplier<Integer>)kryo.readObject(input, ClosureSerializer.Closure.class);
+
+		doAssertEquals(closure1, closure2);
+	}
+
+	@Test
+	void testMethodReference () {
+		Supplier<Integer> closure1 = (Supplier<Integer> & java.io.Serializable)NumberFactory::getNumber;
+
+		// The length cannot be checked reliable, as it can vary based on the JVM.
+		roundTrip(Integer.MIN_VALUE, closure1);
+
+		Output output = new Output(1024, -1);
+		kryo.writeObject(output, closure1);
+
+		Input input = new Input(output.getBuffer(), 0, output.position());
+		Supplier<Integer> closure2 = (Supplier<Integer>)kryo.readObject(input, ClosureSerializer.Closure.class);
+
+		doAssertEquals(closure1, closure2);
+	}
+
+	@Test
+	void testCopyClosure () {
 		Callable<Integer> closure1 = (Callable<Integer> & java.io.Serializable)( () -> 72363);
 
 		final Callable<Integer> closure2 = kryo.copy(closure1);
@@ -69,9 +103,20 @@ class ClosureSerializerTest extends KryoTestCase {
 
 	protected void doAssertEquals (Object object1, Object object2) {
 		try {
-			assertEquals(((Callable)object1).call(), ((Callable)object2).call());
+			if (object1 instanceof Callable) {
+				assertEquals(((Callable)object1).call(), ((Callable)object2).call());
+			}
+			if (object1 instanceof Supplier) {
+				assertEquals(((Supplier)object1).get(), ((Supplier)object2).get());
+			}
 		} catch (Exception ex) {
 			throw new RuntimeException(ex.getMessage());
+		}
+	}
+
+	static class NumberFactory {
+		private static int getNumber () {
+			return 72363;
 		}
 	}
 }


### PR DESCRIPTION
This PR improves the default implementation of `Kryo.isClosure()` in two ways:

1. Check if the type is synthetic
2. Check if the simple name of the class contains a `/`

This is only slightly faster for hits, but significantly faster for misses:

| Benchmark        |           Mode |   Cnt    |        Score |    Units | 
| ------------- | ------------- | ------------- | -------------: | ------------- |
| ClosureBenchmark.newHit   |  thrpt   |  2 |   231402690,531    |       ops/s | 
| ClosureBenchmark.newMiss |  thrpt |    2  |  **1796295832,164**   |        ops/s | 
| ClosureBenchmark.oldHit  |  thrpt   |  2   |  188889209,053       |    ops/s | 
| ClosureBenchmark.oldMiss |  thrpt |    2  |  174581347,713        |   ops/s | 

I hope that `Class.isSynthetic()` is `true` for closures on all JDKs.