### PR TITLE
Add ConcurrentHashMap.KeySetView serializer

### DIFF
--- a/src/com/esotericsoftware/kryo/serializers/DefaultSerializers.java
+++ b/src/com/esotericsoftware/kryo/serializers/DefaultSerializers.java
@@ -855,18 +855,18 @@ public class DefaultSerializers {
 
 	/** Serializer for {@link ConcurrentHashMap.KeySetView}.
 	 * @author Andreas Bergander */
-	public static class KeySetViewSerializer extends CollectionSerializer<ConcurrentHashMap.KeySetView> {
-		protected void writeHeader (Kryo kryo, Output output, ConcurrentHashMap.KeySetView set) {
+	public static class KeySetViewSerializer extends Serializer<ConcurrentHashMap.KeySetView> {
+		public void write (Kryo kryo, Output output, ConcurrentHashMap.KeySetView set) {
 			kryo.writeClassAndObject(output, set.getMap());
 			kryo.writeClassAndObject(output, set.getMappedValue());
 		}
 
-		protected ConcurrentHashMap.KeySetView create (Kryo kryo, Input input, Class<? extends ConcurrentHashMap.KeySetView> type, int size) {
+		public ConcurrentHashMap.KeySetView read (Kryo kryo, Input input, Class<? extends ConcurrentHashMap.KeySetView> type) {
 			return createKeySetView((ConcurrentHashMap)kryo.readClassAndObject(input), kryo.readClassAndObject(input));
 		}
 
-		protected ConcurrentHashMap.KeySetView createCopy (Kryo kryo, ConcurrentHashMap.KeySetView original) {
-			return createKeySetView(original.getMap(), original.getMappedValue());
+		public ConcurrentHashMap.KeySetView copy (Kryo kryo, ConcurrentHashMap.KeySetView original) {
+			return createKeySetView(kryo.copy(original.getMap()), kryo.copy(original.getMappedValue()));
 		}
 
 		private ConcurrentHashMap.KeySetView createKeySetView (ConcurrentHashMap map, Object mappedValue) {

--- a/src/com/esotericsoftware/kryo/serializers/DefaultSerializers.java
+++ b/src/com/esotericsoftware/kryo/serializers/DefaultSerializers.java
@@ -62,6 +62,7 @@ import java.util.TimeZone;
 import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -849,6 +850,27 @@ public class DefaultSerializers {
 			} catch (Exception ex) {
 				throw new KryoException(ex);
 			}
+		}
+	}
+
+	/** Serializer for {@link ConcurrentHashMap.KeySetView}.
+	 * @author Andreas Bergander */
+	public static class KeySetViewSerializer extends CollectionSerializer<ConcurrentHashMap.KeySetView> {
+		protected void writeHeader (Kryo kryo, Output output, ConcurrentHashMap.KeySetView set) {
+			kryo.writeClassAndObject(output, set.getMap());
+			kryo.writeClassAndObject(output, set.getMappedValue());
+		}
+
+		protected ConcurrentHashMap.KeySetView create (Kryo kryo, Input input, Class<? extends ConcurrentHashMap.KeySetView> type, int size) {
+			return createKeySetView((ConcurrentHashMap)kryo.readClassAndObject(input), kryo.readClassAndObject(input));
+		}
+
+		protected ConcurrentHashMap.KeySetView createCopy (Kryo kryo, ConcurrentHashMap.KeySetView original) {
+			return createKeySetView(original.getMap(), original.getMappedValue());
+		}
+
+		private ConcurrentHashMap.KeySetView createKeySetView (ConcurrentHashMap map, Object mappedValue) {
+			return map.keySet(mappedValue);
 		}
 	}
 

--- a/test/com/esotericsoftware/kryo/serializers/DefaultSerializersTest.java
+++ b/test/com/esotericsoftware/kryo/serializers/DefaultSerializersTest.java
@@ -460,7 +460,7 @@ class DefaultSerializersTest extends KryoTestCase {
 		set.add(12);
 		kryo.register(ConcurrentHashMap.KeySetView.class, new KeySetViewSerializer());
 		kryo.register(ConcurrentHashMap.class);
-		roundTrip(13, set);
+		roundTrip(9, set);
 	}
 
 	@Test
@@ -474,7 +474,7 @@ class DefaultSerializersTest extends KryoTestCase {
 
 		kryo.register(ConcurrentHashMap.KeySetView.class, new KeySetViewSerializer());
 		kryo.register(ConcurrentHashMap.class);
-		roundTrip(22, set);
+		roundTrip(15, set);
 	}
 
 	@Test
@@ -482,7 +482,7 @@ class DefaultSerializersTest extends KryoTestCase {
 		ConcurrentHashMap.KeySetView set = ConcurrentHashMap.newKeySet();
 		kryo.register(ConcurrentHashMap.KeySetView.class, new KeySetViewSerializer());
 		kryo.register(ConcurrentHashMap.class);
-		roundTrip(6, set);
+		roundTrip(5, set);
 	}
 
 	@Test

--- a/test/com/esotericsoftware/kryo/serializers/DefaultSerializersTest.java
+++ b/test/com/esotericsoftware/kryo/serializers/DefaultSerializersTest.java
@@ -26,6 +26,7 @@ import com.esotericsoftware.kryo.KryoTestCase;
 import com.esotericsoftware.kryo.io.Input;
 import com.esotericsoftware.kryo.io.Output;
 import com.esotericsoftware.kryo.util.DefaultInstantiatorStrategy;
+import com.esotericsoftware.kryo.serializers.DefaultSerializers.KeySetViewSerializer;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -45,6 +46,7 @@ import java.util.Locale;
 import java.util.PriorityQueue;
 import java.util.TimeZone;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
@@ -246,7 +248,7 @@ class DefaultSerializersTest extends KryoTestCase {
 		roundTrip(11, newTimestamp(-1234567, 1));
 		roundTrip(14, newTimestamp(-1234567, 123_456_789));
 	}
-	
+
 	private java.sql.Timestamp newTimestamp(long time, int nanos) {
 		java.sql.Timestamp t = new java.sql.Timestamp(time);
 		t.setNanos(nanos);
@@ -453,6 +455,53 @@ class DefaultSerializersTest extends KryoTestCase {
 	}
 
 	@Test
+	void testConcurrentHashMapKeySetView () {
+		ConcurrentHashMap.KeySetView<Integer, Boolean> set = ConcurrentHashMap.newKeySet();
+		set.add(12);
+		kryo.register(ConcurrentHashMap.KeySetView.class, new KeySetViewSerializer());
+		kryo.register(ConcurrentHashMap.class);
+		roundTrip(13, set);
+	}
+
+	@Test
+	void testConcurrentHashMapKeySetViewFromExistingMap () {
+		ConcurrentHashMap<String, Integer> map = new ConcurrentHashMap<>();
+
+		map.put("1", 1);
+		map.put("2", 2);
+
+		ConcurrentHashMap.KeySetView<String, Integer> set = map.keySet(4);
+
+		kryo.register(ConcurrentHashMap.KeySetView.class, new KeySetViewSerializer());
+		kryo.register(ConcurrentHashMap.class);
+		roundTrip(22, set);
+	}
+
+	@Test
+	void testEmptyConcurrentHashMapKeySetView () {
+		ConcurrentHashMap.KeySetView set = ConcurrentHashMap.newKeySet();
+		kryo.register(ConcurrentHashMap.KeySetView.class, new KeySetViewSerializer());
+		kryo.register(ConcurrentHashMap.class);
+		roundTrip(6, set);
+	}
+
+	@Test
+	void testConcurrentHashMapKeySetViewCopy () {
+		ConcurrentHashMap<String, Integer> map = new ConcurrentHashMap<>();
+
+		map.put("1", 1);
+		map.put("2", 2);
+
+		ConcurrentHashMap.KeySetView<String, Integer> set = map.keySet(4);
+
+		kryo.register(ConcurrentHashMap.KeySetView.class, new KeySetViewSerializer());
+		kryo.register(ConcurrentHashMap.class);
+		ConcurrentHashMap.KeySetView<String, Integer> copy = kryo.copy(set);
+		assertEquals(set.iterator().next(), copy.iterator().next());
+		assertEquals(set.getMappedValue(), copy.getMappedValue());
+	}
+
+	@Test
 	void testCalendar () {
 		kryo.setRegistrationRequired(false);
 		Calendar calendar = Calendar.getInstance();
@@ -589,7 +638,7 @@ class DefaultSerializersTest extends KryoTestCase {
 	@Test
 	void testUUIDSerializer () {
 		kryo.register(UUID.class, new DefaultSerializers.UUIDSerializer());
-		
+
 		roundTrip(17, UUID.fromString("e58ed763-928c-4155-bee9-fdbaaadc15f3"));
 	}
 


### PR DESCRIPTION
This PR adds support for serializing sets created by `ConcurrentHashMap.newKeySet()`.