### PR TITLE
Fix int overflow and ignored offset/count in UnsafeOutput and UnsafeByteBufferOutput

### DIFF
--- a/src/com/esotericsoftware/kryo/unsafe/UnsafeByteBufferOutput.java
+++ b/src/com/esotericsoftware/kryo/unsafe/UnsafeByteBufferOutput.java
@@ -185,47 +185,47 @@ public class UnsafeByteBufferOutput extends ByteBufferOutput {
 	}
 
 	public void writeInts (int[] array, int offset, int count) throws KryoException {
-		writeBytes(array, intArrayBaseOffset, array.length << 2);
+		writeBytes(array, intArrayBaseOffset + ((long)offset << 2), (long)count << 2);
 	}
 
 	public void writeLongs (long[] array, int offset, int count) throws KryoException {
-		writeBytes(array, longArrayBaseOffset, array.length << 3);
+		writeBytes(array, longArrayBaseOffset + ((long)offset << 3), (long)count << 3);
 	}
 
 	public void writeFloats (float[] array, int offset, int count) throws KryoException {
-		writeBytes(array, floatArrayBaseOffset, array.length << 2);
+		writeBytes(array, floatArrayBaseOffset + ((long)offset << 2), (long)count << 2);
 	}
 
 	public void writeDoubles (double[] array, int offset, int count) throws KryoException {
-		writeBytes(array, doubleArrayBaseOffset, array.length << 3);
+		writeBytes(array, doubleArrayBaseOffset + ((long)offset << 3), (long)count << 3);
 	}
 
 	public void writeShorts (short[] array, int offset, int count) throws KryoException {
-		writeBytes(array, shortArrayBaseOffset, array.length << 1);
+		writeBytes(array, shortArrayBaseOffset + ((long)offset << 1), (long)count << 1);
 	}
 
 	public void writeChars (char[] array, int offset, int count) throws KryoException {
-		writeBytes(array, charArrayBaseOffset, array.length << 1);
+		writeBytes(array, charArrayBaseOffset + ((long)offset << 1), (long)count << 1);
 	}
 
 	public void writeBooleans (boolean[] array, int offset, int count) throws KryoException {
-		writeBytes(array, booleanArrayBaseOffset, array.length);
+		writeBytes(array, booleanArrayBaseOffset + offset, count);
 	}
 
 	public void writeBytes (byte[] array, int offset, int count) throws KryoException {
-		writeBytes(array, byteArrayBaseOffset + offset, count);
+		writeBytes(array, byteArrayBaseOffset + offset, (long)count);
 	}
 
 	/** Write count bytes to the byte buffer, reading from the given offset inside the in-memory representation of the object. */
