### PR TITLE
Add better feedback when using abstract classes in serialization

### DIFF
--- a/src/com/esotericsoftware/kryo/Kryo.java
+++ b/src/com/esotericsoftware/kryo/Kryo.java
@@ -765,6 +765,7 @@ public class Kryo {
 	public <T> T readObject (Input input, Class<T> type) {
 		if (input == null) throw new IllegalArgumentException("input cannot be null.");
 		if (type == null) throw new IllegalArgumentException("type cannot be null.");
+		if (Modifier.isAbstract(type.getModifiers())) throw new IllegalArgumentException("type cannot be an abstract class.");
 		beginObject();
 		try {
 			T object;
@@ -787,6 +788,7 @@ public class Kryo {
 		if (input == null) throw new IllegalArgumentException("input cannot be null.");
 		if (type == null) throw new IllegalArgumentException("type cannot be null.");
 		if (serializer == null) throw new IllegalArgumentException("serializer cannot be null.");
+		if (Modifier.isAbstract(type.getModifiers())) throw new IllegalArgumentException("type cannot be an abstract class.");
 		beginObject();
 		try {
 			T object;
@@ -809,6 +811,7 @@ public class Kryo {
 	public <T> T readObjectOrNull (Input input, Class<T> type) {
 		if (input == null) throw new IllegalArgumentException("input cannot be null.");
 		if (type == null) throw new IllegalArgumentException("type cannot be null.");
+		if (Modifier.isAbstract(type.getModifiers())) throw new IllegalArgumentException("type cannot be an abstract class.");
 		beginObject();
 		try {
 			T object;


### PR DESCRIPTION
This should improve the feedback given to the user when supplying an abstract class to deserialise Objects.

Closes #857