### PR TITLE
Avoid allocation in `BigDecimal` serializer.

### DIFF
--- a/src/com/esotericsoftware/kryo/serializers/DefaultSerializers.java
+++ b/src/com/esotericsoftware/kryo/serializers/DefaultSerializers.java
@@ -21,6 +21,7 @@ package com.esotericsoftware.kryo.serializers;
 
 import static com.esotericsoftware.kryo.Kryo.*;
 import static com.esotericsoftware.kryo.util.Util.*;
+import static java.lang.Long.numberOfLeadingZeros;
 
 import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.KryoException;
@@ -283,25 +284,15 @@ public class DefaultSerializers {
 
 		// compatible with writing unscaled value represented as BigInteger's bytes
 		private static void writeUnscaledLong(Output output, long unscaledLong) {
-			if (unscaledLong >>> 7 == 0) { // optimize for tiny values
-				output.writeVarInt(2, true);
-				output.writeByte((byte) unscaledLong);
-			} else {
-				byte[] bytes = new byte[8];
-				int pos = 8;
-				do {
-					bytes[--pos] = (byte) (unscaledLong & 0xFF);
-					unscaledLong >>= 8;
-				} while (unscaledLong != 0 && unscaledLong != -1); // out of bits
+			int insignificantBits = unscaledLong >= 0
+					? numberOfLeadingZeros(unscaledLong)
+					: numberOfLeadingZeros(~unscaledLong);
+			int significantBits = (64 - insignificantBits) + 1; // one more bit is for the sign
+			int length = (significantBits + (8 - 1)) >> 3; // how many bytes are needed (rounded up)
 
-				if (((bytes[pos] ^ unscaledLong) & 0x80) != 0) {
-					// sign bit didn't fit in previous byte, need to add another byte
-					bytes[--pos] = (byte) unscaledLong;
-				}
-
-				int length = 8 - pos;
-				output.writeVarInt(length + 1, true);
-				output.writeBytes(bytes, pos, length);
+			output.writeByte(length + 1);
+			for (int i = length - 1; i >= 0; i--) {
+				output.writeByte((byte) (unscaledLong >> (i << 3)));
 			}
 		}
 
@@ -313,14 +304,13 @@ public class DefaultSerializers {
 			if (length == NULL) return null;
 			length--;
 
-			byte[] bytes = input.readBytes(length);
 			if (length > 8) {
+				byte[] bytes = input.readBytes(length);
 				unscaledBig = new BigInteger(bytes);
 			} else {
-				unscaledLong = bytes[0];
-				for (int i = 1; i < bytes.length; i++) {
-					unscaledLong <<= 8;
-					unscaledLong |= (bytes[i] & 0xFF);
+				unscaledLong = input.readByte();
+				for (int i = 1; i < length; i++) {
+					unscaledLong = (unscaledLong << 8) | (input.readByte() & 0xFF);
 				}
 			}
 


### PR DESCRIPTION
This is a continuation of #1014, following the great advise from @NathanSweet to avoid allocation in the `BigDecimalSerializer` and use the `Long.numberOfLeadingZeros()` to be able to do so, the serialization/deserialization of `BigDecimal`s is now even faster (and the code got simpler):

![avoid-allocation-option-A](https://github.com/EsotericSoftware/kryo/assets/4157004/40c23146-8738-4170-b7d0-5d1f54566538)

