### PR TITLE
Update annotation names and project links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1052,8 +1052,8 @@ Annotations can be used to configure the serializers for each field.
 Annotation | Description
 --- | ---
 `@Bind` | Sets the CachedField settings for any field.
-`@CollectionBind` | Sets the CollectionSerializer settings for Collection fields.
-`@MapBind` | Sets the MapSerializer settings for Map fields.
+`@BindCollection` | Sets the CollectionSerializer settings for Collection fields.
+`@BindMap` | Sets the MapSerializer settings for Map fields.
 `@NotNull` | Marks a field as never being null.
 
 ```java
@@ -1293,7 +1293,7 @@ Kryo can be compared to many other serialization libraries in the [JVM Serialize
 
 There are a number of projects using Kryo. A few are listed below. Please submit a pull request if you'd like your project included here.
 
-- [KryoNet](http://code.google.com/p/kryonet/) (NIO networking)
+- [KryoNet](https://github.com/EsotericSoftware/kryonet) (NIO networking)
 - [kryo-serializers](https://github.com/magro/kryo-serializers) (additional serializers)
 - [Twitter's Scalding](https://github.com/twitter/scalding) (Scala API for Cascading)
 - [Twitter's Chill](https://github.com/twitter/chill) (Kryo serializers for Scala)


### PR DESCRIPTION
Corrected annotation name errors in the FieldSerializer annotations section, update the git address for the kryonet project.

https://github.com/EsotericSoftware/kryo/blob/08b9356a8ccd6fbbc294b4685afc6220fb5b3770/src/com/esotericsoftware/kryo/serializers/MapSerializer.java#L258
https://github.com/EsotericSoftware/kryo/blob/08b9356a8ccd6fbbc294b4685afc6220fb5b3770/src/com/esotericsoftware/kryo/serializers/CollectionSerializer.java#L270