### PR TITLE
Avoid creating a `GenericsHierarchy` when generics optimization is disabled

### DIFF
--- a/src/com/esotericsoftware/kryo/serializers/FieldSerializer.java
+++ b/src/com/esotericsoftware/kryo/serializers/FieldSerializer.java
@@ -76,7 +76,8 @@ public class FieldSerializer<T> extends Serializer<T> {
 		this.type = type;
 		this.config = config;
 
-		genericsHierarchy = new GenericsHierarchy(type);
+		final Generics generics = kryo.getGenerics();
+		genericsHierarchy = generics.buildHierarchy(type);
 
 		cachedFields = new CachedFields(this);
 		cachedFields.rebuild();

--- a/src/com/esotericsoftware/kryo/util/DefaultGenerics.java
+++ b/src/com/esotericsoftware/kryo/util/DefaultGenerics.java
@@ -41,6 +41,11 @@ public final class DefaultGenerics implements Generics {
 	}
 
 	@Override
+	public GenericsHierarchy buildHierarchy (Class type) {
+		return new GenericsHierarchy(type);
+	}
+
+	@Override
 	public void pushGenericType (GenericType fieldType) {
 		// Ensure genericTypes and depths capacity.
 		int size = genericTypesSize;

--- a/src/com/esotericsoftware/kryo/util/Generics.java
+++ b/src/com/esotericsoftware/kryo/util/Generics.java
@@ -31,6 +31,10 @@ import java.util.ArrayList;
 
 /** Handles storage of generic type information */
 public interface Generics {
+
+	/** Builds a {@link GenericsHierarchy} for the specified type. */
+	GenericsHierarchy buildHierarchy (Class type);
+	
 	/** Sets the type that is currently being serialized. Must be balanced by {@link #popGenericType()}. Between those calls, the
 	 * {@link GenericType#getTypeParameters() type parameters} are returned by {@link #nextGenericTypes()} and
 	 * {@link #nextGenericClass()}. */
@@ -41,7 +45,7 @@ public interface Generics {
 	void popGenericType ();
 
 	/** Returns the current type parameters and {@link #pushGenericType(GenericType) pushes} the next level of type parameters for
-	 * subsquent calls. Must be balanced by {@link #popGenericType()} (optional if null is returned). If multiple type parameters
+	 * subsequent calls. Must be balanced by {@link #popGenericType()} (optional if null is returned). If multiple type parameters
 	 * are returned, the last is used to advance to the next level of type parameters.
 	 * <p>
 	 * {@link #nextGenericClass()} is easier to use when a class has a single type parameter. When a class has multiple type
@@ -77,6 +81,8 @@ public interface Generics {
 	/** Stores the type parameters for a class and, for parameters passed to super classes, the corresponding super class type
 	 * parameters. */
 	class GenericsHierarchy {
+		static final GenericsHierarchy EMPTY = new GenericsHierarchy(0, 0, new int[0], new TypeVariable[0]);
+		
 		/* Total number of type parameters in the hierarchy. */
 		final int total;
 		/* Total number of type parameters at the root of the hierarchy. */
@@ -125,6 +131,13 @@ public interface Generics {
 			this.rootTotal = type.getTypeParameters().length;
 			this.counts = counts.toArray();
 			this.parameters = parameters.toArray(new TypeVariable[parameters.size()]);
+		}
+
+		GenericsHierarchy (int total, int rootTotal, int[] counts, TypeVariable[] parameters) {
+			this.total = total;
+			this.rootTotal = rootTotal;
+			this.counts = counts;
+			this.parameters = parameters;
 		}
 
 		public String toString () {

--- a/src/com/esotericsoftware/kryo/util/NoGenerics.java
+++ b/src/com/esotericsoftware/kryo/util/NoGenerics.java
@@ -31,6 +31,11 @@ public final class NoGenerics implements Generics {
 	}
 
 	@Override
+	public GenericsHierarchy buildHierarchy (Class type) {
+		return GenericsHierarchy.EMPTY;
+	}
+
+	@Override
 	public void pushGenericType (GenericType fieldType) {
 	}
 


### PR DESCRIPTION
This PR avoids creating `GenericsHierarchy` when `Kryo.setOptimizedGenerics(false)`.