-	public void writeBytes (Object from, long offset, int count) throws KryoException {
-		int copyCount = Math.min(capacity - position, count);
+	public void writeBytes (Object from, long offset, long count) throws KryoException {
+		int copyCount = (int)Math.min(capacity - position, count);
 		while (true) {
 			unsafe.copyMemory(from, offset, null, bufferAddress + position, copyCount);
 			position += copyCount;
 			count -= copyCount;
 			if (count == 0) break;
 			offset += copyCount;
-			copyCount = Math.min(capacity, count);
+			copyCount = (int)Math.min(capacity, count);
 			require(copyCount);
 		}
 		setBufferPosition(byteBuffer, position);

--- a/src/com/esotericsoftware/kryo/unsafe/UnsafeOutput.java
+++ b/src/com/esotericsoftware/kryo/unsafe/UnsafeOutput.java
@@ -135,47 +135,47 @@ public class UnsafeOutput extends Output {
 	}
 
 	public void writeInts (int[] array, int offset, int count) throws KryoException {
-		writeBytes(array, intArrayBaseOffset, array.length << 2);
+		writeBytes(array, intArrayBaseOffset + ((long)offset << 2), (long)count << 2);
 	}
 
 	public void writeLongs (long[] array, int offset, int count) throws KryoException {
-		writeBytes(array, longArrayBaseOffset, array.length << 3);
+		writeBytes(array, longArrayBaseOffset + ((long)offset << 3), (long)count << 3);
 	}
 
 	public void writeFloats (float[] array, int offset, int count) throws KryoException {
-		writeBytes(array, floatArrayBaseOffset, array.length << 2);
+		writeBytes(array, floatArrayBaseOffset + ((long)offset << 2), (long)count << 2);
 	}
 
 	public void writeDoubles (double[] array, int offset, int count) throws KryoException {
-		writeBytes(array, doubleArrayBaseOffset, array.length << 3);
+		writeBytes(array, doubleArrayBaseOffset + ((long)offset << 3), (long)count << 3);
 	}
 
 	public void writeShorts (short[] array, int offset, int count) throws KryoException {
-		writeBytes(array, shortArrayBaseOffset, array.length << 1);
+		writeBytes(array, shortArrayBaseOffset + ((long)offset << 1), (long)count << 1);
 	}
 
 	public void writeChars (char[] array, int offset, int count) throws KryoException {
-		writeBytes(array, charArrayBaseOffset, array.length << 1);
+		writeBytes(array, charArrayBaseOffset + ((long)offset << 1), (long)count << 1);
 	}
 
 	public void writeBooleans (boolean[] array, int offset, int count) throws KryoException {
-		writeBytes(array, booleanArrayBaseOffset, array.length);
+		writeBytes(array, booleanArrayBaseOffset + offset, count);
 	}
 
 	public void writeBytes (byte[] array, int offset, int count) throws KryoException {
-		writeBytes(array, byteArrayBaseOffset + offset, count);
+		writeBytes(array, byteArrayBaseOffset + offset, (long)count);
 	}
 
 	/** Write count bytes to the byte buffer, reading from the given offset inside the in-memory representation of the object. */
-	public void writeBytes (Object from, long offset, int count) throws KryoException {
-		int copyCount = Math.min(capacity - position, count);
+	public void writeBytes (Object from, long offset, long count) throws KryoException {
+		int copyCount = (int)Math.min(capacity - position, count);
 		while (true) {
 			unsafe.copyMemory(from, offset, buffer, byteArrayBaseOffset + position, copyCount);
 			position += copyCount;
 			count -= copyCount;
 			if (count == 0) break;
 			offset += copyCount;
-			copyCount = Math.min(capacity, count);
+			copyCount = (int)Math.min(capacity, count);
 			require(copyCount);
 		}
 	}

--- a/test/com/esotericsoftware/kryo/io/UnsafeByteBufferInputOutputTest.java
+++ b/test/com/esotericsoftware/kryo/io/UnsafeByteBufferInputOutputTest.java
@@ -842,4 +842,68 @@ class UnsafeByteBufferInputOutputTest {
 		assertEquals(32767, read.readChar());
 		assertEquals(65535, read.readChar());
 	}
+
+	// Verifies that bulk array writes honor the offset and count parameters (issue #1270 / PR #1270).
+	// Before the fix, UnsafeByteBufferOutput.writeInts/Longs/Floats/Doubles/Shorts/Chars/Booleans ignored
+	// offset and count and always wrote the entire array.
+	@Test
+	void testWriteArrayOffsetAndCount () {
+		int offset = 2, count = 5;
+
+		int[] ints = {10, 11, 12, 13, 14, 15, 16, 17, 18, 19};
+		UnsafeByteBufferOutput out = new UnsafeByteBufferOutput(4096);
+		out.writeInts(ints, offset, count);
+		assertEquals(count * 4L, out.total(), "writeInts wrote wrong number of bytes");
+		int[] expectedInts = new int[count];
+		System.arraycopy(ints, offset, expectedInts, 0, count);
+		assertArrayEquals(expectedInts, new UnsafeByteBufferInput(out.toBytes()).readInts(count));
+
+		long[] longs = {10L, 11L, 12L, 13L, 14L, 15L, 16L, 17L, 18L, 19L};
+		out = new UnsafeByteBufferOutput(4096);
+		out.writeLongs(longs, offset, count);
+		assertEquals(count * 8L, out.total(), "writeLongs wrote wrong number of bytes");
+		long[] expectedLongs = new long[count];
+		System.arraycopy(longs, offset, expectedLongs, 0, count);
+		assertArrayEquals(expectedLongs, new UnsafeByteBufferInput(out.toBytes()).readLongs(count));
+
+		float[] floats = {0f, 1.5f, 2.5f, 3.5f, 4.5f, 5.5f, 6.5f, 7.5f, 8.5f, 9.5f};
+		out = new UnsafeByteBufferOutput(4096);
+		out.writeFloats(floats, offset, count);
+		assertEquals(count * 4L, out.total(), "writeFloats wrote wrong number of bytes");
+		float[] expectedFloats = new float[count];
+		System.arraycopy(floats, offset, expectedFloats, 0, count);
+		assertArrayEquals(expectedFloats, new UnsafeByteBufferInput(out.toBytes()).readFloats(count));
+
+		double[] doubles = {0d, 1.5d, 2.5d, 3.5d, 4.5d, 5.5d, 6.5d, 7.5d, 8.5d, 9.5d};
+		out = new UnsafeByteBufferOutput(4096);
+		out.writeDoubles(doubles, offset, count);
+		assertEquals(count * 8L, out.total(), "writeDoubles wrote wrong number of bytes");
+		double[] expectedDoubles = new double[count];
+		System.arraycopy(doubles, offset, expectedDoubles, 0, count);
+		assertArrayEquals(expectedDoubles, new UnsafeByteBufferInput(out.toBytes()).readDoubles(count));
+
+		short[] shorts = {10, 11, 12, 13, 14, 15, 16, 17, 18, 19};
+		out = new UnsafeByteBufferOutput(4096);
+		out.writeShorts(shorts, offset, count);
+		assertEquals(count * 2L, out.total(), "writeShorts wrote wrong number of bytes");
+		short[] expectedShorts = new short[count];
+		System.arraycopy(shorts, offset, expectedShorts, 0, count);
+		assertArrayEquals(expectedShorts, new UnsafeByteBufferInput(out.toBytes()).readShorts(count));
+
+		char[] chars = {'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j'};
+		out = new UnsafeByteBufferOutput(4096);
+		out.writeChars(chars, offset, count);
+		assertEquals(count * 2L, out.total(), "writeChars wrote wrong number of bytes");
+		char[] expectedChars = new char[count];
+		System.arraycopy(chars, offset, expectedChars, 0, count);
+		assertArrayEquals(expectedChars, new UnsafeByteBufferInput(out.toBytes()).readChars(count));
+
+		boolean[] booleans = {true, false, true, true, false, true, false, false, true, false};
+		out = new UnsafeByteBufferOutput(4096);
+		out.writeBooleans(booleans, offset, count);
+		assertEquals(count, out.total(), "writeBooleans wrote wrong number of bytes");
+		boolean[] expectedBooleans = new boolean[count];
+		System.arraycopy(booleans, offset, expectedBooleans, 0, count);
+		assertArrayEquals(expectedBooleans, new UnsafeByteBufferInput(out.toBytes()).readBooleans(count));
+	}
 }


### PR DESCRIPTION
## Summary

Both `UnsafeOutput` and `UnsafeByteBufferOutput` contain two bugs in their
six primitive-array bulk write methods.

### Bug 1 — Integer overflow → JVM crash

Byte count was computed by left-shifting `array.length` as a 32-bit `int`:

    writeBytes(array, longArrayBaseOffset, array.length << 3);

When `array.length` exceeds the type's overflow threshold the shift wraps to a
negative `int`. `writeBytes` widens it to a large positive `long` and passes it
to `unsafe.copyMemory()`, causing a fatal JVM crash.

This is reachable from `DefaultArraySerializers` without any custom code.

### Bug 2 — offset and count parameters silently ignored

All six methods accepted `offset` and `count` but always serialized the full
array from element 0, this behavior is altered from these method's safe counterparts.

## Fix

- Promote the shift operand to `long` before the shift so the byte count is
  computed correctly for large arrays.
- Change `writeBytes(Object, long, int count)` to accept `long count` so the
  corrected value is not truncated on the way in.
- Pass `offset` and `count` through to `writeBytes` in all six methods.

Applied identically to both `UnsafeOutput` and `UnsafeByteBufferOutput`.
The `unsafe.copyMemory()` call that provides the performance benefit is
untouched; the fix has no meaningful impact on throughput.