### PR TITLE
BigDecimal serializer memory and throughput optimizations

### DIFF
--- a/benchmarks/src/main/java/com/esotericsoftware/kryo/benchmarks/BigDecimalBenchmark.java
+++ b/benchmarks/src/main/java/com/esotericsoftware/kryo/benchmarks/BigDecimalBenchmark.java
@@ -45,24 +45,26 @@ public class BigDecimalBenchmark {
 
         @Setup(Level.Iteration)
         public void setUp() {
-            decimal = switch (numOfDigits) {
-                case "null" -> null;
-                case "zero" -> ZERO;
-                case "one" -> ONE;
-                case "0" -> BigDecimal.valueOf(0, scale);
-                case "max_in_long" -> BigDecimal.valueOf(Long.MAX_VALUE, scale);
-                case "min_in_long" -> BigDecimal.valueOf(Long.MIN_VALUE, scale);
-                default -> {
-                    int digits = parseInt(numOfDigits.replace("-", ""));
-                    var d = BigDecimal.valueOf(10, 1 - digits).subtract(ONE).scaleByPowerOfTen(-scale); // '9' repeated numOfDigit times
-                    yield numOfDigits.charAt(0) != '-' ? d : d.negate();
-                }
-            };
-
+            decimal = newDecimal(numOfDigits, scale);
             output = new Output(2, -1);
             serializer.write(null, output, decimal);
             input = new Input(output.toBytes());
             output.reset();
+        }
+
+        private static BigDecimal newDecimal(String numOfDigits, int scale) {
+            switch (numOfDigits) {
+                case "null": return null;
+                case "zero": return ZERO;
+                case "one": return ONE;
+                case "0": return BigDecimal.valueOf(0, scale);
+                case "max_in_long": return BigDecimal.valueOf(Long.MAX_VALUE, scale);
+                case "min_in_long": return BigDecimal.valueOf(Long.MIN_VALUE, scale);
+                default:
+                    int digits = parseInt(numOfDigits.replace("-", ""));
+                    BigDecimal d = BigDecimal.valueOf(10, 1 - digits).subtract(ONE).scaleByPowerOfTen(-scale); // '9' repeated numOfDigit times
+                    return numOfDigits.charAt(0) != '-' ? d : d.negate();
+            }
         }
 
         @TearDown(Level.Iteration)

--- a/benchmarks/src/main/java/com/esotericsoftware/kryo/benchmarks/BigDecimalBenchmark.java
+++ b/benchmarks/src/main/java/com/esotericsoftware/kryo/benchmarks/BigDecimalBenchmark.java
@@ -1,0 +1,100 @@
+package com.esotericsoftware.kryo.benchmarks;
+
+import com.esotericsoftware.kryo.Serializer;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+import com.esotericsoftware.kryo.serializers.DefaultSerializers;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.math.BigDecimal;
+
+import static java.lang.Integer.parseInt;
+import static java.math.BigDecimal.ONE;
+import static java.math.BigDecimal.ZERO;
+import static java.util.concurrent.TimeUnit.MICROSECONDS;
+import static org.openjdk.jmh.runner.options.TimeValue.seconds;
+
+public class BigDecimalBenchmark {
+
+    @State(Scope.Thread)
+    public static class MyState {
+        final Serializer<BigDecimal> serializer = new DefaultSerializers.BigDecimalSerializer();
+
+        Output output;
+        Input input;
+
+        @Param({
+                "null", "zero", "one", "0",
+                "2", "10", "max_in_long", "20", // twenty is more than the number of digits in Long.MAX_VALUE
+                "-2", "-10", "min_in_long", "-20" // twenty is more than the number of digits in Long.MIN_VALUE
+        })
+        String numOfDigits = "5";
+        int scale = 2;
+
+        BigDecimal decimal;
+
+        @Setup(Level.Iteration)
+        public void setUp() {
+            decimal = switch (numOfDigits) {
+                case "null" -> null;
+                case "zero" -> ZERO;
+                case "one" -> ONE;
+                case "0" -> BigDecimal.valueOf(0, scale);
+                case "max_in_long" -> BigDecimal.valueOf(Long.MAX_VALUE, scale);
+                case "min_in_long" -> BigDecimal.valueOf(Long.MIN_VALUE, scale);
+                default -> {
+                    int digits = parseInt(numOfDigits.replace("-", ""));
+                    var d = BigDecimal.valueOf(10, 1 - digits).subtract(ONE).scaleByPowerOfTen(-scale); // '9' repeated numOfDigit times
+                    yield numOfDigits.charAt(0) != '-' ? d : d.negate();
+                }
+            };
+
+            output = new Output(2, -1);
+            serializer.write(null, output, decimal);
+            input = new Input(output.toBytes());
+            output.reset();
+        }
+
+        @TearDown(Level.Iteration)
+        public void tearDown () {
+            output.close();
+            input.close();
+        }
+    }
+
+    @Benchmark
+    public byte[] write (MyState state) {
+        state.output.reset();
+        state.serializer.write(null, state.output, state.decimal);
+        return state.output.getBuffer();
+    }
+
+    @Benchmark
+    public BigDecimal read (MyState state) {
+        state.input.reset();
+        return state.serializer.read(null, state.input, BigDecimal.class);
+    }
+
+    public static void main (String[] args) throws RunnerException {
+        final Options opt = new OptionsBuilder()
+                .include(".*" + BigDecimalBenchmark.class.getSimpleName() + ".*")
+                .timeUnit(MICROSECONDS)
+                .warmupIterations(1)
+                .warmupTime(seconds(1))
+                .measurementIterations(4)
+                .measurementTime(seconds(1))
+                .forks(1)
+                .build();
+        new Runner(opt).run();
+    }
+}

--- a/src/com/esotericsoftware/kryo/serializers/DefaultSerializers.java
+++ b/src/com/esotericsoftware/kryo/serializers/DefaultSerializers.java
@@ -205,18 +205,7 @@ public class DefaultSerializers {
 			byte[] bytes = input.readBytes(length - 1);
 			if (type != BigInteger.class && type != null) {
 				// Use reflection for subclasses.
-				try {
-					Constructor<? extends BigInteger> constructor = type.getConstructor(byte[].class);
-					if (!constructor.isAccessible()) {
-						try {
-							constructor.setAccessible(true);
-						} catch (SecurityException ignored) {
-						}
-					}
-					return constructor.newInstance(bytes);
-				} catch (Exception ex) {
-					throw new KryoException(ex);
-				}
+				return newCustomBigInteger(type, bytes);
 			}
 			if (length == 2) {
 				// Fast-path optimizations for BigInteger constants.
@@ -231,13 +220,26 @@ public class DefaultSerializers {
 			}
 			return new BigInteger(bytes);
 		}
+
+		private static BigInteger newCustomBigInteger(Class<? extends BigInteger> type, byte[] bytes) {
+			try {
+				Constructor<? extends BigInteger> constructor = type.getConstructor(byte[].class);
+				if (!constructor.isAccessible()) {
+					try {
+						constructor.setAccessible(true);
+					} catch (SecurityException ignored) {
+					}
+				}
+				return constructor.newInstance(bytes);
+			} catch (Exception ex) {
+				throw new KryoException(ex);
+			}
+		}
 	}
 
 	/** Serializer for {@link BigDecimal} and any subclass.
 	 * @author Tumi <serverperformance@gmail.com> (enhacements) */
 	public static class BigDecimalSerializer extends ImmutableSerializer<BigDecimal> {
-		private final BigIntegerSerializer bigIntegerSerializer = new BigIntegerSerializer();
-
 		{
 			setAcceptsNull(true);
 		}
@@ -247,42 +249,105 @@ public class DefaultSerializers {
 				output.writeByte(NULL);
 				return;
 			}
-			// fast-path optimizations for BigDecimal constants
 			if (object == BigDecimal.ZERO) {
-				bigIntegerSerializer.write(kryo, output, BigInteger.ZERO);
-				output.writeInt(0, false); // for backwards compatibility
+				output.writeVarInt(2, true);
+				output.writeByte(0);
+				output.writeInt(object.scale(), false);
 				return;
 			}
-			// default behaviour
-			bigIntegerSerializer.write(kryo, output, object.unscaledValue());
+			if (object == BigDecimal.ONE) {
+				output.writeVarInt(2, true);
+				output.writeByte(1);
+				output.writeInt(object.scale(), false);
+				return;
+			}
+
+			BigInteger unscaledBig = null; // avoid getting it from BigDecimal, as non-inflated BigDecimal will have to create it
+			boolean compactForm = object.precision() < 19; // less than nineteen decimal digits for sure fits in a long
+			if (!compactForm) {
+				unscaledBig = object.unscaledValue(); // get and remember for possible use in non-compact form
+				compactForm = unscaledBig.bitLength() <= 63; // check exactly if unscaled value will fit in a long
+			}
+
+			if (!compactForm) {
+				byte[] bytes = unscaledBig.toByteArray();
+				output.writeVarInt(bytes.length + 1, true);
+				output.writeBytes(bytes);
+			} else {
+				long unscaledLong = object.scaleByPowerOfTen(object.scale()).longValue(); // best way to get unscaled long value without creating unscaled BigInteger on the way
+
+				byte[] bytes = new byte[8];
+				int pos = 8;
+				do {
+					bytes[--pos] = (byte) (unscaledLong & 0xFF);
+					unscaledLong = unscaledLong >> 8;
+				} while (unscaledLong != 0 && unscaledLong != -1); // out of bits
+
+				if (((bytes[pos] ^ unscaledLong) & 0x80) != 0) {
+					// sign bit didn't fit in previous byte, need to add another byte
+					bytes[--pos] = (byte) unscaledLong;
+				}
+
+				int length = 8 - pos;
+				output.writeVarInt(length + 1, true);
+				output.writeBytes(bytes, pos, length);
+			}
+
 			output.writeInt(object.scale(), false);
 		}
 
 		public BigDecimal read (Kryo kryo, Input input, Class<? extends BigDecimal> type) {
-			BigInteger unscaledValue = bigIntegerSerializer.read(kryo, input, BigInteger.class);
-			if (unscaledValue == null) return null;
+			BigInteger unscaledBig = null;
+			long unscaledLong = 0;
+
+			int length = input.readVarInt(true);
+			if (length == NULL) return null;
+			length--;
+
+			byte[] bytes = input.readBytes(length);
+			if (length > 8) {
+				unscaledBig = new BigInteger(bytes);
+			} else {
+				unscaledLong = bytes[0];
+				for (int i = 1; i < bytes.length; i++) {
+					unscaledLong = unscaledLong << 8;
+					unscaledLong = unscaledLong | (bytes[i] & 0xFF);
+				}
+			}
+
 			int scale = input.readInt(false);
 			if (type != BigDecimal.class && type != null) {
 				// For subclasses, use reflection
-				try {
-					Constructor<? extends BigDecimal> constructor = type.getConstructor(BigInteger.class, int.class);
-					if (!constructor.isAccessible()) {
-						try {
-							constructor.setAccessible(true);
-						} catch (SecurityException ignored) {
+				return newCustomBigDecimal(type, unscaledBig != null ? unscaledBig : BigInteger.valueOf(unscaledLong), scale);
+			} else {
+				// For BigDecimal, if possible use factory methods to avoid instantiating BigInteger
+				if (unscaledBig != null) {
+					return new BigDecimal(unscaledBig, scale);
+				} else {
+					if (scale == 0) {
+						switch ((int) unscaledLong) {
+							case 0: return BigDecimal.ZERO;
+							case 1: return BigDecimal.ONE;
 						}
 					}
-					return constructor.newInstance(unscaledValue, scale);
-				} catch (Exception ex) {
-					throw new KryoException(ex);
+					return BigDecimal.valueOf(unscaledLong, scale);
 				}
 			}
-			// fast-path optimizations for BigDecimal constants
-			if (unscaledValue == BigInteger.ZERO && scale == 0) {
-				return BigDecimal.ZERO;
+		}
+
+		private static BigDecimal newCustomBigDecimal (Class<? extends BigDecimal> type, BigInteger unscaledValue, int scale) {
+			try {
+				Constructor<? extends BigDecimal> constructor = type.getConstructor(BigInteger.class, int.class);
+				if (!constructor.isAccessible()) {
+					try {
+						constructor.setAccessible(true);
+					} catch (SecurityException ignored) {
+					}
+				}
+				return constructor.newInstance(unscaledValue, scale);
+			} catch (Exception ex) {
+				throw new KryoException(ex);
 			}
-			// default behaviour
-			return new BigDecimal(unscaledValue, scale);
 		}
 	}
 

--- a/src/com/esotericsoftware/kryo/serializers/DefaultSerializers.java
+++ b/src/com/esotericsoftware/kryo/serializers/DefaultSerializers.java
@@ -251,13 +251,13 @@ public class DefaultSerializers {
 			}
 			if (object == BigDecimal.ZERO) {
 				output.writeVarInt(2, true);
-				output.writeByte(0);
+				output.writeByte((byte) 0);
 				output.writeInt(0, false);
 				return;
 			}
 			if (object == BigDecimal.ONE) {
 				output.writeVarInt(2, true);
-				output.writeByte(1);
+				output.writeByte((byte) 1);
 				output.writeInt(0, false);
 				return;
 			}

--- a/src/com/esotericsoftware/kryo/serializers/DefaultSerializers.java
+++ b/src/com/esotericsoftware/kryo/serializers/DefaultSerializers.java
@@ -205,7 +205,7 @@ public class DefaultSerializers {
 			byte[] bytes = input.readBytes(length - 1);
 			if (type != BigInteger.class && type != null) {
 				// Use reflection for subclasses.
-				return newCustomBigInteger(type, bytes);
+				return newBigIntegerSubclass(type, bytes);
 			}
 			if (length == 2) {
 				// Fast-path optimizations for BigInteger constants.
@@ -221,7 +221,7 @@ public class DefaultSerializers {
 			return new BigInteger(bytes);
 		}
 
-		private static BigInteger newCustomBigInteger(Class<? extends BigInteger> type, byte[] bytes) {
+		private static BigInteger newBigIntegerSubclass(Class<? extends BigInteger> type, byte[] bytes) {
 			try {
 				Constructor<? extends BigInteger> constructor = type.getConstructor(byte[].class);
 				if (!constructor.isAccessible()) {
@@ -327,7 +327,7 @@ public class DefaultSerializers {
 			int scale = input.readInt(false);
 			if (type != BigDecimal.class && type != null) {
 				// For subclasses, use reflection
-				return newCustomBigDecimal(type, unscaledBig != null ? unscaledBig : BigInteger.valueOf(unscaledLong), scale);
+				return newBigDecimalSubclass(type, unscaledBig != null ? unscaledBig : BigInteger.valueOf(unscaledLong), scale);
 			} else {
 				// For BigDecimal, if possible use factory methods to avoid instantiating BigInteger
 				if (unscaledBig != null) {
@@ -342,7 +342,7 @@ public class DefaultSerializers {
 			}
 		}
 
-		private static BigDecimal newCustomBigDecimal (Class<? extends BigDecimal> type, BigInteger unscaledValue, int scale) {
+		private static BigDecimal newBigDecimalSubclass(Class<? extends BigDecimal> type, BigInteger unscaledValue, int scale) {
 			try {
 				Constructor<? extends BigDecimal> constructor = type.getConstructor(BigInteger.class, int.class);
 				if (!constructor.isAccessible()) {


### PR DESCRIPTION
This is an optimization of the default serializer for `BigDecimal`. Main goal is to avoid constructing `BigDecimal` in the inflated form during deserialization to save on memory and GC pressure of the program that did the deserialization. Avoiding constructing it with a `BigInteger` unscaled value is possible if the unscaled value fits in a `long`. More reasoning behind this can be found in my article: https://medium.com/@gdela/hidden-memory-effects-of-bigdecimal-caa0bfdb1e87

A nice side effect of this is improved throughput of serialization/deserialization for the cases where unscaled value fits in a `long`, i.e. if there are less than ~19 precision digits in the `BigDecimal`:

![bigdecimal-optimiziation](https://github.com/EsotericSoftware/kryo/assets/4157004/e6afc8d7-f810-4a95-ad46-13fb9c908926)

The changes in the `BigDecimalSerializer` do not change how the serialized form of `BigDecimal` looks like. They are backwards-compatible.