### PR TITLE
Remove unnecessary comma in the link to the closure blog post

### DIFF
--- a/README.md
+++ b/README.md
@@ -639,7 +639,7 @@ Input input = new Input(output.getBuffer(), 0, output.position());
 Callable<Integer> closure2 = (Callable<Integer>)kryo.readObject(input, ClosureSerializer.Closure.class);
 ```
 
-Serializing closures which do not implement Serializable is possible [with some effort](https://ruediste.github.io/java,/kryo/2017/05/07/serializing-non-serializable-lambdas.html).
+Serializing closures which do not implement Serializable is possible [with some effort](https://ruediste.github.io/java/kryo/2017/05/07/serializing-non-serializable-lambdas.html).
 
 ### Compression and encryption
 


### PR DESCRIPTION
The link to the blog post about serialising closures that do not implement `Serializable` has an extra comma in the link, leading to a 404 when you click on it. Due to this being a quite trivial no-code PR I have skipped creating an issue, hope that this is okay.