### PR TITLE
Avoid allocation in `BigDecimal` serializer with alternative way to write bytes.

### DIFF
--- a/src/com/esotericsoftware/kryo/io/ByteBufferInput.java
+++ b/src/com/esotericsoftware/kryo/io/ByteBufferInput.java
@@ -352,6 +352,17 @@ public class ByteBufferInput extends Input {
 		}
 	}
 
+	public int readInt (int count) {
+		if (count < 0 || count > 4) throw new IllegalArgumentException("count must be >= 0 and <= 4: " + count);
+		require(count);
+		position += count;
+		int bytes = byteBuffer.get();
+		for (int i = 1; i < count; i++) {
+			bytes = (bytes << 8) | (byteBuffer.get() & 0xFF);
+		}
+		return bytes;
+	}
+
 	public long readLong (int count) {
 		if (count < 0 || count > 8) throw new IllegalArgumentException("count must be >= 0 and <= 8: " + count);
 		require(count);

--- a/src/com/esotericsoftware/kryo/io/ByteBufferInput.java
+++ b/src/com/esotericsoftware/kryo/io/ByteBufferInput.java
@@ -352,7 +352,8 @@ public class ByteBufferInput extends Input {
 		}
 	}
 
-	public long readBytesAsLong (int count) {
+	public long readLong (int count) {
+		if (count < 0 || count > 8) throw new IllegalArgumentException("count must be >= 0 and <= 8: " + count);
 		require(count);
 		position += count;
 		long bytes = byteBuffer.get();

--- a/src/com/esotericsoftware/kryo/io/ByteBufferInput.java
+++ b/src/com/esotericsoftware/kryo/io/ByteBufferInput.java
@@ -356,22 +356,24 @@ public class ByteBufferInput extends Input {
 		if (count < 0 || count > 4) throw new IllegalArgumentException("count must be >= 0 and <= 4: " + count);
 		require(count);
 		position += count;
-		int bytes = byteBuffer.get();
-		for (int i = 1; i < count; i++) {
-			bytes = (bytes << 8) | (byteBuffer.get() & 0xFF);
+		ByteBuffer byteBuffer = this.byteBuffer;
+		switch (count) {
+			case 1:
+				return byteBuffer.get();
+			case 2:
+				return byteBuffer.get() << 8
+					| byteBuffer.get() & 0xFF;
+			case 3:
+				return byteBuffer.get() << 16
+					| (byteBuffer.get() & 0xFF) << 8
+					| byteBuffer.get() & 0xFF;
+			case 4:
+				return byteBuffer.get() << 24
+					| (byteBuffer.get() & 0xFF) << 16
+					| (byteBuffer.get() & 0xFF) << 8
+					| byteBuffer.get() & 0xFF;
 		}
-		return bytes;
-	}
-
-	public long readLong (int count) {
-		if (count < 0 || count > 8) throw new IllegalArgumentException("count must be >= 0 and <= 8: " + count);
-		require(count);
-		position += count;
-		long bytes = byteBuffer.get();
-		for (int i = 1; i < count; i++) {
-			bytes = (bytes << 8) | (byteBuffer.get() & 0xFF);
-		}
-		return bytes;
+		throw new IllegalStateException(); // impossible
 	}
 
 	// int:

--- a/src/com/esotericsoftware/kryo/io/ByteBufferInput.java
+++ b/src/com/esotericsoftware/kryo/io/ByteBufferInput.java
@@ -352,6 +352,16 @@ public class ByteBufferInput extends Input {
 		}
 	}
 
+	public long readBytesAsLong (int count) {
+		require(count);
+		position += count;
+		long bytes = byteBuffer.get();
+		for (int i = 1; i < count; i++) {
+			bytes = (bytes << 8) | (byteBuffer.get() & 0xFF);
+		}
+		return bytes;
+	}
+
 	// int:
 
 	public int readInt () throws KryoException {

--- a/src/com/esotericsoftware/kryo/io/ByteBufferOutput.java
+++ b/src/com/esotericsoftware/kryo/io/ByteBufferOutput.java
@@ -280,17 +280,26 @@ public class ByteBufferOutput extends Output {
 		if (count < 0 || count > 4) throw new IllegalArgumentException("count must be >= 0 and <= 4: " + count);
 		require(count);
 		position += count;
-		for (int i = count - 1; i >= 0; i--) {
-			byteBuffer.put((byte) (bytes >> (i << 3)));
-		}
-	}
-
-	public void writeLong (long bytes, int count) {
-		if (count < 0 || count > 8) throw new IllegalArgumentException("count must be >= 0 and <= 8: " + count);
-		require(count);
-		position += count;
-		for (int i = count - 1; i >= 0; i--) {
-			byteBuffer.put((byte) (bytes >> (i << 3)));
+		ByteBuffer byteBuffer = this.byteBuffer;
+		switch (count) {
+			case 1:
+				byteBuffer.put((byte)bytes);
+				break;
+			case 2:
+				byteBuffer.put((byte)(bytes >> 8));
+				byteBuffer.put((byte)bytes);
+				break;
+			case 3:
+				byteBuffer.put((byte)(bytes >> 16));
+				byteBuffer.put((byte)(bytes >> 8));
+				byteBuffer.put((byte)bytes);
+				break;
+			case 4:
+				byteBuffer.put((byte)(bytes >> 24));
+				byteBuffer.put((byte)(bytes >> 16));
+				byteBuffer.put((byte)(bytes >> 8));
+				byteBuffer.put((byte)bytes);
+				break;
 		}
 	}
 

--- a/src/com/esotericsoftware/kryo/io/ByteBufferOutput.java
+++ b/src/com/esotericsoftware/kryo/io/ByteBufferOutput.java
@@ -276,6 +276,15 @@ public class ByteBufferOutput extends Output {
 		}
 	}
 
+	public void writeInt (int bytes, int count) {
+		if (count < 0 || count > 4) throw new IllegalArgumentException("count must be >= 0 and <= 4: " + count);
+		require(count);
+		position += count;
+		for (int i = count - 1; i >= 0; i--) {
+			byteBuffer.put((byte) (bytes >> (i << 3)));
+		}
+	}
+
 	public void writeLong (long bytes, int count) {
 		if (count < 0 || count > 8) throw new IllegalArgumentException("count must be >= 0 and <= 8: " + count);
 		require(count);

--- a/src/com/esotericsoftware/kryo/io/ByteBufferOutput.java
+++ b/src/com/esotericsoftware/kryo/io/ByteBufferOutput.java
@@ -276,6 +276,14 @@ public class ByteBufferOutput extends Output {
 		}
 	}
 
+	public void writeBytesFromLong (long bytes, int count) {
+		require(count);
+		position += count;
+		for (int i = count - 1; i >= 0; i--) {
+			byteBuffer.put((byte) (bytes >> (i << 3)));
+		}
+	}
+
 	// int:
 
 	public void writeInt (int value) throws KryoException {

--- a/src/com/esotericsoftware/kryo/io/ByteBufferOutput.java
+++ b/src/com/esotericsoftware/kryo/io/ByteBufferOutput.java
@@ -276,7 +276,8 @@ public class ByteBufferOutput extends Output {
 		}
 	}
 
-	public void writeBytesFromLong (long bytes, int count) {
+	public void writeLong (long bytes, int count) {
+		if (count < 0 || count > 8) throw new IllegalArgumentException("count must be >= 0 and <= 8: " + count);
 		require(count);
 		position += count;
 		for (int i = count - 1; i >= 0; i--) {

--- a/src/com/esotericsoftware/kryo/io/Input.java
+++ b/src/com/esotericsoftware/kryo/io/Input.java
@@ -374,7 +374,8 @@ public class Input extends InputStream implements Poolable {
 	}
 
 	/** Reads count bytes and returns them as long, the last byte read will be the lowest byte in the long. */
-	public long readBytesAsLong (int count) {
+	public long readLong (int count) {
+		if (count < 0 || count > 8) throw new IllegalArgumentException("count must be >= 0 and <= 8: " + count);
 		require(count);
 		int p = position;
 		position = p + count;

--- a/src/com/esotericsoftware/kryo/io/Input.java
+++ b/src/com/esotericsoftware/kryo/io/Input.java
@@ -373,6 +373,19 @@ public class Input extends InputStream implements Poolable {
 		}
 	}
 
+	/** Reads count bytes and returns them as int, the last byte read will be the lowest byte in the int. */
+	public int readInt (int count) {
+		if (count < 0 || count > 4) throw new IllegalArgumentException("count must be >= 0 and <= 4: " + count);
+		require(count);
+		int p = position;
+		position = p + count;
+		int bytes = buffer[p++];
+		for (int i = 1; i < count; i++) {
+			bytes = (bytes << 8) | (buffer[p++] & 0xFF);
+		}
+		return bytes;
+	}
+
 	/** Reads count bytes and returns them as long, the last byte read will be the lowest byte in the long. */
 	public long readLong (int count) {
 		if (count < 0 || count > 8) throw new IllegalArgumentException("count must be >= 0 and <= 8: " + count);

--- a/src/com/esotericsoftware/kryo/io/Input.java
+++ b/src/com/esotericsoftware/kryo/io/Input.java
@@ -373,6 +373,18 @@ public class Input extends InputStream implements Poolable {
 		}
 	}
 
+	/** Reads count bytes and returns them as long, the last byte read will be the lowest byte in the long. */
+	public long readBytesAsLong (int count) {
+		require(count);
+		int p = position;
+		position = p + count;
+		long bytes = buffer[p++];
+		for (int i = 1; i < count; i++) {
+			bytes = (bytes << 8) | (buffer[p++] & 0xFF);
+		}
+		return bytes;
+	}
+
 	// int:
 
 	/** Reads a 4 byte int. */

--- a/src/com/esotericsoftware/kryo/io/Output.java
+++ b/src/com/esotericsoftware/kryo/io/Output.java
@@ -275,6 +275,18 @@ public class Output extends OutputStream implements AutoCloseable, Poolable {
 
 	/** Writes count bytes from long, the last byte written is the lowest byte from the long.
 	 *  Note the number of bytes is not written. */
+	public void writeInt (int bytes, int count) {
+		if (count < 0 || count > 4) throw new IllegalArgumentException("count must be >= 0 and <= 4: " + count);
+		require(count);
+		int p = position;
+		position = p + count;
+		for (int i = count - 1; i >= 0; i--) {
+			buffer[p++] = (byte) (bytes >> (i << 3));
+		}
+	}
+
+	/** Writes count bytes from long, the last byte written is the lowest byte from the long.
+	 *  Note the number of bytes is not written. */
 	public void writeLong (long bytes, int count) {
 		if (count < 0 || count > 8) throw new IllegalArgumentException("count must be >= 0 and <= 8: " + count);
 		require(count);

--- a/src/com/esotericsoftware/kryo/io/Output.java
+++ b/src/com/esotericsoftware/kryo/io/Output.java
@@ -275,7 +275,8 @@ public class Output extends OutputStream implements AutoCloseable, Poolable {
 
 	/** Writes count bytes from long, the last byte written is the lowest byte from the long.
 	 *  Note the number of bytes is not written. */
-	public void writeBytesFromLong (long bytes, int count) {
+	public void writeLong (long bytes, int count) {
+		if (count < 0 || count > 8) throw new IllegalArgumentException("count must be >= 0 and <= 8: " + count);
 		require(count);
 		int p = position;
 		position = p + count;

--- a/src/com/esotericsoftware/kryo/io/Output.java
+++ b/src/com/esotericsoftware/kryo/io/Output.java
@@ -20,7 +20,6 @@
 package com.esotericsoftware.kryo.io;
 
 import com.esotericsoftware.kryo.KryoException;
-import com.esotericsoftware.kryo.io.KryoBufferOverflowException;
 import com.esotericsoftware.kryo.util.Pool.Poolable;
 import com.esotericsoftware.kryo.util.Util;
 
@@ -271,6 +270,17 @@ public class Output extends OutputStream implements AutoCloseable, Poolable {
 			offset += copyCount;
 			copyCount = Math.min(Math.max(capacity, 1), count);
 			require(copyCount);
+		}
+	}
+
+	/** Writes count bytes from long, the last byte written is the lowest byte from the long.
+	 *  Note the number of bytes is not written. */
+	public void writeBytesFromLong (long bytes, int count) {
+		require(count);
+		int p = position;
+		position = p + count;
+		for (int i = count - 1; i >= 0; i--) {
+			buffer[p++] = (byte) (bytes >> (i << 3));
 		}
 	}
 

--- a/src/com/esotericsoftware/kryo/io/Output.java
+++ b/src/com/esotericsoftware/kryo/io/Output.java
@@ -280,8 +280,25 @@ public class Output extends OutputStream implements AutoCloseable, Poolable {
 		require(count);
 		int p = position;
 		position = p + count;
-		for (int i = count - 1; i >= 0; i--) {
-			buffer[p++] = (byte) (bytes >> (i << 3));
+		switch (count) {
+			case 1:
+				buffer[p] = (byte)bytes;
+				break;
+			case 2:
+				buffer[p] = (byte)(bytes >> 8);
+				buffer[p+1] = (byte)bytes;
+				break;
+			case 3:
+				buffer[p] = (byte)(bytes >> 16);
+				buffer[p+1] = (byte)(bytes >> 8);
+				buffer[p+2] = (byte)bytes;
+				break;
+			case 4:
+				buffer[p] = (byte)(bytes >> 24);
+				buffer[p+1] = (byte)(bytes >> 16);
+				buffer[p+2] = (byte)(bytes >> 8);
+				buffer[p+3] = (byte)bytes;
+				break;
 		}
 	}
 
@@ -289,11 +306,12 @@ public class Output extends OutputStream implements AutoCloseable, Poolable {
 	 *  Note the number of bytes is not written. */
 	public void writeLong (long bytes, int count) {
 		if (count < 0 || count > 8) throw new IllegalArgumentException("count must be >= 0 and <= 8: " + count);
-		require(count);
-		int p = position;
-		position = p + count;
-		for (int i = count - 1; i >= 0; i--) {
-			buffer[p++] = (byte) (bytes >> (i << 3));
+		if (count <= 4) {
+			writeInt((int) bytes, count);
+		} else {
+			require(count);
+			writeInt((int) (bytes >> 32), count - 4);
+			writeInt((int) bytes, 4);
 		}
 	}
 

--- a/src/com/esotericsoftware/kryo/serializers/DefaultSerializers.java
+++ b/src/com/esotericsoftware/kryo/serializers/DefaultSerializers.java
@@ -291,7 +291,7 @@ public class DefaultSerializers {
 			int length = (significantBits + (8 - 1)) >> 3; // how many bytes are needed (rounded up)
 
 			output.writeByte(length + 1);
-			output.writeBytesFromLong(unscaledLong, length);
+			output.writeLong(unscaledLong, length);
 		}
 
 		public BigDecimal read (Kryo kryo, Input input, Class<? extends BigDecimal> type) {
@@ -306,7 +306,7 @@ public class DefaultSerializers {
 				byte[] bytes = input.readBytes(length);
 				unscaledBig = new BigInteger(bytes);
 			} else {
-				unscaledLong = input.readBytesAsLong(length);
+				unscaledLong = input.readLong(length);
 			}
 
 			int scale = input.readInt(false);

--- a/test/com/esotericsoftware/kryo/io/InputOutputTest.java
+++ b/test/com/esotericsoftware/kryo/io/InputOutputTest.java
@@ -348,6 +348,25 @@ class InputOutputTest extends KryoTestCase {
 		write.writeInt(-268435455);
 		write.writeInt(-134217728);
 		write.writeInt(-268435456);
+		write.writeInt(0, 1);
+		write.writeInt(63, 1);
+		write.writeInt(64, 1);
+		write.writeInt(127, 1);
+		write.writeInt(128, 2);
+		write.writeInt(8192, 2);
+		write.writeInt(16384, 2);
+		write.writeInt(2097151, 3);
+		write.writeInt(1048575, 3);
+		write.writeInt(134217727, 4);
+		write.writeInt(268435455, 4);
+		write.writeInt(134217728, 4);
+		write.writeInt(268435456, 4);
+		write.writeInt(-2097151, 3);
+		write.writeInt(-1048575, 3);
+		write.writeInt(-134217727, 4);
+		write.writeInt(-268435455, 4);
+		write.writeInt(-134217728, 4);
+		write.writeInt(-268435456, 4);
 		assertEquals(1, write.writeVarInt(0, true));
 		assertEquals(1, write.writeVarInt(0, false));
 		assertEquals(1, write.writeVarInt(63, true));
@@ -417,6 +436,25 @@ class InputOutputTest extends KryoTestCase {
 		assertEquals(-268435455, read.readInt());
 		assertEquals(-134217728, read.readInt());
 		assertEquals(-268435456, read.readInt());
+		assertEquals(0, read.readInt(1));
+		assertEquals(63, read.readInt(1));
+		assertEquals(64, read.readInt(1));
+		assertEquals(127, read.readInt(1));
+		assertEquals(128, read.readInt(2));
+		assertEquals(8192, read.readInt(2));
+		assertEquals(16384, read.readInt(2));
+		assertEquals(2097151, read.readInt(3));
+		assertEquals(1048575, read.readInt(3));
+		assertEquals(134217727, read.readInt(4));
+		assertEquals(268435455, read.readInt(4));
+		assertEquals(134217728, read.readInt(4));
+		assertEquals(268435456, read.readInt(4));
+		assertEquals(-2097151, read.readInt(3));
+		assertEquals(-1048575, read.readInt(3));
+		assertEquals(-134217727, read.readInt(4));
+		assertEquals(-268435455, read.readInt(4));
+		assertEquals(-134217728, read.readInt(4));
+		assertEquals(-268435456, read.readInt(4));
 		assertTrue(read.canReadVarInt());
 		assertTrue(read.canReadVarInt());
 		assertTrue(read.canReadVarInt());
@@ -477,11 +515,15 @@ class InputOutputTest extends KryoTestCase {
 			write.writeInt(value);
 			write.writeVarInt(value, true);
 			write.writeVarInt(value, false);
+			int numOfBytes = (i % 4) + 1;
+			write.writeInt(value, numOfBytes);
 
 			read.setBuffer(write.toBytes());
 			assertEquals(value, read.readInt());
 			assertEquals(value, read.readVarInt(true));
 			assertEquals(value, read.readVarInt(false));
+			int numOfBytesMask = numOfBytes == 4 ? -1 : (1 << numOfBytes * 8) - 1;
+			assertEquals(value & numOfBytesMask, read.readInt(numOfBytes) & numOfBytesMask);
 		}
 	}
 

--- a/test/com/esotericsoftware/kryo/io/InputOutputTest.java
+++ b/test/com/esotericsoftware/kryo/io/InputOutputTest.java
@@ -511,6 +511,25 @@ class InputOutputTest extends KryoTestCase {
 		write.writeLong(-268435455);
 		write.writeLong(-134217728);
 		write.writeLong(-268435456);
+		write.writeLong(0, 1);
+		write.writeLong(63, 1);
+		write.writeLong(64, 1);
+		write.writeLong(127, 1);
+		write.writeLong(128, 2);
+		write.writeLong(8192, 2);
+		write.writeLong(16384, 2);
+		write.writeLong(2097151, 3);
+		write.writeLong(1048575, 3);
+		write.writeLong(134217727, 4);
+		write.writeLong(268435455, 4);
+		write.writeLong(134217728, 4);
+		write.writeLong(268435456, 4);
+		write.writeLong(-2097151, 3);
+		write.writeLong(-1048575, 3);
+		write.writeLong(-134217727, 4);
+		write.writeLong(-268435455, 4);
+		write.writeLong(-134217728, 4);
+		write.writeLong(-268435456, 4);
 		assertEquals(1, write.writeVarLong(0, true));
 		assertEquals(1, write.writeVarLong(0, false));
 		assertEquals(1, write.writeVarLong(63, true));
@@ -574,6 +593,25 @@ class InputOutputTest extends KryoTestCase {
 		assertEquals(-268435455, read.readLong());
 		assertEquals(-134217728, read.readLong());
 		assertEquals(-268435456, read.readLong());
+		assertEquals(0, read.readLong(1));
+		assertEquals(63, read.readLong(1));
+		assertEquals(64, read.readLong(1));
+		assertEquals(127, read.readLong(1));
+		assertEquals(128, read.readLong(2));
+		assertEquals(8192, read.readLong(2));
+		assertEquals(16384, read.readLong(2));
+		assertEquals(2097151, read.readLong(3));
+		assertEquals(1048575, read.readLong(3));
+		assertEquals(134217727, read.readLong(4));
+		assertEquals(268435455, read.readLong(4));
+		assertEquals(134217728, read.readLong(4));
+		assertEquals(268435456, read.readLong(4));
+		assertEquals(-2097151, read.readLong(3));
+		assertEquals(-1048575, read.readLong(3));
+		assertEquals(-134217727, read.readLong(4));
+		assertEquals(-268435455, read.readLong(4));
+		assertEquals(-134217728, read.readLong(4));
+		assertEquals(-268435456, read.readLong(4));
 		assertEquals(0, read.readVarLong(true));
 		assertEquals(0, read.readVarLong(false));
 		assertEquals(63, read.readVarLong(true));
@@ -624,11 +662,15 @@ class InputOutputTest extends KryoTestCase {
 			write.writeLong(value);
 			write.writeVarLong(value, true);
 			write.writeVarLong(value, false);
+			int numOfBytes = (i % 8) + 1;
+			write.writeLong(value, numOfBytes);
 
 			read.setBuffer(write.toBytes());
 			assertEquals(value, read.readLong());
 			assertEquals(value, read.readVarLong(true));
 			assertEquals(value, read.readVarLong(false));
+			long numOfBytesMask = numOfBytes == 8 ? -1 : (1L << numOfBytes * 8) - 1;
+			assertEquals(value & numOfBytesMask, read.readLong(numOfBytes) & numOfBytesMask);
 		}
 	}
 


### PR DESCRIPTION
This is a continuation of #1014 and alternative to #1015. Same as #1015 it avoids allocation, but additionally new methods were added to the Input/Output:
- `Output.writeBytesFromLong(long bytes, int count)`
- `Input.readBytesAsLong(int count)`
Those methods write/read specified number of bytes using a `long` value as storage for bytes instead of `byte[]` array, to avoid allocation of the array on the heap. Additionally they properly `require()` necessary number of bytes in the buffer.

Thanks to those changes, the `BigDecimalSerializer` is even faster (mostly) than the version from #1015:
![avoid-allocation-option-B-vs-A](https://github.com/EsotericSoftware/kryo/assets/4157004/afde57e0-3142-4700-872e-d9be98d4028b)

Of course it's thus also faster (completely) than the code in the master branch:
![avoid-allocation-option-B](https://github.com/EsotericSoftware/kryo/assets/4157004/f659ed04-1b22-4c10-8834-dcd7d8a2d121)

Any suggestions for the method names (and the code) are welcome, and if this change is too intrusive I'm also happy with only the #1015 being merged.