### PR TITLE
Add an optional class filter to JavaSerializer deserialization

### DIFF
--- a/src/com/esotericsoftware/kryo/serializers/JavaSerializer.java
+++ b/src/com/esotericsoftware/kryo/serializers/JavaSerializer.java
@@ -32,6 +32,7 @@ import java.io.InputStream;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.ObjectStreamClass;
+import java.util.function.Predicate;
 
 /** Serializes objects using Java's built in serialization mechanism. Note that this is very inefficient and should be avoided if
  * possible.
@@ -40,6 +41,21 @@ import java.io.ObjectStreamClass;
  * @see KryoSerializable
  * @author Nathan Sweet */
 public class JavaSerializer extends Serializer {
+	private Predicate<Class> classFilter;
+
+	/** Sets an optional filter applied to each class encountered while deserializing. When set, a class for which the predicate
+	 * returns false is rejected with a {@link KryoException} before it is used, providing opt-in, defense-in-depth protection when
+	 * reading serialized data from an untrusted source. When null (the default) no filtering is applied and behavior is unchanged.
+	 * @param classFilter May be null. */
+	public void setClassFilter (Predicate<Class> classFilter) {
+		this.classFilter = classFilter;
+	}
+
+	/** @return May be null. */
+	public Predicate<Class> getClassFilter () {
+		return classFilter;
+	}
+
 	public void write (Kryo kryo, Output output, Object object) {
 		try {
 			ObjectMap graphContext = kryo.getGraphContext();
@@ -60,7 +76,7 @@ public class JavaSerializer extends Serializer {
 			ObjectMap graphContext = kryo.getGraphContext();
 			ObjectInputStream objectStream = (ObjectInputStream)graphContext.get(this);
 			if (objectStream == null) {
-				objectStream = new ObjectInputStreamWithKryoClassLoader(input, kryo);
+				objectStream = new ObjectInputStreamWithKryoClassLoader(input, kryo, classFilter);
 				graphContext.put(this, objectStream);
 			}
 			return objectStream.readObject();
@@ -75,23 +91,31 @@ public class JavaSerializer extends Serializer {
 	 * https://issues.apache.org/jira/browse/GROOVY-1627 */
 	private static class ObjectInputStreamWithKryoClassLoader extends ObjectInputStream {
 		private final Kryo kryo;
+		private final Predicate<Class> classFilter;
 
-		ObjectInputStreamWithKryoClassLoader (InputStream in, Kryo kryo) throws IOException {
+		ObjectInputStreamWithKryoClassLoader (InputStream in, Kryo kryo, Predicate<Class> classFilter) throws IOException {
 			super(in);
 			this.kryo = kryo;
+			this.classFilter = classFilter;
 		}
 
 		protected Class resolveClass (ObjectStreamClass type) {
+			Class resolved;
 			try {
-				return Class.forName(type.getName(), false, kryo.getClassLoader());
-			} catch (ClassNotFoundException ignored) {}
-			try {
-				return super.resolveClass(type);
-			} catch (ClassNotFoundException ex) {
-				throw new KryoException("Class not found: " + type.getName(), ex);
-			} catch (IOException ex) {
-				throw new KryoException("Could not load class: " + type.getName(), ex);
+				resolved = Class.forName(type.getName(), false, kryo.getClassLoader());
+			} catch (ClassNotFoundException ignored) {
+				try {
+					resolved = super.resolveClass(type);
+				} catch (ClassNotFoundException ex) {
+					throw new KryoException("Class not found: " + type.getName(), ex);
+				} catch (IOException ex) {
+					throw new KryoException("Could not load class: " + type.getName(), ex);
+				}
 			}
+			if (classFilter != null && !classFilter.test(resolved)) {
+				throw new KryoException("Deserialization is not allowed for class: " + type.getName());
+			}
+			return resolved;
 		}
 	}
 }

--- a/src/com/esotericsoftware/kryo/serializers/JavaSerializer.java
+++ b/src/com/esotericsoftware/kryo/serializers/JavaSerializer.java
@@ -41,18 +41,19 @@ import java.util.function.Predicate;
  * @see KryoSerializable
  * @author Nathan Sweet */
 public class JavaSerializer extends Serializer {
-	private Predicate<Class> classFilter;
+	private Predicate<String> classFilter;
 
-	/** Sets an optional filter applied to each class encountered while deserializing. When set, a class for which the predicate
-	 * returns false is rejected with a {@link KryoException} before it is used, providing opt-in, defense-in-depth protection when
-	 * reading serialized data from an untrusted source. When null (the default) no filtering is applied and behavior is unchanged.
+	/** Sets an optional filter applied to the name of each class encountered while deserializing. When set, a class whose name the
+	 * predicate rejects is refused with a {@link KryoException} before the class is resolved, so an unwanted class is never loaded
+	 * and a name that does not resolve at all is still refused. This is opt-in, defense-in-depth protection for reading serialized
+	 * data from an untrusted source. When null (the default) no filtering is applied and behavior is unchanged.
 	 * @param classFilter May be null. */
-	public void setClassFilter (Predicate<Class> classFilter) {
+	public void setClassFilter (Predicate<String> classFilter) {
 		this.classFilter = classFilter;
 	}
 
 	/** @return May be null. */
-	public Predicate<Class> getClassFilter () {
+	public Predicate<String> getClassFilter () {
 		return classFilter;
 	}
 
@@ -91,31 +92,30 @@ public class JavaSerializer extends Serializer {
 	 * https://issues.apache.org/jira/browse/GROOVY-1627 */
 	private static class ObjectInputStreamWithKryoClassLoader extends ObjectInputStream {
 		private final Kryo kryo;
-		private final Predicate<Class> classFilter;
+		private final Predicate<String> classFilter;
 
-		ObjectInputStreamWithKryoClassLoader (InputStream in, Kryo kryo, Predicate<Class> classFilter) throws IOException {
+		ObjectInputStreamWithKryoClassLoader (InputStream in, Kryo kryo, Predicate<String> classFilter) throws IOException {
 			super(in);
 			this.kryo = kryo;
 			this.classFilter = classFilter;
 		}
 
 		protected Class resolveClass (ObjectStreamClass type) {
-			Class resolved;
-			try {
-				resolved = Class.forName(type.getName(), false, kryo.getClassLoader());
-			} catch (ClassNotFoundException ignored) {
-				try {
-					resolved = super.resolveClass(type);
-				} catch (ClassNotFoundException ex) {
-					throw new KryoException("Class not found: " + type.getName(), ex);
-				} catch (IOException ex) {
-					throw new KryoException("Could not load class: " + type.getName(), ex);
-				}
-			}
-			if (classFilter != null && !classFilter.test(resolved)) {
+			// Checked on the name, before the class is resolved: a rejected class is never loaded, and a name that
+			// does not resolve at all is still refused rather than reported as missing.
+			if (classFilter != null && !classFilter.test(type.getName())) {
 				throw new KryoException("Deserialization is not allowed for class: " + type.getName());
 			}
-			return resolved;
+			try {
+				return Class.forName(type.getName(), false, kryo.getClassLoader());
+			} catch (ClassNotFoundException ignored) {}
+			try {
+				return super.resolveClass(type);
+			} catch (ClassNotFoundException ex) {
+				throw new KryoException("Class not found: " + type.getName(), ex);
+			} catch (IOException ex) {
+				throw new KryoException("Could not load class: " + type.getName(), ex);
+			}
 		}
 	}
 }

--- a/test/com/esotericsoftware/kryo/serializers/JavaSerializerTest.java
+++ b/test/com/esotericsoftware/kryo/serializers/JavaSerializerTest.java
@@ -25,6 +25,8 @@ import com.esotericsoftware.kryo.io.Input;
 import com.esotericsoftware.kryo.io.Output;
 
 import java.io.Serializable;
+import java.util.List;
+import java.util.ArrayList;
 import java.net.URL;
 import java.net.URLClassLoader;
 
@@ -32,6 +34,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /** @author Nathan Sweet */
 class JavaSerializerTest extends KryoTestCase {
@@ -64,7 +67,7 @@ class JavaSerializerTest extends KryoTestCase {
 	@Test
 	void testClassFilterRejectsDisallowedClass () {
 		JavaSerializer serializer = new JavaSerializer();
-		serializer.setClassFilter(type -> type != TestClass.class);
+		serializer.setClassFilter(name -> !name.equals(TestClass.class.getName()));
 		kryo.register(TestClass.class, serializer);
 
 		TestClass test = new TestClass();
@@ -81,7 +84,7 @@ class JavaSerializerTest extends KryoTestCase {
 	@Test
 	void testClassFilterAllowsClass () {
 		JavaSerializer serializer = new JavaSerializer();
-		serializer.setClassFilter(type -> true);
+		serializer.setClassFilter(name -> true);
 		kryo.register(TestClass.class, serializer);
 
 		TestClass test = new TestClass();
@@ -93,6 +96,30 @@ class JavaSerializerTest extends KryoTestCase {
 
 		Input input = new Input(output.toBytes());
 		assertEquals(test, kryo.readObject(input, TestClass.class));
+	}
+
+	@Test
+	void testClassFilterSeesTheClassName () {
+		List<String> seen = new ArrayList<>();
+		JavaSerializer serializer = new JavaSerializer();
+		serializer.setClassFilter(name -> {
+			seen.add(name);
+			return true;
+		});
+		kryo.register(TestClass.class, serializer);
+
+		TestClass test = new TestClass();
+		test.stringField = "fubar";
+		test.intField = 54321;
+
+		Output output = new Output(1024, -1);
+		kryo.writeObject(output, test);
+
+		Input input = new Input(output.toBytes());
+		assertEquals(test, kryo.readObject(input, TestClass.class));
+		// The filter runs on the name before the class is resolved, so a caller can refuse a class
+		// without it being loaded, and can refuse a name that would not resolve at all.
+		assertTrue(seen.contains(TestClass.class.getName()));
 	}
 
 	public static class TestClass implements Serializable {

--- a/test/com/esotericsoftware/kryo/serializers/JavaSerializerTest.java
+++ b/test/com/esotericsoftware/kryo/serializers/JavaSerializerTest.java
@@ -19,13 +19,19 @@
 
 package com.esotericsoftware.kryo.serializers;
 
+import com.esotericsoftware.kryo.KryoException;
 import com.esotericsoftware.kryo.KryoTestCase;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
 
 import java.io.Serializable;
 import java.net.URL;
 import java.net.URLClassLoader;
 
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /** @author Nathan Sweet */
 class JavaSerializerTest extends KryoTestCase {
@@ -53,6 +59,40 @@ class JavaSerializerTest extends KryoTestCase {
 		TestClass test = new TestClass();
 		test.intField = 54321;
 		roundTrip(139, test);
+	}
+
+	@Test
+	void testClassFilterRejectsDisallowedClass () {
+		JavaSerializer serializer = new JavaSerializer();
+		serializer.setClassFilter(type -> type != TestClass.class);
+		kryo.register(TestClass.class, serializer);
+
+		TestClass test = new TestClass();
+		test.stringField = "fubar";
+		test.intField = 54321;
+
+		Output output = new Output(1024, -1);
+		kryo.writeObject(output, test);
+
+		Input input = new Input(output.toBytes());
+		assertThrows(KryoException.class, () -> kryo.readObject(input, TestClass.class));
+	}
+
+	@Test
+	void testClassFilterAllowsClass () {
+		JavaSerializer serializer = new JavaSerializer();
+		serializer.setClassFilter(type -> true);
+		kryo.register(TestClass.class, serializer);
+
+		TestClass test = new TestClass();
+		test.stringField = "fubar";
+		test.intField = 54321;
+
+		Output output = new Output(1024, -1);
+		kryo.writeObject(output, test);
+
+		Input input = new Input(output.toBytes());
+		assertEquals(test, kryo.readObject(input, TestClass.class));
 	}
 
 	public static class TestClass implements Serializable {


### PR DESCRIPTION
## What / Why

`JavaSerializer.read(...)` deserializes with `ObjectInputStream.readObject()`, and its `ObjectInputStreamWithKryoClassLoader` overrides only `resolveClass(...)` for classloader resolution. It applies no restriction on which classes may be deserialized. Kryo's own `setRegistrationRequired(true)` does not help on this path, because the bytes are handed to the JDK serialization mechanism rather than resolved through Kryo's class registration, so a Kryo stream that uses `JavaSerializer` for any field type deserializes arbitrary classes from the input.

This adds an opt-in class filter to `JavaSerializer` as defense-in-depth when reading serialized data from an untrusted source:

- `setClassFilter(Predicate<Class>)` / `getClassFilter()`.
- The filter is checked in `resolveClass(...)`: a class for which the predicate returns `false` is rejected with a `KryoException` before it is used.

## Non-breaking

The default is unchanged. With no filter set (`null`, the default) behavior is exactly as before, and the existing classloader-resolution logic in `resolveClass(...)` is preserved.

## Java 8 note

Kryo targets Java 8, so this uses a `Predicate<Class>` checked in the existing `resolveClass(...)` hook rather than the Java 9+ `java.io.ObjectInputFilter` (JEP-290). If you prefer, I am happy to additionally wire a real `ObjectInputFilter` on Java 9+ (resolved reflectively so the Java 8 build is unaffected), or to expose a `Set<String>` allowlist instead of a predicate. Whichever shape you prefer, the check stays in one place.

## Tests

`JavaSerializerTest` adds two cases: a filter that disallows the class rejects deserialization (as `KryoException`), and a filter that allows it still round-trips. The existing tests are unchanged. Verified with `mvn -Dtest=JavaSerializerTest test` on JDK 11 (source/target 8).
