### PR TITLE
Refactor: replace generic RuntimeException with custom Serialization Exception

### DIFF
--- a/benchmarks/src/main/java/com/esotericsoftware/kryo/benchmarks/ConcurrencyBenchmark.java
+++ b/benchmarks/src/main/java/com/esotericsoftware/kryo/benchmarks/ConcurrencyBenchmark.java
@@ -141,7 +141,7 @@ public class ConcurrencyBenchmark {
 				output.flush();
 				return stream.toByteArray();
 			} catch (IOException e) {
-				throw new RuntimeException(e);
+				 throw new SerializationException("Error during serialization", e);
 			} finally {
 				output.reset();
 			}
@@ -184,4 +184,10 @@ public class ConcurrencyBenchmark {
 		new Runner(opt).run();
 
 	}
+}
+
+public class SerializationException extends RuntimeException {
+    public SerializationException(String message, Throwable cause) {
+        super(message, cause);
+    }
 }


### PR DESCRIPTION
Bug :
The AbstractConcurrencyState.serialize() method was throwing a generic RuntimeException when an IOException occurred during serialization. This made it difficult to identify the root cause and violated clean code and SonarCloud recommendations for using specific or custom exceptions.

To Reproduce
Run any Kryo serialization benchmark (e.g., ConcurrencyBenchmark).
Trigger an I/O failure during the serialize() process (e.g., invalid output stream).
Observe that the code throws a generic RuntimeException without meaningful context.

Expected behavior:
A meaningful, domain-specific exception should be thrown to clearly indicate that the failure occurred during serialization.