### PR TITLE
Fix nondeterministic behavior in testConcurrentHashMapKeySetViewCopy()

### DIFF
--- a/test/com/esotericsoftware/kryo/serializers/DefaultSerializersTest.java
+++ b/test/com/esotericsoftware/kryo/serializers/DefaultSerializersTest.java
@@ -497,7 +497,7 @@ class DefaultSerializersTest extends KryoTestCase {
 		kryo.register(ConcurrentHashMap.KeySetView.class, new KeySetViewSerializer());
 		kryo.register(ConcurrentHashMap.class);
 		ConcurrentHashMap.KeySetView<String, Integer> copy = kryo.copy(set);
-		assertEquals(set.iterator().next(), copy.iterator().next());
+		assertTrue(set.containsAll(copy) && copy.containsAll(set));
 		assertEquals(set.getMappedValue(), copy.getMappedValue());
 	}
 


### PR DESCRIPTION
## **What does this PR do?**  
This PR fixes a nondeterministic test failure in `DefaultSerializersTest.testConcurrentHashMapKeySetViewCopy()` within both the **`main`** and **`main-versioned`** modules when running with NonDex.


## **Problem**  
The nondeterminism arises from using `assertEquals(set.iterator().next(), copy.iterator().next())`, which depends on the iteration order of a `ConcurrentHashMap.KeySetView`.  
Since `ConcurrentHashMap` does not guarantee a stable iteration order, the first element returned by `iterator().next()` can vary between runs, causing the test to fail under NonDex.

## **Reproduce Test**  
To reproduce the failure, run NonDex on both the `main` and `main-versioned` modules using the following commands:

```bash
mvn -pl main edu.illinois:nondex-maven-plugin:2.2.1:nondex \
  -Dtest=com.esotericsoftware.kryo.serializers.DefaultSerializersTest#testConcurrentHashMapKeySetViewCopy
```

```bash
mvn -pl main-versioned edu.illinois:nondex-maven-plugin:2.2.1:nondex \
  -Dtest=com.esotericsoftware.kryo.serializers.DefaultSerializersTest#testConcurrentHashMapKeySetViewCopy
```


## **The Fix**  
Instead of comparing the first element returned by each iterator — which could differ due to the nondeterministic iteration order of `ConcurrentHashMap` — the test now verifies that both collections contain the same elements.  
This approach ensures logical equality without relying on iteration order, effectively confirming that both sets represent the same data regardless of internal ordering. 
