### PR TITLE
Fix for Issue #1282: Guard deserialization against unbounded allocation from declared sizes

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Kryo maintenance and development is sponsored by the [Gecko fund](https://geckof
 - [IO](#io)
    * [Output](#output)
    * [Input](#input)
+   * [Limiting deserialized size](#limiting-deserialized-size)
    * [ByteBuffers](#bytebuffers)
    * [Unsafe buffers](#unsafe-buffers)
    * [Variable length encoding](#variable-length-encoding)
@@ -225,6 +226,21 @@ The Input class is an InputStream that reads data from a byte array buffer. This
 If the Input `close` is called, the Input's InputStream is closed, if any. If not reading from an InputStream then it is not necessary to call `close`. Unlike many streams, an Input instance can be reused by setting the position and limit, or setting a new byte array or InputStream.
 
 The zero argument Input constructor creates an uninitialized Input. Input `setBuffer` must be called before the Input can be used.
+
+### Limiting deserialized size
+
+When reading an array, string, collection, or map, Kryo first reads a declared size and uses it to allocate before reading any elements. A corrupt or malicious message can declare a size of billions, triggering a large allocation from only a few bytes.
+
+For an Input backed by a byte array (no InputStream), this is guarded automatically: the declared size cannot exceed the bytes remaining, since every element occupies at least one byte, so an impossible size is rejected with a `KryoException` before allocating. No configuration is needed and valid input is never affected.
+
+An Input reading from an InputStream cannot be checked this way, because the buffered window is not the total size. For that case, `setMaxArraySize` bounds the declared size:
+
+```java
+Input input = new Input(inputStream);
+input.setMaxArraySize(1024 * 1024); // reject any declared array/string/collection/map size above 1M elements
+```
+
+The default is `Integer.MAX_VALUE`, ie no limit, so by default behavior is unchanged and Kryo's trusted-source assumption is preserved: a valid payload never declares more elements than the input can supply, so the limit never fires on valid input. A declared size above the limit throws a `KryoException` before allocating. Callers that decode untrusted input, especially from a stream, should set a limit suited to their application.
 
 ### ByteBuffers
 

--- a/benchmarks/src/main/java/com/esotericsoftware/kryo/benchmarks/io/ArrayBenchmark.java
+++ b/benchmarks/src/main/java/com/esotericsoftware/kryo/benchmarks/io/ArrayBenchmark.java
@@ -77,6 +77,18 @@ public class ArrayBenchmark {
 		state.input.readLongs(state.longs.length, true);
 	}
 
+	@Benchmark
+	public void writeDoubles (WriteDoublesState state) {
+		state.reset();
+		state.output.writeDoubles(state.doubles, 0, state.doubles.length);
+	}
+
+	@Benchmark
+	public void readDoubles (ReadDoublesState state) {
+		state.reset();
+		state.input.readDoubles(state.doubles.length);
+	}
+
 	//
 
 	@State(Scope.Thread)
@@ -109,6 +121,20 @@ public class ArrayBenchmark {
 		public void setup () {
 			super.setup();
 			new ArrayBenchmark().writeLongs(this);
+		}
+	}
+
+	@State(Scope.Thread)
+	static public class WriteDoublesState extends InputOutputState {
+		public double[] doubles = {0, 1, 2, 3, 4, 5, 63, 64, 65, 127, 128, 129, 4000, 5000, 6000, 16000, 32000, 256000, 1024000,
+			-1, -2, -3, -4, Double.MIN_VALUE, Double.MAX_VALUE, 0.5, -0.5, 3.14159};
+	}
+
+	@State(Scope.Thread)
+	static public class ReadDoublesState extends WriteDoublesState {
+		public void setup () {
+			super.setup();
+			new ArrayBenchmark().writeDoubles(this);
 		}
 	}
 }

--- a/src/com/esotericsoftware/kryo/io/ByteBufferInput.java
+++ b/src/com/esotericsoftware/kryo/io/ByteBufferInput.java
@@ -333,7 +333,7 @@ public class ByteBufferInput extends Input {
 	}
 
 	public byte[] readBytes (int length) throws KryoException {
-		byte[] bytes = new byte[length];
+		byte[] bytes = new byte[validateArrayLength(length)];
 		readBytes(bytes, 0, length);
 		return bytes;
 	}
@@ -858,7 +858,7 @@ public class ByteBufferInput extends Input {
 	// Primitive arrays:
 
 	public int[] readInts (int length) throws KryoException {
-		int[] array = new int[length];
+		int[] array = new int[validateArrayLength(length)];
 		if (optional(length << 2) == length << 2) {
 			ByteBuffer byteBuffer = this.byteBuffer;
 			for (int i = 0; i < length; i++) {
@@ -876,7 +876,7 @@ public class ByteBufferInput extends Input {
 	}
 
 	public long[] readLongs (int length) throws KryoException {
-		long[] array = new long[length];
+		long[] array = new long[validateArrayLength(length)];
 		if (optional(length << 3) == length << 3) {
 			ByteBuffer byteBuffer = this.byteBuffer;
 			for (int i = 0; i < length; i++) {
@@ -898,7 +898,7 @@ public class ByteBufferInput extends Input {
 	}
 
 	public float[] readFloats (int length) throws KryoException {
-		float[] array = new float[length];
+		float[] array = new float[validateArrayLength(length)];
 		if (optional(length << 2) == length << 2) {
 			ByteBuffer byteBuffer = this.byteBuffer;
 			for (int i = 0; i < length; i++) {
@@ -916,7 +916,7 @@ public class ByteBufferInput extends Input {
 	}
 
 	public double[] readDoubles (int length) throws KryoException {
-		double[] array = new double[length];
+		double[] array = new double[validateArrayLength(length)];
 		if (optional(length << 3) == length << 3) {
 			ByteBuffer byteBuffer = this.byteBuffer;
 			for (int i = 0; i < length; i++) {
@@ -938,7 +938,7 @@ public class ByteBufferInput extends Input {
 	}
 
 	public short[] readShorts (int length) throws KryoException {
-		short[] array = new short[length];
+		short[] array = new short[validateArrayLength(length)];
 		if (optional(length << 1) == length << 1) {
 			ByteBuffer byteBuffer = this.byteBuffer;
 			for (int i = 0; i < length; i++)
@@ -952,7 +952,7 @@ public class ByteBufferInput extends Input {
 	}
 
 	public char[] readChars (int length) throws KryoException {
-		char[] array = new char[length];
+		char[] array = new char[validateArrayLength(length)];
 		if (optional(length << 1) == length << 1) {
 			ByteBuffer byteBuffer = this.byteBuffer;
 			for (int i = 0; i < length; i++)
@@ -966,7 +966,7 @@ public class ByteBufferInput extends Input {
 	}
 
 	public boolean[] readBooleans (int length) throws KryoException {
-		boolean[] array = new boolean[length];
+		boolean[] array = new boolean[validateArrayLength(length)];
 		if (optional(length) == length) {
 			ByteBuffer byteBuffer = this.byteBuffer;
 			for (int i = 0; i < length; i++)

--- a/src/com/esotericsoftware/kryo/io/ByteBufferInput.java
+++ b/src/com/esotericsoftware/kryo/io/ByteBufferInput.java
@@ -762,7 +762,7 @@ public class ByteBufferInput extends Input {
 	}
 
 	private void readUtf8Chars (int charCount) {
-		if (chars.length < charCount) chars = new char[charCount];
+		if (chars.length < charCount) chars = new char[validateArrayLength(charCount)];
 		char[] chars = this.chars;
 		// Try to read 7 bit ASCII chars.
 		ByteBuffer byteBuffer = this.byteBuffer;

--- a/src/com/esotericsoftware/kryo/io/ByteBufferInput.java
+++ b/src/com/esotericsoftware/kryo/io/ByteBufferInput.java
@@ -858,7 +858,7 @@ public class ByteBufferInput extends Input {
 	// Primitive arrays:
 
 	public int[] readInts (int length) throws KryoException {
-		int[] array = new int[validateArrayLength(length, 4)];
+		int[] array = new int[validateArrayLength(length, Integer.BYTES)];
 		if (optional(length << 2) == length << 2) {
 			ByteBuffer byteBuffer = this.byteBuffer;
 			for (int i = 0; i < length; i++) {
@@ -876,7 +876,7 @@ public class ByteBufferInput extends Input {
 	}
 
 	public long[] readLongs (int length) throws KryoException {
-		long[] array = new long[validateArrayLength(length, 8)];
+		long[] array = new long[validateArrayLength(length, Long.BYTES)];
 		if (optional(length << 3) == length << 3) {
 			ByteBuffer byteBuffer = this.byteBuffer;
 			for (int i = 0; i < length; i++) {
@@ -898,7 +898,7 @@ public class ByteBufferInput extends Input {
 	}
 
 	public float[] readFloats (int length) throws KryoException {
-		float[] array = new float[validateArrayLength(length, 4)];
+		float[] array = new float[validateArrayLength(length, Float.BYTES)];
 		if (optional(length << 2) == length << 2) {
 			ByteBuffer byteBuffer = this.byteBuffer;
 			for (int i = 0; i < length; i++) {
@@ -916,7 +916,7 @@ public class ByteBufferInput extends Input {
 	}
 
 	public double[] readDoubles (int length) throws KryoException {
-		double[] array = new double[validateArrayLength(length, 8)];
+		double[] array = new double[validateArrayLength(length, Double.BYTES)];
 		if (optional(length << 3) == length << 3) {
 			ByteBuffer byteBuffer = this.byteBuffer;
 			for (int i = 0; i < length; i++) {
@@ -938,7 +938,7 @@ public class ByteBufferInput extends Input {
 	}
 
 	public short[] readShorts (int length) throws KryoException {
-		short[] array = new short[validateArrayLength(length, 2)];
+		short[] array = new short[validateArrayLength(length, Short.BYTES)];
 		if (optional(length << 1) == length << 1) {
 			ByteBuffer byteBuffer = this.byteBuffer;
 			for (int i = 0; i < length; i++)
@@ -952,7 +952,7 @@ public class ByteBufferInput extends Input {
 	}
 
 	public char[] readChars (int length) throws KryoException {
-		char[] array = new char[validateArrayLength(length, 2)];
+		char[] array = new char[validateArrayLength(length, Character.BYTES)];
 		if (optional(length << 1) == length << 1) {
 			ByteBuffer byteBuffer = this.byteBuffer;
 			for (int i = 0; i < length; i++)

--- a/src/com/esotericsoftware/kryo/io/ByteBufferInput.java
+++ b/src/com/esotericsoftware/kryo/io/ByteBufferInput.java
@@ -859,7 +859,7 @@ public class ByteBufferInput extends Input {
 
 	public int[] readInts (int length) throws KryoException {
 		int[] array = new int[validateArrayLength(length, Integer.BYTES)];
-		if (optional(length << 2) == length << 2) {
+		if (optional(length * Integer.BYTES) == length * Integer.BYTES) {
 			ByteBuffer byteBuffer = this.byteBuffer;
 			for (int i = 0; i < length; i++) {
 				array[i] = byteBuffer.get() & 0xFF //
@@ -877,7 +877,7 @@ public class ByteBufferInput extends Input {
 
 	public long[] readLongs (int length) throws KryoException {
 		long[] array = new long[validateArrayLength(length, Long.BYTES)];
-		if (optional(length << 3) == length << 3) {
+		if (optional(length * Long.BYTES) == length * Long.BYTES) {
 			ByteBuffer byteBuffer = this.byteBuffer;
 			for (int i = 0; i < length; i++) {
 				array[i] = byteBuffer.get() & 0xFF//
@@ -899,7 +899,7 @@ public class ByteBufferInput extends Input {
 
 	public float[] readFloats (int length) throws KryoException {
 		float[] array = new float[validateArrayLength(length, Float.BYTES)];
-		if (optional(length << 2) == length << 2) {
+		if (optional(length * Float.BYTES) == length * Float.BYTES) {
 			ByteBuffer byteBuffer = this.byteBuffer;
 			for (int i = 0; i < length; i++) {
 				array[i] = Float.intBitsToFloat(byteBuffer.get() & 0xFF //
@@ -917,7 +917,7 @@ public class ByteBufferInput extends Input {
 
 	public double[] readDoubles (int length) throws KryoException {
 		double[] array = new double[validateArrayLength(length, Double.BYTES)];
-		if (optional(length << 3) == length << 3) {
+		if (optional(length * Double.BYTES) == length * Double.BYTES) {
 			ByteBuffer byteBuffer = this.byteBuffer;
 			for (int i = 0; i < length; i++) {
 				array[i] = Double.longBitsToDouble(byteBuffer.get() & 0xFF //
@@ -939,7 +939,7 @@ public class ByteBufferInput extends Input {
 
 	public short[] readShorts (int length) throws KryoException {
 		short[] array = new short[validateArrayLength(length, Short.BYTES)];
-		if (optional(length << 1) == length << 1) {
+		if (optional(length * Short.BYTES) == length * Short.BYTES) {
 			ByteBuffer byteBuffer = this.byteBuffer;
 			for (int i = 0; i < length; i++)
 				array[i] = (short)((byteBuffer.get() & 0xFF) | ((byteBuffer.get() & 0xFF) << 8));
@@ -953,7 +953,7 @@ public class ByteBufferInput extends Input {
 
 	public char[] readChars (int length) throws KryoException {
 		char[] array = new char[validateArrayLength(length, Character.BYTES)];
-		if (optional(length << 1) == length << 1) {
+		if (optional(length * Character.BYTES) == length * Character.BYTES) {
 			ByteBuffer byteBuffer = this.byteBuffer;
 			for (int i = 0; i < length; i++)
 				array[i] = (char)((byteBuffer.get() & 0xFF) | ((byteBuffer.get() & 0xFF) << 8));

--- a/src/com/esotericsoftware/kryo/io/ByteBufferInput.java
+++ b/src/com/esotericsoftware/kryo/io/ByteBufferInput.java
@@ -858,7 +858,7 @@ public class ByteBufferInput extends Input {
 	// Primitive arrays:
 
 	public int[] readInts (int length) throws KryoException {
-		int[] array = new int[validateArrayLength(length)];
+		int[] array = new int[validateArrayLength(length, 4)];
 		if (optional(length << 2) == length << 2) {
 			ByteBuffer byteBuffer = this.byteBuffer;
 			for (int i = 0; i < length; i++) {
@@ -876,7 +876,7 @@ public class ByteBufferInput extends Input {
 	}
 
 	public long[] readLongs (int length) throws KryoException {
-		long[] array = new long[validateArrayLength(length)];
+		long[] array = new long[validateArrayLength(length, 8)];
 		if (optional(length << 3) == length << 3) {
 			ByteBuffer byteBuffer = this.byteBuffer;
 			for (int i = 0; i < length; i++) {
@@ -898,7 +898,7 @@ public class ByteBufferInput extends Input {
 	}
 
 	public float[] readFloats (int length) throws KryoException {
-		float[] array = new float[validateArrayLength(length)];
+		float[] array = new float[validateArrayLength(length, 4)];
 		if (optional(length << 2) == length << 2) {
 			ByteBuffer byteBuffer = this.byteBuffer;
 			for (int i = 0; i < length; i++) {
@@ -916,7 +916,7 @@ public class ByteBufferInput extends Input {
 	}
 
 	public double[] readDoubles (int length) throws KryoException {
-		double[] array = new double[validateArrayLength(length)];
+		double[] array = new double[validateArrayLength(length, 8)];
 		if (optional(length << 3) == length << 3) {
 			ByteBuffer byteBuffer = this.byteBuffer;
 			for (int i = 0; i < length; i++) {
@@ -938,7 +938,7 @@ public class ByteBufferInput extends Input {
 	}
 
 	public short[] readShorts (int length) throws KryoException {
-		short[] array = new short[validateArrayLength(length)];
+		short[] array = new short[validateArrayLength(length, 2)];
 		if (optional(length << 1) == length << 1) {
 			ByteBuffer byteBuffer = this.byteBuffer;
 			for (int i = 0; i < length; i++)
@@ -952,7 +952,7 @@ public class ByteBufferInput extends Input {
 	}
 
 	public char[] readChars (int length) throws KryoException {
-		char[] array = new char[validateArrayLength(length)];
+		char[] array = new char[validateArrayLength(length, 2)];
 		if (optional(length << 1) == length << 1) {
 			ByteBuffer byteBuffer = this.byteBuffer;
 			for (int i = 0; i < length; i++)

--- a/src/com/esotericsoftware/kryo/io/Input.java
+++ b/src/com/esotericsoftware/kryo/io/Input.java
@@ -348,7 +348,7 @@ public class Input extends InputStream implements Poolable {
 
 	/** Reads the specified number of bytes into a new byte[]. */
 	public byte[] readBytes (int length) throws KryoException {
-		byte[] bytes = new byte[length];
+		byte[] bytes = new byte[validateArrayLength(length)];
 		readBytes(bytes, 0, length);
 		return bytes;
 	}
@@ -941,9 +941,14 @@ public class Input extends InputStream implements Poolable {
 
 	// Primitive arrays:
 
+	protected int validateArrayLength (int length) {
+		if (inputStream == null && length > limit - position) throw new KryoBufferUnderflowException("Buffer underflow.");
+		return length;
+	}
+
 	/** Reads an int array in bulk. This may be more efficient than reading them individually. */
 	public int[] readInts (int length) throws KryoException {
-		int[] array = new int[length];
+		int[] array = new int[validateArrayLength(length)];
 		if (optional(length << 2) == length << 2) {
 			byte[] buffer = this.buffer;
 			int p = this.position;
@@ -965,7 +970,7 @@ public class Input extends InputStream implements Poolable {
 	 * {@link #setVariableLengthEncoding(boolean)}. This may be more efficient than reading them individually. */
 	public int[] readInts (int length, boolean optimizePositive) throws KryoException {
 		if (varEncoding) {
-			int[] array = new int[length];
+			int[] array = new int[validateArrayLength(length)];
 			for (int i = 0; i < length; i++)
 				array[i] = readVarInt(optimizePositive);
 			return array;
@@ -975,7 +980,7 @@ public class Input extends InputStream implements Poolable {
 
 	/** Reads a long array in bulk. This may be more efficient than reading them individually. */
 	public long[] readLongs (int length) throws KryoException {
-		long[] array = new long[length];
+		long[] array = new long[validateArrayLength(length)];
 		if (optional(length << 3) == length << 3) {
 			byte[] buffer = this.buffer;
 			int p = this.position;
@@ -1001,7 +1006,7 @@ public class Input extends InputStream implements Poolable {
 	 * {@link #setVariableLengthEncoding(boolean)}. This may be more efficient than reading them individually. */
 	public long[] readLongs (int length, boolean optimizePositive) throws KryoException {
 		if (varEncoding) {
-			long[] array = new long[length];
+			long[] array = new long[validateArrayLength(length)];
 			for (int i = 0; i < length; i++)
 				array[i] = readVarLong(optimizePositive);
 			return array;
@@ -1011,7 +1016,7 @@ public class Input extends InputStream implements Poolable {
 
 	/** Reads a float array in bulk. This may be more efficient than reading them individually. */
 	public float[] readFloats (int length) throws KryoException {
-		float[] array = new float[length];
+		float[] array = new float[validateArrayLength(length)];
 		if (optional(length << 2) == length << 2) {
 			byte[] buffer = this.buffer;
 			int p = this.position;
@@ -1031,7 +1036,7 @@ public class Input extends InputStream implements Poolable {
 
 	/** Reads a double array in bulk. This may be more efficient than reading them individually. */
 	public double[] readDoubles (int length) throws KryoException {
-		double[] array = new double[length];
+		double[] array = new double[validateArrayLength(length)];
 		if (optional(length << 3) == length << 3) {
 			byte[] buffer = this.buffer;
 			int p = this.position;
@@ -1055,7 +1060,7 @@ public class Input extends InputStream implements Poolable {
 
 	/** Reads a short array in bulk. This may be more efficient than reading them individually. */
 	public short[] readShorts (int length) throws KryoException {
-		short[] array = new short[length];
+		short[] array = new short[validateArrayLength(length)];
 		if (optional(length << 1) == length << 1) {
 			byte[] buffer = this.buffer;
 			int p = this.position;
@@ -1071,7 +1076,7 @@ public class Input extends InputStream implements Poolable {
 
 	/** Reads a char array in bulk. This may be more efficient than reading them individually. */
 	public char[] readChars (int length) throws KryoException {
-		char[] array = new char[length];
+		char[] array = new char[validateArrayLength(length)];
 		if (optional(length << 1) == length << 1) {
 			byte[] buffer = this.buffer;
 			int p = this.position;
@@ -1087,7 +1092,7 @@ public class Input extends InputStream implements Poolable {
 
 	/** Reads a boolean array in bulk. This may be more efficient than reading them individually. */
 	public boolean[] readBooleans (int length) throws KryoException {
-		boolean[] array = new boolean[length];
+		boolean[] array = new boolean[validateArrayLength(length)];
 		if (optional(length) == length) {
 			byte[] buffer = this.buffer;
 			int p = this.position;

--- a/src/com/esotericsoftware/kryo/io/Input.java
+++ b/src/com/esotericsoftware/kryo/io/Input.java
@@ -982,7 +982,7 @@ public class Input extends InputStream implements Poolable {
 			if (bytes > limit - position) throw new KryoBufferUnderflowException("Buffer underflow.");
 		} else if (bytes > Integer.MAX_VALUE) {
 			// Stream-backed input cannot be checked against the buffered window, but a size whose byte count overflows an int
-			// can never be read and would overflow the length << n shifts in the bulk readers, so reject it.
+			// can never be read and would overflow the length * bytesPerElement computations in the bulk readers, so reject it.
 			throw new KryoException("Declared size is too large to read: " + length + " elements of " + bytesPerElement + " bytes");
 		}
 		return length;
@@ -1002,7 +1002,7 @@ public class Input extends InputStream implements Poolable {
 	/** Reads an int array in bulk. This may be more efficient than reading them individually. */
 	public int[] readInts (int length) throws KryoException {
 		int[] array = new int[validateArrayLength(length, Integer.BYTES)];
-		if (optional(length << 2) == length << 2) {
+		if (optional(length * Integer.BYTES) == length * Integer.BYTES) {
 			byte[] buffer = this.buffer;
 			int p = this.position;
 			for (int i = 0; i < length; i++, p += 4) {
@@ -1034,7 +1034,7 @@ public class Input extends InputStream implements Poolable {
 	/** Reads a long array in bulk. This may be more efficient than reading them individually. */
 	public long[] readLongs (int length) throws KryoException {
 		long[] array = new long[validateArrayLength(length, Long.BYTES)];
-		if (optional(length << 3) == length << 3) {
+		if (optional(length * Long.BYTES) == length * Long.BYTES) {
 			byte[] buffer = this.buffer;
 			int p = this.position;
 			for (int i = 0; i < length; i++, p += 8) {
@@ -1070,7 +1070,7 @@ public class Input extends InputStream implements Poolable {
 	/** Reads a float array in bulk. This may be more efficient than reading them individually. */
 	public float[] readFloats (int length) throws KryoException {
 		float[] array = new float[validateArrayLength(length, Float.BYTES)];
-		if (optional(length << 2) == length << 2) {
+		if (optional(length * Float.BYTES) == length * Float.BYTES) {
 			byte[] buffer = this.buffer;
 			int p = this.position;
 			for (int i = 0; i < length; i++, p += 4) {
@@ -1090,7 +1090,7 @@ public class Input extends InputStream implements Poolable {
 	/** Reads a double array in bulk. This may be more efficient than reading them individually. */
 	public double[] readDoubles (int length) throws KryoException {
 		double[] array = new double[validateArrayLength(length, Double.BYTES)];
-		if (optional(length << 3) == length << 3) {
+		if (optional(length * Double.BYTES) == length * Double.BYTES) {
 			byte[] buffer = this.buffer;
 			int p = this.position;
 			for (int i = 0; i < length; i++, p += 8) {
@@ -1114,7 +1114,7 @@ public class Input extends InputStream implements Poolable {
 	/** Reads a short array in bulk. This may be more efficient than reading them individually. */
 	public short[] readShorts (int length) throws KryoException {
 		short[] array = new short[validateArrayLength(length, Short.BYTES)];
-		if (optional(length << 1) == length << 1) {
+		if (optional(length * Short.BYTES) == length * Short.BYTES) {
 			byte[] buffer = this.buffer;
 			int p = this.position;
 			for (int i = 0; i < length; i++, p += 2)
@@ -1130,7 +1130,7 @@ public class Input extends InputStream implements Poolable {
 	/** Reads a char array in bulk. This may be more efficient than reading them individually. */
 	public char[] readChars (int length) throws KryoException {
 		char[] array = new char[validateArrayLength(length, Character.BYTES)];
-		if (optional(length << 1) == length << 1) {
+		if (optional(length * Character.BYTES) == length * Character.BYTES) {
 			byte[] buffer = this.buffer;
 			int p = this.position;
 			for (int i = 0; i < length; i++, p += 2)

--- a/src/com/esotericsoftware/kryo/io/Input.java
+++ b/src/com/esotericsoftware/kryo/io/Input.java
@@ -989,10 +989,11 @@ public class Input extends InputStream implements Poolable {
 	}
 
 	/** Clamps a declared collection or map size before it is used as an initial capacity. Throws if {@code size} exceeds
-	 * {@link #setMaxArraySize(int) maxArraySize}; otherwise, for a buffer-backed input (no {@link InputStream}), limits it to the
-	 * bytes remaining, since a collection or map element can occupy as little as a single byte. A stream-backed input is returned
-	 * unchanged (the remaining size is unknown). Unlike {@link #validateArrayLength(int, int)} the size is clamped rather than
-	 * rejected, because the capacity is only a hint and elements may occupy zero bytes. */
+	 * {@link #setMaxArraySize(int) maxArraySize}. Otherwise, for a buffer-backed input (no {@link InputStream}), caps it at the
+	 * bytes remaining so a corrupt size cannot force a large pre-allocation; the collection or map still grows as elements are
+	 * read. A stream-backed input is returned unchanged (the remaining size is unknown). Unlike
+	 * {@link #validateArrayLength(int, int)} the size is only clamped, not rejected, because it is an initial-capacity hint rather
+	 * than an exact element count. */
 	public int clampSize (int size) {
 		if (size > maxArraySize)
 			throw new KryoException("Declared size larger than maxArraySize: " + size + " > " + maxArraySize);

--- a/src/com/esotericsoftware/kryo/io/Input.java
+++ b/src/com/esotericsoftware/kryo/io/Input.java
@@ -848,7 +848,7 @@ public class Input extends InputStream implements Poolable {
 	}
 
 	private void readUtf8Chars (int charCount) {
-		if (chars.length < charCount) chars = new char[charCount];
+		if (chars.length < charCount) chars = new char[validateArrayLength(charCount)];
 		byte[] buffer = this.buffer;
 		char[] chars = this.chars;
 		// Try to read 7 bit ASCII chars.
@@ -941,7 +941,7 @@ public class Input extends InputStream implements Poolable {
 
 	// Primitive arrays:
 
-	protected int validateArrayLength (int length) {
+	public int validateArrayLength (int length) {
 		if (inputStream == null && length > limit - position) throw new KryoBufferUnderflowException("Buffer underflow.");
 		return length;
 	}

--- a/src/com/esotericsoftware/kryo/io/Input.java
+++ b/src/com/esotericsoftware/kryo/io/Input.java
@@ -39,6 +39,7 @@ public class Input extends InputStream implements Poolable {
 	protected char[] chars = new char[32];
 	protected InputStream inputStream;
 	protected boolean varEncoding = true;
+	protected int maxArraySize = Integer.MAX_VALUE;
 
 	/** Creates an uninitialized Input, {@link #setBuffer(byte[])} must be called before the Input is used. */
 	public Input () {
@@ -124,6 +125,14 @@ public class Input extends InputStream implements Poolable {
 	 * {@link #readLongs(int, boolean)} will use fixed length encoding, which may be faster for some data. Default is true. */
 	public void setVariableLengthEncoding (boolean varEncoding) {
 		this.varEncoding = varEncoding;
+	}
+
+	public int getMaxArraySize () {
+		return maxArraySize;
+	}
+
+	public void setMaxArraySize (int maxArraySize) {
+		this.maxArraySize = maxArraySize;
 	}
 
 	/** Returns the total number of bytes read. */
@@ -942,6 +951,7 @@ public class Input extends InputStream implements Poolable {
 	// Primitive arrays:
 
 	public int validateArrayLength (int length) {
+		if (length > maxArraySize) throw new KryoException("Array size is larger than maxArraySize: " + length + " > " + maxArraySize);
 		if (inputStream == null && length > limit - position) throw new KryoBufferUnderflowException("Buffer underflow.");
 		return length;
 	}

--- a/src/com/esotericsoftware/kryo/io/Input.java
+++ b/src/com/esotericsoftware/kryo/io/Input.java
@@ -127,11 +127,21 @@ public class Input extends InputStream implements Poolable {
 		this.varEncoding = varEncoding;
 	}
 
+	/** Returns the maximum size, in elements, that a declared array, string, collection, or map size may have when reading. See
+	 * {@link #setMaxArraySize(int)}. */
 	public int getMaxArraySize () {
 		return maxArraySize;
 	}
 
+	/** Sets the maximum size, in elements, that a declared array, string, collection, or map size may have when reading. A
+	 * declared size larger than this throws {@link KryoException} before any allocation, bounding the memory a corrupt or
+	 * malicious message can request. The default is {@link Integer#MAX_VALUE}, ie no limit, which preserves Kryo's trusted-source
+	 * behavior: a valid payload never declares more elements than the input can supply, so the limit never fires on valid input.
+	 * Callers that decode untrusted input, especially from an {@link InputStream} where the declared size cannot be checked
+	 * against the buffered bytes, should set a limit suited to their application.
+	 * @param maxArraySize must be >= 0. */
 	public void setMaxArraySize (int maxArraySize) {
+		if (maxArraySize < 0) throw new IllegalArgumentException("maxArraySize must be >= 0: " + maxArraySize);
 		this.maxArraySize = maxArraySize;
 	}
 
@@ -950,15 +960,37 @@ public class Input extends InputStream implements Poolable {
 
 	// Primitive arrays:
 
+	/** Validates a declared array length read from the input, treating each element as occupying at least one byte. Equivalent to
+	 * {@link #validateArrayLength(int, int)} with a bytes per element of 1. */
 	public int validateArrayLength (int length) {
-		if (length > maxArraySize) throw new KryoException("Array size is larger than maxArraySize: " + length + " > " + maxArraySize);
-		if (inputStream == null && length > limit - position) throw new KryoBufferUnderflowException("Buffer underflow.");
+		return validateArrayLength(length, 1);
+	}
+
+	/** Validates a declared array length read from the input before it is used to allocate. Throws if {@code length} exceeds
+	 * {@link #setMaxArraySize(int) maxArraySize}, if the total size {@code length * bytesPerElement} would overflow an int, or, for
+	 * a buffer-backed input (no {@link InputStream}), if it exceeds the bytes remaining. A buffer-backed input can never hold more
+	 * elements than it has bytes remaining, since every element occupies at least {@code bytesPerElement} bytes, so a larger
+	 * declared length is provably malformed and is rejected before allocating. Stream-backed input cannot be checked this way and
+	 * is bounded only by {@code maxArraySize} and the overflow check.
+	 * @param bytesPerElement the minimum number of bytes each element occupies in the input. */
+	public int validateArrayLength (int length, int bytesPerElement) {
+		if (length > maxArraySize)
+			throw new KryoException("Declared size larger than maxArraySize: " + length + " > " + maxArraySize);
+		long bytes = (long)length * bytesPerElement;
+		if (inputStream == null) {
+			// A buffer-backed input cannot supply more bytes than it has remaining, so a larger declared size is malformed.
+			if (bytes > limit - position) throw new KryoBufferUnderflowException("Buffer underflow.");
+		} else if (bytes > Integer.MAX_VALUE) {
+			// Stream-backed input cannot be checked against the buffered window, but a size whose byte count overflows an int
+			// can never be read and would overflow the length << n shifts in the bulk readers, so reject it.
+			throw new KryoException("Declared size is too large to read: " + length + " elements of " + bytesPerElement + " bytes");
+		}
 		return length;
 	}
 
 	/** Reads an int array in bulk. This may be more efficient than reading them individually. */
 	public int[] readInts (int length) throws KryoException {
-		int[] array = new int[validateArrayLength(length)];
+		int[] array = new int[validateArrayLength(length, 4)];
 		if (optional(length << 2) == length << 2) {
 			byte[] buffer = this.buffer;
 			int p = this.position;
@@ -990,7 +1022,7 @@ public class Input extends InputStream implements Poolable {
 
 	/** Reads a long array in bulk. This may be more efficient than reading them individually. */
 	public long[] readLongs (int length) throws KryoException {
-		long[] array = new long[validateArrayLength(length)];
+		long[] array = new long[validateArrayLength(length, 8)];
 		if (optional(length << 3) == length << 3) {
 			byte[] buffer = this.buffer;
 			int p = this.position;
@@ -1026,7 +1058,7 @@ public class Input extends InputStream implements Poolable {
 
 	/** Reads a float array in bulk. This may be more efficient than reading them individually. */
 	public float[] readFloats (int length) throws KryoException {
-		float[] array = new float[validateArrayLength(length)];
+		float[] array = new float[validateArrayLength(length, 4)];
 		if (optional(length << 2) == length << 2) {
 			byte[] buffer = this.buffer;
 			int p = this.position;
@@ -1046,7 +1078,7 @@ public class Input extends InputStream implements Poolable {
 
 	/** Reads a double array in bulk. This may be more efficient than reading them individually. */
 	public double[] readDoubles (int length) throws KryoException {
-		double[] array = new double[validateArrayLength(length)];
+		double[] array = new double[validateArrayLength(length, 8)];
 		if (optional(length << 3) == length << 3) {
 			byte[] buffer = this.buffer;
 			int p = this.position;
@@ -1070,7 +1102,7 @@ public class Input extends InputStream implements Poolable {
 
 	/** Reads a short array in bulk. This may be more efficient than reading them individually. */
 	public short[] readShorts (int length) throws KryoException {
-		short[] array = new short[validateArrayLength(length)];
+		short[] array = new short[validateArrayLength(length, 2)];
 		if (optional(length << 1) == length << 1) {
 			byte[] buffer = this.buffer;
 			int p = this.position;
@@ -1086,7 +1118,7 @@ public class Input extends InputStream implements Poolable {
 
 	/** Reads a char array in bulk. This may be more efficient than reading them individually. */
 	public char[] readChars (int length) throws KryoException {
-		char[] array = new char[validateArrayLength(length)];
+		char[] array = new char[validateArrayLength(length, 2)];
 		if (optional(length << 1) == length << 1) {
 			byte[] buffer = this.buffer;
 			int p = this.position;

--- a/src/com/esotericsoftware/kryo/io/Input.java
+++ b/src/com/esotericsoftware/kryo/io/Input.java
@@ -988,9 +988,20 @@ public class Input extends InputStream implements Poolable {
 		return length;
 	}
 
+	/** Clamps a declared collection or map size before it is used as an initial capacity. Throws if {@code size} exceeds
+	 * {@link #setMaxArraySize(int) maxArraySize}; otherwise, for a buffer-backed input (no {@link InputStream}), limits it to the
+	 * bytes remaining, since a collection or map element can occupy as little as a single byte. A stream-backed input is returned
+	 * unchanged (the remaining size is unknown). Unlike {@link #validateArrayLength(int, int)} the size is clamped rather than
+	 * rejected, because the capacity is only a hint and elements may occupy zero bytes. */
+	public int clampSize (int size) {
+		if (size > maxArraySize)
+			throw new KryoException("Declared size larger than maxArraySize: " + size + " > " + maxArraySize);
+		return inputStream == null ? Math.min(size, limit - position) : size;
+	}
+
 	/** Reads an int array in bulk. This may be more efficient than reading them individually. */
 	public int[] readInts (int length) throws KryoException {
-		int[] array = new int[validateArrayLength(length, 4)];
+		int[] array = new int[validateArrayLength(length, Integer.BYTES)];
 		if (optional(length << 2) == length << 2) {
 			byte[] buffer = this.buffer;
 			int p = this.position;
@@ -1022,7 +1033,7 @@ public class Input extends InputStream implements Poolable {
 
 	/** Reads a long array in bulk. This may be more efficient than reading them individually. */
 	public long[] readLongs (int length) throws KryoException {
-		long[] array = new long[validateArrayLength(length, 8)];
+		long[] array = new long[validateArrayLength(length, Long.BYTES)];
 		if (optional(length << 3) == length << 3) {
 			byte[] buffer = this.buffer;
 			int p = this.position;
@@ -1058,7 +1069,7 @@ public class Input extends InputStream implements Poolable {
 
 	/** Reads a float array in bulk. This may be more efficient than reading them individually. */
 	public float[] readFloats (int length) throws KryoException {
-		float[] array = new float[validateArrayLength(length, 4)];
+		float[] array = new float[validateArrayLength(length, Float.BYTES)];
 		if (optional(length << 2) == length << 2) {
 			byte[] buffer = this.buffer;
 			int p = this.position;
@@ -1078,7 +1089,7 @@ public class Input extends InputStream implements Poolable {
 
 	/** Reads a double array in bulk. This may be more efficient than reading them individually. */
 	public double[] readDoubles (int length) throws KryoException {
-		double[] array = new double[validateArrayLength(length, 8)];
+		double[] array = new double[validateArrayLength(length, Double.BYTES)];
 		if (optional(length << 3) == length << 3) {
 			byte[] buffer = this.buffer;
 			int p = this.position;
@@ -1102,7 +1113,7 @@ public class Input extends InputStream implements Poolable {
 
 	/** Reads a short array in bulk. This may be more efficient than reading them individually. */
 	public short[] readShorts (int length) throws KryoException {
-		short[] array = new short[validateArrayLength(length, 2)];
+		short[] array = new short[validateArrayLength(length, Short.BYTES)];
 		if (optional(length << 1) == length << 1) {
 			byte[] buffer = this.buffer;
 			int p = this.position;
@@ -1118,7 +1129,7 @@ public class Input extends InputStream implements Poolable {
 
 	/** Reads a char array in bulk. This may be more efficient than reading them individually. */
 	public char[] readChars (int length) throws KryoException {
-		char[] array = new char[validateArrayLength(length, 2)];
+		char[] array = new char[validateArrayLength(length, Character.BYTES)];
 		if (optional(length << 1) == length << 1) {
 			byte[] buffer = this.buffer;
 			int p = this.position;

--- a/src/com/esotericsoftware/kryo/serializers/ClosureSerializer.java
+++ b/src/com/esotericsoftware/kryo/serializers/ClosureSerializer.java
@@ -98,7 +98,7 @@ public class ClosureSerializer extends Serializer {
 
 	public Object read (Kryo kryo, Input input, Class type) {
 		int count = input.readVarInt(true);
-		Object[] capturedArgs = new Object[count];
+		Object[] capturedArgs = new Object[input.validateArrayLength(count)];
 		for (int i = 0; i < count; i++)
 			capturedArgs[i] = kryo.readClassAndObject(input);
 		Class<?> capturingClass = kryo.readClass(input).getType();

--- a/src/com/esotericsoftware/kryo/serializers/CollectionSerializer.java
+++ b/src/com/esotericsoftware/kryo/serializers/CollectionSerializer.java
@@ -30,7 +30,6 @@ import java.util.Collection;
 import java.util.HashSet;
 
 import com.esotericsoftware.kryo.Kryo;
-import com.esotericsoftware.kryo.KryoException;
 import com.esotericsoftware.kryo.Registration;
 import com.esotericsoftware.kryo.Serializer;
 import com.esotericsoftware.kryo.SerializerFactory;
@@ -180,12 +179,6 @@ public class CollectionSerializer<T extends Collection> extends Serializer<T> {
 		return collection;
 	}
 
-	private static int clampSize (Input input, int size) {
-		if (size > input.getMaxArraySize())
-			throw new KryoException("Declared size larger than maxArraySize: " + size + " > " + input.getMaxArraySize());
-		return input.getInputStream() == null ? Math.min(size, input.limit() - input.position()) : size;
-	}
-
 	public T read (Kryo kryo, Input input, Class<? extends T> type) {
 		Class elementClass = this.elementClass;
 		Serializer elementSerializer = this.elementSerializer;
@@ -210,7 +203,7 @@ public class CollectionSerializer<T extends Collection> extends Serializer<T> {
 				if (length == 0) return null;
 
 				length--;
-				collection = create(kryo, input, type, clampSize(input, length));
+				collection = create(kryo, input, type, input.clampSize(length));
 				kryo.reference(collection);
 
 				if (length == 0) return collection;
@@ -220,7 +213,7 @@ public class CollectionSerializer<T extends Collection> extends Serializer<T> {
 				if (length == 0) return null;
 
 				length--;
-				collection = create(kryo, input, type, clampSize(input, length));
+				collection = create(kryo, input, type, input.clampSize(length));
 				kryo.reference(collection);
 
 				if (length == 0) return collection;

--- a/src/com/esotericsoftware/kryo/serializers/CollectionSerializer.java
+++ b/src/com/esotericsoftware/kryo/serializers/CollectionSerializer.java
@@ -30,6 +30,7 @@ import java.util.Collection;
 import java.util.HashSet;
 
 import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.KryoException;
 import com.esotericsoftware.kryo.Registration;
 import com.esotericsoftware.kryo.Serializer;
 import com.esotericsoftware.kryo.SerializerFactory;
@@ -180,6 +181,8 @@ public class CollectionSerializer<T extends Collection> extends Serializer<T> {
 	}
 
 	private static int clampSize (Input input, int size) {
+		if (size > input.getMaxArraySize())
+			throw new KryoException("Array size is larger than maxArraySize: " + size + " > " + input.getMaxArraySize());
 		return input.getInputStream() == null ? Math.min(size, input.limit() - input.position()) : size;
 	}
 

--- a/src/com/esotericsoftware/kryo/serializers/CollectionSerializer.java
+++ b/src/com/esotericsoftware/kryo/serializers/CollectionSerializer.java
@@ -179,6 +179,10 @@ public class CollectionSerializer<T extends Collection> extends Serializer<T> {
 		return collection;
 	}
 
+	private static int clampSize (Input input, int size) {
+		return input.getInputStream() == null ? Math.min(size, input.limit() - input.position()) : size;
+	}
+
 	public T read (Kryo kryo, Input input, Class<? extends T> type) {
 		Class elementClass = this.elementClass;
 		Serializer elementSerializer = this.elementSerializer;
@@ -203,7 +207,7 @@ public class CollectionSerializer<T extends Collection> extends Serializer<T> {
 				if (length == 0) return null;
 
 				length--;
-				collection = create(kryo, input, type, length);
+				collection = create(kryo, input, type, clampSize(input, length));
 				kryo.reference(collection);
 
 				if (length == 0) return collection;
@@ -213,7 +217,7 @@ public class CollectionSerializer<T extends Collection> extends Serializer<T> {
 				if (length == 0) return null;
 
 				length--;
-				collection = create(kryo, input, type, length);
+				collection = create(kryo, input, type, clampSize(input, length));
 				kryo.reference(collection);
 
 				if (length == 0) return collection;

--- a/src/com/esotericsoftware/kryo/serializers/CollectionSerializer.java
+++ b/src/com/esotericsoftware/kryo/serializers/CollectionSerializer.java
@@ -182,7 +182,7 @@ public class CollectionSerializer<T extends Collection> extends Serializer<T> {
 
 	private static int clampSize (Input input, int size) {
 		if (size > input.getMaxArraySize())
-			throw new KryoException("Array size is larger than maxArraySize: " + size + " > " + input.getMaxArraySize());
+			throw new KryoException("Declared size larger than maxArraySize: " + size + " > " + input.getMaxArraySize());
 		return input.getInputStream() == null ? Math.min(size, input.limit() - input.position()) : size;
 	}
 

--- a/src/com/esotericsoftware/kryo/serializers/CompatibleFieldSerializer.java
+++ b/src/com/esotericsoftware/kryo/serializers/CompatibleFieldSerializer.java
@@ -193,7 +193,7 @@ public class CompatibleFieldSerializer<T> extends FieldSerializer<T> {
 	private CachedField[] readFields (Kryo kryo, Input input) {
 		if (TRACE) trace("kryo", "Read fields for class: " + type.getName());
 
-		int length = input.readVarInt(true);
+		int length = input.validateArrayLength(input.readVarInt(true));
 		String[] names = new String[length];
 		for (int i = 0; i < length; i++) {
 			names[i] = input.readString();

--- a/src/com/esotericsoftware/kryo/serializers/DefaultArraySerializers.java
+++ b/src/com/esotericsoftware/kryo/serializers/DefaultArraySerializers.java
@@ -277,7 +277,7 @@ public class DefaultArraySerializers {
 		public String[] read (Kryo kryo, Input input, Class type) {
 			int length = input.readVarInt(true);
 			if (length == NULL) return null;
-			String[] array = new String[--length];
+			String[] array = new String[input.validateArrayLength(--length)];
 			if (kryo.getReferences() && kryo.getReferenceResolver().useReferences(String.class)) {
 				Serializer serializer = kryo.getSerializer(String.class);
 				for (int i = 0; i < length; i++)

--- a/src/com/esotericsoftware/kryo/serializers/MapSerializer.java
+++ b/src/com/esotericsoftware/kryo/serializers/MapSerializer.java
@@ -172,6 +172,10 @@ public class MapSerializer<T extends Map> extends Serializer<T> {
 	/** Used by {@link #read(Kryo, Input, Class)} to create the new object. This can be overridden to customize object creation, eg
 	 * to call a constructor with arguments. The default implementation uses {@link Kryo#newInstance(Class)} with a special case
 	 * for HashMap. */
+	private static int clampSize (Input input, int size) {
+		return input.getInputStream() == null ? Math.min(size, input.limit() - input.position()) : size;
+	}
+
 	protected T create (Kryo kryo, Input input, Class<? extends T> type, int size) {
 		if (type == HashMap.class) {
 			if (size < 3)
@@ -188,7 +192,7 @@ public class MapSerializer<T extends Map> extends Serializer<T> {
 		if (length == 0) return null;
 		length--;
 
-		T map = create(kryo, input, type, length);
+		T map = create(kryo, input, type, clampSize(input, length));
 		kryo.reference(map);
 		if (length == 0) return map;
 

--- a/src/com/esotericsoftware/kryo/serializers/MapSerializer.java
+++ b/src/com/esotericsoftware/kryo/serializers/MapSerializer.java
@@ -175,7 +175,7 @@ public class MapSerializer<T extends Map> extends Serializer<T> {
 	 * for HashMap. */
 	private static int clampSize (Input input, int size) {
 		if (size > input.getMaxArraySize())
-			throw new KryoException("Array size is larger than maxArraySize: " + size + " > " + input.getMaxArraySize());
+			throw new KryoException("Declared size larger than maxArraySize: " + size + " > " + input.getMaxArraySize());
 		return input.getInputStream() == null ? Math.min(size, input.limit() - input.position()) : size;
 	}
 

--- a/src/com/esotericsoftware/kryo/serializers/MapSerializer.java
+++ b/src/com/esotericsoftware/kryo/serializers/MapSerializer.java
@@ -20,7 +20,6 @@
 package com.esotericsoftware.kryo.serializers;
 
 import com.esotericsoftware.kryo.Kryo;
-import com.esotericsoftware.kryo.KryoException;
 import com.esotericsoftware.kryo.Serializer;
 import com.esotericsoftware.kryo.SerializerFactory;
 import com.esotericsoftware.kryo.io.Input;
@@ -173,12 +172,6 @@ public class MapSerializer<T extends Map> extends Serializer<T> {
 	/** Used by {@link #read(Kryo, Input, Class)} to create the new object. This can be overridden to customize object creation, eg
 	 * to call a constructor with arguments. The default implementation uses {@link Kryo#newInstance(Class)} with a special case
 	 * for HashMap. */
-	private static int clampSize (Input input, int size) {
-		if (size > input.getMaxArraySize())
-			throw new KryoException("Declared size larger than maxArraySize: " + size + " > " + input.getMaxArraySize());
-		return input.getInputStream() == null ? Math.min(size, input.limit() - input.position()) : size;
-	}
-
 	protected T create (Kryo kryo, Input input, Class<? extends T> type, int size) {
 		if (type == HashMap.class) {
 			if (size < 3)
@@ -195,7 +188,7 @@ public class MapSerializer<T extends Map> extends Serializer<T> {
 		if (length == 0) return null;
 		length--;
 
-		T map = create(kryo, input, type, clampSize(input, length));
+		T map = create(kryo, input, type, input.clampSize(length));
 		kryo.reference(map);
 		if (length == 0) return map;
 

--- a/src/com/esotericsoftware/kryo/serializers/MapSerializer.java
+++ b/src/com/esotericsoftware/kryo/serializers/MapSerializer.java
@@ -20,6 +20,7 @@
 package com.esotericsoftware.kryo.serializers;
 
 import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.KryoException;
 import com.esotericsoftware.kryo.Serializer;
 import com.esotericsoftware.kryo.SerializerFactory;
 import com.esotericsoftware.kryo.io.Input;
@@ -173,6 +174,8 @@ public class MapSerializer<T extends Map> extends Serializer<T> {
 	 * to call a constructor with arguments. The default implementation uses {@link Kryo#newInstance(Class)} with a special case
 	 * for HashMap. */
 	private static int clampSize (Input input, int size) {
+		if (size > input.getMaxArraySize())
+			throw new KryoException("Array size is larger than maxArraySize: " + size + " > " + input.getMaxArraySize());
 		return input.getInputStream() == null ? Math.min(size, input.limit() - input.position()) : size;
 	}
 

--- a/src/com/esotericsoftware/kryo/unsafe/UnsafeByteBufferInput.java
+++ b/src/com/esotericsoftware/kryo/unsafe/UnsafeByteBufferInput.java
@@ -185,37 +185,37 @@ public class UnsafeByteBufferInput extends ByteBufferInput {
 	}
 
 	public int[] readInts (int length) throws KryoException {
-		int[] array = new int[validateArrayLength(length)];
+		int[] array = new int[validateArrayLength(length, 4)];
 		readBytes(array, intArrayBaseOffset, length << 2);
 		return array;
 	}
 
 	public long[] readLongs (int length) throws KryoException {
-		long[] array = new long[validateArrayLength(length)];
+		long[] array = new long[validateArrayLength(length, 8)];
 		readBytes(array, longArrayBaseOffset, length << 3);
 		return array;
 	}
 
 	public float[] readFloats (int length) throws KryoException {
-		float[] array = new float[validateArrayLength(length)];
+		float[] array = new float[validateArrayLength(length, 4)];
 		readBytes(array, floatArrayBaseOffset, length << 2);
 		return array;
 	}
 
 	public double[] readDoubles (int length) throws KryoException {
-		double[] array = new double[validateArrayLength(length)];
+		double[] array = new double[validateArrayLength(length, 8)];
 		readBytes(array, doubleArrayBaseOffset, length << 3);
 		return array;
 	}
 
 	public short[] readShorts (int length) throws KryoException {
-		short[] array = new short[validateArrayLength(length)];
+		short[] array = new short[validateArrayLength(length, 2)];
 		readBytes(array, shortArrayBaseOffset, length << 1);
 		return array;
 	}
 
 	public char[] readChars (int length) throws KryoException {
-		char[] array = new char[validateArrayLength(length)];
+		char[] array = new char[validateArrayLength(length, 2)];
 		readBytes(array, charArrayBaseOffset, length << 1);
 		return array;
 	}

--- a/src/com/esotericsoftware/kryo/unsafe/UnsafeByteBufferInput.java
+++ b/src/com/esotericsoftware/kryo/unsafe/UnsafeByteBufferInput.java
@@ -185,43 +185,43 @@ public class UnsafeByteBufferInput extends ByteBufferInput {
 	}
 
 	public int[] readInts (int length) throws KryoException {
-		int[] array = new int[length];
+		int[] array = new int[validateArrayLength(length)];
 		readBytes(array, intArrayBaseOffset, length << 2);
 		return array;
 	}
 
 	public long[] readLongs (int length) throws KryoException {
-		long[] array = new long[length];
+		long[] array = new long[validateArrayLength(length)];
 		readBytes(array, longArrayBaseOffset, length << 3);
 		return array;
 	}
 
 	public float[] readFloats (int length) throws KryoException {
-		float[] array = new float[length];
+		float[] array = new float[validateArrayLength(length)];
 		readBytes(array, floatArrayBaseOffset, length << 2);
 		return array;
 	}
 
 	public double[] readDoubles (int length) throws KryoException {
-		double[] array = new double[length];
+		double[] array = new double[validateArrayLength(length)];
 		readBytes(array, doubleArrayBaseOffset, length << 3);
 		return array;
 	}
 
 	public short[] readShorts (int length) throws KryoException {
-		short[] array = new short[length];
+		short[] array = new short[validateArrayLength(length)];
 		readBytes(array, shortArrayBaseOffset, length << 1);
 		return array;
 	}
 
 	public char[] readChars (int length) throws KryoException {
-		char[] array = new char[length];
+		char[] array = new char[validateArrayLength(length)];
 		readBytes(array, charArrayBaseOffset, length << 1);
 		return array;
 	}
 
 	public boolean[] readBooleans (int length) throws KryoException {
-		boolean[] array = new boolean[length];
+		boolean[] array = new boolean[validateArrayLength(length)];
 		readBytes(array, booleanArrayBaseOffset, length);
 		return array;
 	}

--- a/src/com/esotericsoftware/kryo/unsafe/UnsafeByteBufferInput.java
+++ b/src/com/esotericsoftware/kryo/unsafe/UnsafeByteBufferInput.java
@@ -185,38 +185,38 @@ public class UnsafeByteBufferInput extends ByteBufferInput {
 	}
 
 	public int[] readInts (int length) throws KryoException {
-		int[] array = new int[validateArrayLength(length, 4)];
-		readBytes(array, intArrayBaseOffset, length << 2);
+		int[] array = new int[validateArrayLength(length, Integer.BYTES)];
+		readBytes(array, intArrayBaseOffset, length * Integer.BYTES);
 		return array;
 	}
 
 	public long[] readLongs (int length) throws KryoException {
-		long[] array = new long[validateArrayLength(length, 8)];
-		readBytes(array, longArrayBaseOffset, length << 3);
+		long[] array = new long[validateArrayLength(length, Long.BYTES)];
+		readBytes(array, longArrayBaseOffset, length * Long.BYTES);
 		return array;
 	}
 
 	public float[] readFloats (int length) throws KryoException {
-		float[] array = new float[validateArrayLength(length, 4)];
-		readBytes(array, floatArrayBaseOffset, length << 2);
+		float[] array = new float[validateArrayLength(length, Float.BYTES)];
+		readBytes(array, floatArrayBaseOffset, length * Float.BYTES);
 		return array;
 	}
 
 	public double[] readDoubles (int length) throws KryoException {
-		double[] array = new double[validateArrayLength(length, 8)];
-		readBytes(array, doubleArrayBaseOffset, length << 3);
+		double[] array = new double[validateArrayLength(length, Double.BYTES)];
+		readBytes(array, doubleArrayBaseOffset, length * Double.BYTES);
 		return array;
 	}
 
 	public short[] readShorts (int length) throws KryoException {
-		short[] array = new short[validateArrayLength(length, 2)];
-		readBytes(array, shortArrayBaseOffset, length << 1);
+		short[] array = new short[validateArrayLength(length, Short.BYTES)];
+		readBytes(array, shortArrayBaseOffset, length * Short.BYTES);
 		return array;
 	}
 
 	public char[] readChars (int length) throws KryoException {
-		char[] array = new char[validateArrayLength(length, 2)];
-		readBytes(array, charArrayBaseOffset, length << 1);
+		char[] array = new char[validateArrayLength(length, Character.BYTES)];
+		readBytes(array, charArrayBaseOffset, length * Character.BYTES);
 		return array;
 	}
 

--- a/src/com/esotericsoftware/kryo/unsafe/UnsafeInput.java
+++ b/src/com/esotericsoftware/kryo/unsafe/UnsafeInput.java
@@ -136,38 +136,38 @@ public class UnsafeInput extends Input {
 	}
 
 	public int[] readInts (int length) throws KryoException {
-		int[] array = new int[validateArrayLength(length, 4)];
-		readBytes(array, intArrayBaseOffset, length << 2);
+		int[] array = new int[validateArrayLength(length, Integer.BYTES)];
+		readBytes(array, intArrayBaseOffset, length * Integer.BYTES);
 		return array;
 	}
 
 	public long[] readLongs (int length) throws KryoException {
-		long[] array = new long[validateArrayLength(length, 8)];
-		readBytes(array, longArrayBaseOffset, length << 3);
+		long[] array = new long[validateArrayLength(length, Long.BYTES)];
+		readBytes(array, longArrayBaseOffset, length * Long.BYTES);
 		return array;
 	}
 
 	public float[] readFloats (int length) throws KryoException {
-		float[] array = new float[validateArrayLength(length, 4)];
-		readBytes(array, floatArrayBaseOffset, length << 2);
+		float[] array = new float[validateArrayLength(length, Float.BYTES)];
+		readBytes(array, floatArrayBaseOffset, length * Float.BYTES);
 		return array;
 	}
 
 	public double[] readDoubles (int length) throws KryoException {
-		double[] array = new double[validateArrayLength(length, 8)];
-		readBytes(array, doubleArrayBaseOffset, length << 3);
+		double[] array = new double[validateArrayLength(length, Double.BYTES)];
+		readBytes(array, doubleArrayBaseOffset, length * Double.BYTES);
 		return array;
 	}
 
 	public short[] readShorts (int length) throws KryoException {
-		short[] array = new short[validateArrayLength(length, 2)];
-		readBytes(array, shortArrayBaseOffset, length << 1);
+		short[] array = new short[validateArrayLength(length, Short.BYTES)];
+		readBytes(array, shortArrayBaseOffset, length * Short.BYTES);
 		return array;
 	}
 
 	public char[] readChars (int length) throws KryoException {
-		char[] array = new char[validateArrayLength(length, 2)];
-		readBytes(array, charArrayBaseOffset, length << 1);
+		char[] array = new char[validateArrayLength(length, Character.BYTES)];
+		readBytes(array, charArrayBaseOffset, length * Character.BYTES);
 		return array;
 	}
 

--- a/src/com/esotericsoftware/kryo/unsafe/UnsafeInput.java
+++ b/src/com/esotericsoftware/kryo/unsafe/UnsafeInput.java
@@ -136,43 +136,43 @@ public class UnsafeInput extends Input {
 	}
 
 	public int[] readInts (int length) throws KryoException {
-		int[] array = new int[length];
+		int[] array = new int[validateArrayLength(length)];
 		readBytes(array, intArrayBaseOffset, length << 2);
 		return array;
 	}
 
 	public long[] readLongs (int length) throws KryoException {
-		long[] array = new long[length];
+		long[] array = new long[validateArrayLength(length)];
 		readBytes(array, longArrayBaseOffset, length << 3);
 		return array;
 	}
 
 	public float[] readFloats (int length) throws KryoException {
-		float[] array = new float[length];
+		float[] array = new float[validateArrayLength(length)];
 		readBytes(array, floatArrayBaseOffset, length << 2);
 		return array;
 	}
 
 	public double[] readDoubles (int length) throws KryoException {
-		double[] array = new double[length];
+		double[] array = new double[validateArrayLength(length)];
 		readBytes(array, doubleArrayBaseOffset, length << 3);
 		return array;
 	}
 
 	public short[] readShorts (int length) throws KryoException {
-		short[] array = new short[length];
+		short[] array = new short[validateArrayLength(length)];
 		readBytes(array, shortArrayBaseOffset, length << 1);
 		return array;
 	}
 
 	public char[] readChars (int length) throws KryoException {
-		char[] array = new char[length];
+		char[] array = new char[validateArrayLength(length)];
 		readBytes(array, charArrayBaseOffset, length << 1);
 		return array;
 	}
 
 	public boolean[] readBooleans (int length) throws KryoException {
-		boolean[] array = new boolean[length];
+		boolean[] array = new boolean[validateArrayLength(length)];
 		readBytes(array, booleanArrayBaseOffset, length);
 		return array;
 	}

--- a/src/com/esotericsoftware/kryo/unsafe/UnsafeInput.java
+++ b/src/com/esotericsoftware/kryo/unsafe/UnsafeInput.java
@@ -136,37 +136,37 @@ public class UnsafeInput extends Input {
 	}
 
 	public int[] readInts (int length) throws KryoException {
-		int[] array = new int[validateArrayLength(length)];
+		int[] array = new int[validateArrayLength(length, 4)];
 		readBytes(array, intArrayBaseOffset, length << 2);
 		return array;
 	}
 
 	public long[] readLongs (int length) throws KryoException {
-		long[] array = new long[validateArrayLength(length)];
+		long[] array = new long[validateArrayLength(length, 8)];
 		readBytes(array, longArrayBaseOffset, length << 3);
 		return array;
 	}
 
 	public float[] readFloats (int length) throws KryoException {
-		float[] array = new float[validateArrayLength(length)];
+		float[] array = new float[validateArrayLength(length, 4)];
 		readBytes(array, floatArrayBaseOffset, length << 2);
 		return array;
 	}
 
 	public double[] readDoubles (int length) throws KryoException {
-		double[] array = new double[validateArrayLength(length)];
+		double[] array = new double[validateArrayLength(length, 8)];
 		readBytes(array, doubleArrayBaseOffset, length << 3);
 		return array;
 	}
 
 	public short[] readShorts (int length) throws KryoException {
-		short[] array = new short[validateArrayLength(length)];
+		short[] array = new short[validateArrayLength(length, 2)];
 		readBytes(array, shortArrayBaseOffset, length << 1);
 		return array;
 	}
 
 	public char[] readChars (int length) throws KryoException {
-		char[] array = new char[validateArrayLength(length)];
+		char[] array = new char[validateArrayLength(length, 2)];
 		readBytes(array, charArrayBaseOffset, length << 1);
 		return array;
 	}

--- a/test/com/esotericsoftware/kryo/io/InputOutputTest.java
+++ b/test/com/esotericsoftware/kryo/io/InputOutputTest.java
@@ -198,6 +198,16 @@ class InputOutputTest extends KryoTestCase {
 	}
 
 	@Test
+	void testMaxArraySize () throws IOException {
+		Input stream = new Input(new ByteArrayInputStream(new byte[16]));
+		stream.setMaxArraySize(1024);
+		assertEquals(1024, stream.getMaxArraySize());
+		assertThrows(KryoException.class, () -> stream.readInts(2000000));
+		assertThrows(KryoException.class, () -> stream.readBytes(2000000));
+		assertThrows(KryoException.class, () -> stream.readLongs(2000000, true));
+	}
+
+	@Test
 	void testStrings () throws IOException {
 		runStringTest(new Output(4096));
 		runStringTest(new Output(897));

--- a/test/com/esotericsoftware/kryo/io/InputOutputTest.java
+++ b/test/com/esotericsoftware/kryo/io/InputOutputTest.java
@@ -23,6 +23,7 @@ import static com.esotericsoftware.kryo.KryoAssert.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.KryoException;
 import com.esotericsoftware.kryo.KryoTestCase;
 import com.esotericsoftware.kryo.Registration;
 import com.esotericsoftware.kryo.io.KryoBufferUnderflowException;
@@ -137,6 +138,48 @@ class InputOutputTest extends KryoTestCase {
 		);
 
 		assertTrue(thrown.getMessage().equals("Buffer underflow."));
+	}
+
+	@Test
+	void testArrayLengthValidation () throws IOException {
+		int hugeLength = 2000000000;
+
+		assertThrows(KryoBufferUnderflowException.class, () -> new Input(new byte[5]).readInts(hugeLength));
+		assertThrows(KryoBufferUnderflowException.class, () -> new Input(new byte[5]).readInts(hugeLength, true));
+		assertThrows(KryoBufferUnderflowException.class, () -> new Input(new byte[5]).readLongs(hugeLength));
+		assertThrows(KryoBufferUnderflowException.class, () -> new Input(new byte[5]).readLongs(hugeLength, true));
+		assertThrows(KryoBufferUnderflowException.class, () -> new Input(new byte[5]).readFloats(hugeLength));
+		assertThrows(KryoBufferUnderflowException.class, () -> new Input(new byte[5]).readDoubles(hugeLength));
+		assertThrows(KryoBufferUnderflowException.class, () -> new Input(new byte[5]).readShorts(hugeLength));
+		assertThrows(KryoBufferUnderflowException.class, () -> new Input(new byte[5]).readChars(hugeLength));
+		assertThrows(KryoBufferUnderflowException.class, () -> new Input(new byte[5]).readBooleans(hugeLength));
+		assertThrows(KryoBufferUnderflowException.class, () -> new Input(new byte[5]).readBytes(hugeLength));
+
+		assertThrows(KryoBufferUnderflowException.class, () -> new ByteBufferInput(new byte[5]).readInts(hugeLength));
+		assertThrows(KryoBufferUnderflowException.class, () -> new ByteBufferInput(new byte[5]).readDoubles(hugeLength));
+		assertThrows(KryoBufferUnderflowException.class, () -> new ByteBufferInput(new byte[5]).readBytes(hugeLength));
+
+		int[] ints = {1, 2, 3, 4, 5};
+		Output output = new Output(64);
+		output.writeInts(ints, 0, ints.length, false);
+		output.flush();
+		assertArrayEquals(ints, new Input(output.toBytes()).readInts(ints.length, false));
+	}
+
+	@Test
+	void testMaliciousArrayLength () throws IOException {
+		kryo.register(int[].class);
+
+		Output declared = new Output(8);
+		declared.writeVarInt(2000000001, true);
+		declared.flush();
+		assertThrows(KryoException.class, () -> kryo.readObject(new Input(declared.toBytes()), int[].class));
+
+		int[] valid = {1, 2, 3, 4, 5};
+		Output output = new Output(64);
+		kryo.writeObject(output, valid);
+		output.flush();
+		assertArrayEquals(valid, kryo.readObject(new Input(output.toBytes()), int[].class));
 	}
 
 	@Test

--- a/test/com/esotericsoftware/kryo/io/InputOutputTest.java
+++ b/test/com/esotericsoftware/kryo/io/InputOutputTest.java
@@ -183,6 +183,21 @@ class InputOutputTest extends KryoTestCase {
 	}
 
 	@Test
+	void testMaliciousStringLength () throws IOException {
+		Output declared = new Output(8);
+		declared.writeVarIntFlag(true, 2000000001, true);
+		declared.flush();
+		assertThrows(KryoBufferUnderflowException.class, () -> new Input(declared.toBytes()).readString());
+		assertThrows(KryoBufferUnderflowException.class, () -> new ByteBufferInput(declared.toBytes()).readString());
+
+		String value = "kryo \u00e9\u00fc\u1234 unicode string";
+		Output output = new Output(64);
+		output.writeString(value);
+		output.flush();
+		assertEquals(value, new Input(output.toBytes()).readString());
+	}
+
+	@Test
 	void testStrings () throws IOException {
 		runStringTest(new Output(4096));
 		runStringTest(new Output(897));

--- a/test/com/esotericsoftware/kryo/io/InputOutputTest.java
+++ b/test/com/esotericsoftware/kryo/io/InputOutputTest.java
@@ -208,6 +208,31 @@ class InputOutputTest extends KryoTestCase {
 	}
 
 	@Test
+	void testArrayLengthByteWidthValidation () throws IOException {
+		// A declared element count that fits the buffer by count but not once element width is counted is rejected up front,
+		// before the (potentially much larger) array is allocated. Eight ints need 32 bytes, not 8.
+		assertThrows(KryoBufferUnderflowException.class, () -> new Input(new byte[8]).readInts(8));
+		assertThrows(KryoBufferUnderflowException.class, () -> new Input(new byte[8]).readLongs(8));
+		assertThrows(KryoBufferUnderflowException.class, () -> new Input(new byte[8]).readDoubles(8));
+		assertThrows(KryoBufferUnderflowException.class, () -> new ByteBufferInput(new byte[8]).readInts(8));
+
+		// Stream-backed: a declared size whose total byte count overflows an int can never be read and previously overflowed the
+		// length << n shifts (risking ArrayIndexOutOfBoundsException or a huge allocation). It is now rejected cleanly.
+		assertThrows(KryoException.class, () -> new Input(new ByteArrayInputStream(new byte[16])).readInts(600000000));
+		assertThrows(KryoException.class, () -> new Input(new ByteArrayInputStream(new byte[16])).readLongs(300000000));
+
+		// setMaxArraySize rejects negative limits.
+		assertThrows(IllegalArgumentException.class, () -> new Input(new byte[1]).setMaxArraySize(-1));
+
+		// Valid fixed-width arrays still round-trip through the guard.
+		long[] longs = {1, 2, 3, 4, 5};
+		Output output = new Output(64);
+		output.writeLongs(longs, 0, longs.length, false);
+		output.flush();
+		assertArrayEquals(longs, new Input(output.toBytes()).readLongs(longs.length, false));
+	}
+
+	@Test
 	void testStrings () throws IOException {
 		runStringTest(new Output(4096));
 		runStringTest(new Output(897));

--- a/test/com/esotericsoftware/kryo/io/UnsafeInputOutputTest.java
+++ b/test/com/esotericsoftware/kryo/io/UnsafeInputOutputTest.java
@@ -23,6 +23,8 @@ import static com.esotericsoftware.kryo.KryoAssert.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.esotericsoftware.kryo.Unsafe;
+import com.esotericsoftware.kryo.io.KryoBufferUnderflowException;
+import com.esotericsoftware.kryo.unsafe.UnsafeByteBufferInput;
 import com.esotericsoftware.kryo.unsafe.UnsafeInput;
 import com.esotericsoftware.kryo.unsafe.UnsafeOutput;
 
@@ -35,6 +37,18 @@ import org.junit.jupiter.api.Test;
 /** @author Nathan Sweet <misc@n4te.com> */
 @Unsafe
 class UnsafeInputOutputTest {
+	@Test
+	void testArrayLengthValidation () {
+		int hugeLength = 2000000000;
+
+		assertThrows(KryoBufferUnderflowException.class, () -> new UnsafeInput(new byte[5]).readInts(hugeLength));
+		assertThrows(KryoBufferUnderflowException.class, () -> new UnsafeInput(new byte[5]).readLongs(hugeLength));
+		assertThrows(KryoBufferUnderflowException.class, () -> new UnsafeInput(new byte[5]).readDoubles(hugeLength));
+
+		assertThrows(KryoBufferUnderflowException.class, () -> new UnsafeByteBufferInput(new byte[5]).readInts(hugeLength));
+		assertThrows(KryoBufferUnderflowException.class, () -> new UnsafeByteBufferInput(new byte[5]).readDoubles(hugeLength));
+	}
+
 	@Test
 	void testOutputStream () {
 		ByteArrayOutputStream buffer = new ByteArrayOutputStream();

--- a/test/com/esotericsoftware/kryo/serializers/CollectionSerializerTest.java
+++ b/test/com/esotericsoftware/kryo/serializers/CollectionSerializerTest.java
@@ -30,6 +30,7 @@ import com.esotericsoftware.kryo.serializers.DefaultSerializers.StringSerializer
 import com.esotericsoftware.kryo.serializers.MapSerializerTest.KeyComparator;
 import com.esotericsoftware.kryo.serializers.MapSerializerTest.KeyThatIsntComparable;
 
+import java.io.ByteArrayInputStream;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -55,6 +56,19 @@ class CollectionSerializerTest extends KryoTestCase {
 		declared.writeVarIntFlag(false, 2000000001, true);
 		declared.flush();
 		assertThrows(KryoException.class, () -> kryo.readClassAndObject(new Input(declared.toBytes())));
+	}
+
+	@Test
+	void testMaxCollectionSize () {
+		kryo.setReferences(false);
+		kryo.register(ArrayList.class);
+		Output declared = new Output(8);
+		kryo.writeClass(declared, ArrayList.class);
+		declared.writeVarIntFlag(false, 2000000001, true);
+		declared.flush();
+		Input stream = new Input(new ByteArrayInputStream(declared.toBytes()));
+		stream.setMaxArraySize(1024);
+		assertThrows(KryoException.class, () -> kryo.readClassAndObject(stream));
 	}
 
 	@Test

--- a/test/com/esotericsoftware/kryo/serializers/CollectionSerializerTest.java
+++ b/test/com/esotericsoftware/kryo/serializers/CollectionSerializerTest.java
@@ -22,7 +22,10 @@ package com.esotericsoftware.kryo.serializers;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.KryoException;
 import com.esotericsoftware.kryo.KryoTestCase;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
 import com.esotericsoftware.kryo.serializers.DefaultSerializers.StringSerializer;
 import com.esotericsoftware.kryo.serializers.MapSerializerTest.KeyComparator;
 import com.esotericsoftware.kryo.serializers.MapSerializerTest.KeyThatIsntComparable;
@@ -41,6 +44,17 @@ import org.junit.jupiter.api.Test;
 class CollectionSerializerTest extends KryoTestCase {
 	{
 		supportsCopy = true;
+	}
+
+	@Test
+	void testMaliciousCollectionSize () {
+		kryo.setReferences(false);
+		kryo.register(ArrayList.class);
+		Output declared = new Output(8);
+		kryo.writeClass(declared, ArrayList.class);
+		declared.writeVarIntFlag(false, 2000000001, true);
+		declared.flush();
+		assertThrows(KryoException.class, () -> kryo.readClassAndObject(new Input(declared.toBytes())));
 	}
 
 	@Test

--- a/test/com/esotericsoftware/kryo/serializers/MapSerializerTest.java
+++ b/test/com/esotericsoftware/kryo/serializers/MapSerializerTest.java
@@ -63,6 +63,19 @@ class MapSerializerTest extends KryoTestCase {
 	}
 
 	@Test
+	void testMaxMapSize () {
+		kryo.setReferences(false);
+		kryo.register(HashMap.class);
+		Output declared = new Output(8);
+		kryo.writeClass(declared, HashMap.class);
+		declared.writeVarInt(2000000001, true);
+		declared.flush();
+		Input stream = new Input(new ByteArrayInputStream(declared.toBytes()));
+		stream.setMaxArraySize(1024);
+		assertThrows(KryoException.class, () -> kryo.readClassAndObject(stream));
+	}
+
+	@Test
 	void testMaps () {
 		kryo.register(HashMap.class);
 		kryo.register(LinkedHashMap.class);

--- a/test/com/esotericsoftware/kryo/serializers/MapSerializerTest.java
+++ b/test/com/esotericsoftware/kryo/serializers/MapSerializerTest.java
@@ -22,6 +22,7 @@ package com.esotericsoftware.kryo.serializers;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.KryoException;
 import com.esotericsoftware.kryo.KryoTestCase;
 import com.esotericsoftware.kryo.io.Input;
 import com.esotericsoftware.kryo.io.Output;
@@ -48,6 +49,17 @@ import org.junit.jupiter.api.Test;
 class MapSerializerTest extends KryoTestCase {
 	{
 		supportsCopy = true;
+	}
+
+	@Test
+	void testMaliciousMapSize () {
+		kryo.setReferences(false);
+		kryo.register(HashMap.class);
+		Output declared = new Output(8);
+		kryo.writeClass(declared, HashMap.class);
+		declared.writeVarInt(2000000001, true);
+		declared.flush();
+		assertThrows(KryoException.class, () -> kryo.readClassAndObject(new Input(declared.toBytes())));
 	}
 
 	@Test


### PR DESCRIPTION
## Summary

Several serializers read a declared length, count, or size and allocate from it before validating it against the available input. A small corrupt or malicious message that declares a multi-billion element array, string, collection, or map triggers a multi-gigabyte allocation and an `OutOfMemoryError`. This continues the discussion in #1282 (primitive arrays) and extends the same guard to the other read paths that share the pattern, plus an opt-in size limit for callers that decode untrusted input.

Kryo assumes a trusted source, so these are robustness fixes, not a change to that threat model. The default behavior is unchanged.

## The pattern

`new T[declaredLength]` (and `new char[charCount]`, `new ArrayList<>(declaredSize)`, `new HashMap(declaredSize)`, ...) runs before any element is read, so the declared size alone drives the allocation. A 6 to 10 byte message can request gigabytes.

## What this changes

When an `Input` is backed by a fixed buffer (no `InputStream`), the number of elements cannot exceed the number of bytes remaining, because every element occupies at least one byte. That is the bound used here.

- **Primitive arrays and `byte[]`** (`Input.readInts/readLongs/.../readBytes`, and the `ByteBufferInput`, `UnsafeInput`, `UnsafeByteBufferInput` variants): validate the declared length against the bytes remaining before allocating. This is the #1282 case.
- **Strings** (`readUtf8Chars` in `Input` and `ByteBufferInput`): the same guard on the UTF-8 char count.
- **`String[]`, closure captured args, and `CompatibleFieldSerializer` field counts**: the same guard. Each element is read as a string or a class-tagged object, so it is at least one byte.
- **Collections and Maps** (`CollectionSerializer`, `MapSerializer`, including the `Arrays.asList`, JDK immutable, and `PriorityQueue` create overrides): clamp the initial capacity to the bytes remaining instead of throwing. The collection or map still grows to the real element count, so valid input is never rejected, while a corrupt size no longer forces a large pre-allocation. The clamp is applied in `read()` before `create()` so the create overrides are covered too.

## Why throw in some places and clamp in others

Throwing is only safe where every element is guaranteed to consume at least one byte (primitives, bytes, chars, strings, class-tagged objects). There, a declared length greater than the bytes remaining is provably malformed, so no valid input is rejected.

Collections and maps can hold elements that serialize to zero bytes (for example a registered no-field element type written with a known serializer), so a valid collection can legitimately declare more elements than there are bytes remaining at that point. Throwing there would reject valid input. Clamping the capacity avoids that: it caps the pre-allocation but lets the structure grow, so the result is always correct.

## What is intentionally left unchanged

`ObjectArraySerializer` (generic `Object[]`) is not guarded by the bytes-remaining check. Its elements can serialize to zero bytes and the array is fixed size, so neither the throw nor the clamp can bound it without rejecting valid input. The `maxArraySize` limit below still applies to it.

## maxArraySize: the configurable limit (default off), and why

The bytes-remaining guard only applies to a fixed buffer. For an `InputStream`-backed `Input` the buffered window is not the total size, so a declared size cannot be checked against it without rejecting valid large input. To let callers bound streaming (and buffered) deserialization, this adds:

```java
input.setMaxArraySize(n); // default Integer.MAX_VALUE
```

`validateArrayLength` and the collection and map size reads reject any declared size above the limit, on both stream-backed and buffer-backed input.

The default is `Integer.MAX_VALUE`, that is, unlimited:

- **By default nothing changes.** A valid payload always has length <= bytes remaining, so the
 buffer guard never fires on valid input, and the unlimited cap never fires at all. Existing callers see today's behavior, and the in-memory case is still protected automatically.
- **Callers that decode untrusted data opt in** with a value suited to their application. This is the only mechanism that covers stream-backed input, which cannot be bounded automatically.

A finite default was considered but not chosen. A finite default would reject legitimately large payloads from existing users and would change behavior on upgrade. Keeping it unlimited preserves backward compatibility and matches Kryo's trusted-source model: a caller that exposes Kryo to untrusted input sets the bound it expects.

## Backwards compatibility

- Default behavior is unchanged. Large valid arrays, strings, collections, and maps still deserialize. The guard rejects only a declared size larger than the input can supply.
- The one observable change for malformed input is the exception type: `KryoBufferUnderflowException` or `KryoException` instead of `OutOfMemoryError` or `NegativeArraySizeException`. It is catchable and thrown before the allocation.
- Stream-backed input is unchanged unless `setMaxArraySize` is called.

## New tests

- `InputOutputTest.testArrayLengthValidation`, `testMaliciousArrayLength`: the primitive array and `byte[]` guards, including an end-to-end `int[]` decode.
- `InputOutputTest.testMaliciousStringLength`: the string char-count guard on `Input` and `ByteBufferInput`.
- `InputOutputTest.testMaxArraySize`: the limit on a stream-backed input for arrays.
- `UnsafeInputOutputTest.testArrayLengthValidation`: the unsafe array variants.
- `CollectionSerializerTest.testMaliciousCollectionSize`, `testMaxCollectionSize`: the collection clamp and the stream limit.
- `MapSerializerTest.testMaliciousMapSize`, `testMaxMapSize`: the map clamp and the stream limit.

## Verification

The full module test suite passes. It was also run on the project's JDK matrix (Temurin 8, 11, 17, 21, 25), building on 11 and testing on each, as in CI.
