### PR TITLE
Move pom-main.xml and pom-versioned.xml to separate folders

### DIFF
--- a/build/assembly-all.xml
+++ b/build/assembly-all.xml
@@ -6,9 +6,10 @@
 	</formats>
 	<fileSets>
 		<fileSet>
+			<directory>.</directory>
 			<includes>
 				<include>README*</include>
-				<include>license*</include>
+				<include>LICENCE*</include>
 				<include>CHANGES*</include>
 				<include>lib/</include>
 				<include>src/</include>

--- a/main-versioned/pom.xml
+++ b/main-versioned/pom.xml
@@ -5,15 +5,18 @@
 		<groupId>com.esotericsoftware</groupId>
 		<artifactId>kryo-parent</artifactId>
 		<version>5.5.1-SNAPSHOT</version>
-		<relativePath>./pom.xml</relativePath>
+		<relativePath>../pom.xml</relativePath>
 	</parent>
 
-	<groupId>com.esotericsoftware.kryo</groupId>
 	<artifactId>kryo${kryo.major.version}</artifactId>
 	<packaging>jar</packaging>
 
 	<name>Kryo ${kryo.major.version}</name>
 	<description>Fast, efficient Java serialization. This is the version specific Kryo artifact.</description>
+
+	<properties>
+		<kryo.root>../</kryo.root>
+	</properties>
 
 	<dependencies>
 		<dependency>
@@ -24,7 +27,18 @@
 	</dependencies>
 
 	<build>
+		<directory>${kryo.root}/target</directory>
+		<sourceDirectory>${kryo.root}/src</sourceDirectory>
+		<testSourceDirectory>${kryo.root}/test</testSourceDirectory>
+		
 		<plugins>
+			<plugin>
+				<artifactId>maven-clean-plugin</artifactId>
+				<configuration>
+					<!-- Skip clean phase so that artifacts from main POM are not deleted. -->
+					<skip>true</skip>
+				</configuration>
+			</plugin>
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>build-helper-maven-plugin</artifactId>

--- a/main/pom.xml
+++ b/main/pom.xml
@@ -5,7 +5,7 @@
 		<groupId>com.esotericsoftware</groupId>
 		<artifactId>kryo-parent</artifactId>
 		<version>5.5.1-SNAPSHOT</version>
-		<relativePath>./pom.xml</relativePath>
+		<relativePath>../pom.xml</relativePath>
 	</parent>
 
 	<artifactId>kryo</artifactId>
@@ -13,6 +13,10 @@
 
 	<name>Kryo</name>
 	<description>Fast, efficient Java serialization. This is the main Kryo artifact.</description>
+
+	<properties>
+		<kryo.root>../</kryo.root>
+	</properties>
 
 	<dependencies>
 		<dependency>
@@ -33,6 +37,10 @@
 	</dependencies>
 
 	<build>
+		<directory>${kryo.root}/target</directory>
+		<sourceDirectory>${kryo.root}/src</sourceDirectory>
+		<testSourceDirectory>${kryo.root}/test</testSourceDirectory>
+		
 		<plugins>
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
@@ -75,8 +83,9 @@
 				<artifactId>maven-assembly-plugin</artifactId>
 				<version>3.4.2</version>
 				<configuration>
+					<archiveBaseDirectory>${kryo.root}</archiveBaseDirectory>
 					<descriptors>
-						<descriptor>build/assembly-all.xml</descriptor>
+						<descriptor>${kryo.root}/build/assembly-all.xml</descriptor>
 					</descriptors>
 				</configuration>
 				<!--

--- a/pom.xml
+++ b/pom.xml
@@ -57,8 +57,8 @@
 	</properties>
 
 	<modules>
-		<module>pom-main.xml</module>
-		<module>pom-versioned.xml</module>
+		<module>main</module>
+		<module>main-versioned</module>
 		<module>benchmarks</module>
 	</modules>
 
@@ -182,7 +182,7 @@
 					<artifactId>findbugs-maven-plugin</artifactId>
 					<version>3.0.5</version>
 				</plugin>
-                                
+
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-release-plugin</artifactId>
@@ -194,8 +194,8 @@
 						<arguments>-Prelease</arguments>
 						<goals>deploy</goals>
 						<!-- Don't run clean, because this would delete the kryo artifact, which would fail the shade plugin
-						    because the kryo jar would no longer exist.
-						    https://maven.apache.org/maven-release/maven-release-plugin/prepare-mojo.html#preparationGoals
+							because the kryo jar would no longer exist.
+							https://maven.apache.org/maven-release/maven-release-plugin/prepare-mojo.html#preparationGoals
 						-->
 						<preparationGoals>verify</preparationGoals>
 					</configuration>
@@ -364,7 +364,7 @@
 									</goals>
 									<configuration>
 										<sources>
-											<source>test-kotlin</source>
+											<source>${kryo.root}/test-kotlin</source>
 										</sources>
 									</configuration>
 								</execution>
@@ -419,8 +419,8 @@
 									</goals>
 									<configuration>
 										<sources>
-											<source>test-kotlin</source>
-											<source>test-jdk11</source>
+											<source>${kryo.root}/test-kotlin</source>
+											<source>${kryo.root}/test-jdk11</source>
 										</sources>
 									</configuration>
 								</execution>
@@ -466,9 +466,9 @@
 									</goals>
 									<configuration>
 										<sources>
-											<source>test-kotlin</source>
-											<source>test-jdk11</source>
-											<source>test-jdk17</source>
+											<source>${kryo.root}/test-kotlin</source>
+											<source>${kryo.root}/test-jdk11</source>
+											<source>${kryo.root}/test-jdk17</source>
 										</sources>
 									</configuration>
 								</execution>
@@ -493,12 +493,13 @@
 							<groupId>org.apache.maven.plugins</groupId>
 							<artifactId>maven-surefire-plugin</artifactId>
 							<configuration>
-									<argLine>
-										--enable-preview
-										--add-opens java.base/sun.nio.ch=ALL-UNNAMED
-										--add-opens java.base/java.nio=ALL-UNNAMED
-										--add-opens java.base/java.util.concurrent.atomic=ALL-UNNAMED
-									</argLine>
+								<argLine>
+									--enable-preview
+									--add-opens java.base/sun.nio.ch=ALL-UNNAMED
+									--add-opens java.base/java.lang.invoke=ALL-UNNAMED
+									--add-opens java.base/java.nio=ALL-UNNAMED
+									--add-opens java.base/java.util.concurrent.atomic=ALL-UNNAMED
+								</argLine>
 							</configuration>
 						</plugin>
 					</plugins>


### PR DESCRIPTION
This allows us to use a more standard Maven project setup and should work with GitHub's Dependency Graph and Dependabot.

See https://github.com/orgs/community/discussions/53539